### PR TITLE
Add Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "html5ever"
+version = "0.0.1"
+authors = ["Keegan McAllister <mcallister.keegan@gmail.com>"]


### PR DESCRIPTION
A starting point, however right now this fails with:

```
/html5ever/src/lib.rs:22:1: 22:22 error: can't find crate for `phf_mac`
                                                   ^~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
Could not compile `html5ever`.
```
