### PR TITLE
Upgrade to rustc 0.13.0-nightly (222ae8b9b 2014-10-18 00:47:22 +0000)

### DIFF
--- a/examples/noop-tree-builder.rs
+++ b/examples/noop-tree-builder.rs
@@ -7,7 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate debug;
 extern crate string_cache;
 
 extern crate html5ever;

--- a/examples/print-tree-actions.rs
+++ b/examples/print-tree-actions.rs
@@ -7,7 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate debug;
 extern crate string_cache;
 
 extern crate html5ever;
@@ -46,7 +45,7 @@ impl TreeSink<uint> for Sink {
     }
 
     fn set_quirks_mode(&mut self, mode: QuirksMode) {
-        println!("Set quirks mode to {:?}", mode);
+        println!("Set quirks mode to {}", mode);
     }
 
     fn same_node(&self, x: uint, y: uint) -> bool {

--- a/examples/tokenize.rs
+++ b/examples/tokenize.rs
@@ -7,7 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate debug;
 
 extern crate html5ever;
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -16,7 +16,6 @@
 extern crate syntax;
 extern crate rustc;
 extern crate serialize;
-extern crate debug;
 
 use rustc::plugin::Registry;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,6 @@ extern crate collections;
 #[phase(plugin, link)]
 extern crate log;
 
-#[phase(plugin, link)]
-extern crate debug;
 
 #[phase(plugin)]
 extern crate phf_mac;

--- a/src/sink/owned_dom.rs
+++ b/src/sink/owned_dom.rs
@@ -125,7 +125,7 @@ fn append(mut new_parent: Handle, mut child: Handle) {
     *parent = new_parent
 }
 
-fn get_parent_and_index(mut child: Handle) -> Option<(Handle, uint)> {
+fn get_parent_and_index(child: Handle) -> Option<(Handle, uint)> {
     if child.parent.is_null() {
         return None;
     }
@@ -207,7 +207,7 @@ impl TreeSink<Handle> for Sink {
         self.new_node(Comment(text))
     }
 
-    fn append(&mut self, mut parent: Handle, child: NodeOrText<Handle>) {
+    fn append(&mut self, parent: Handle, child: NodeOrText<Handle>) {
         // Append to an existing Text node if we have one.
         match child {
             AppendText(ref text) => match parent.children.last() {

--- a/src/tokenizer/char_ref/mod.rs
+++ b/src/tokenizer/char_ref/mod.rs
@@ -34,6 +34,7 @@ pub enum Status {
     Done,
 }
 
+#[deriving(Show)]
 enum State {
     Begin,
     Octothorpe,
@@ -115,7 +116,7 @@ impl<Sink: TokenSink> CharRefTokenizer {
             return Done;
         }
 
-        h5e_debug!("char ref tokenizer stepping in state {:?}", self.state);
+        h5e_debug!("char ref tokenizer stepping in state {}", self.state);
         match self.state {
             Begin => self.do_begin(tokenizer),
             Octothorpe => self.do_octothorpe(tokenizer),

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -267,11 +267,11 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         } {
             // format_if!(true) will still use the static error when built for C.
             let msg = format_if!(true, "Bad character",
-                "Bad character {:?}", c);
+                "Bad character {}", c);
             self.emit_error(msg);
         }
 
-        h5e_debug!("got character {:?}", c);
+        h5e_debug!("got character {}", c);
         self.current_char = c;
         Some(c)
     }
@@ -352,7 +352,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         let msg = format_if!(
             self.opts.exact_errors,
             "Bad character",
-            "Saw {:?} in state {:?}", self.current_char, self.state);
+            "Saw {} in state {}", self.current_char, self.state);
         self.emit_error(msg);
     }
 
@@ -360,7 +360,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         let msg = format_if!(
             self.opts.exact_errors,
             "Unexpected EOF",
-            "Saw EOF in state {:?}", self.state);
+            "Saw EOF in state {}", self.state);
         self.emit_error(msg);
     }
 
@@ -642,7 +642,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             return self.step_char_ref_tokenizer();
         }
 
-        h5e_debug!("processing in state {:?}", self.state);
+        h5e_debug!("processing in state {}", self.state);
         match self.state {
             //§ data-state
             states::Data => loop {
@@ -1163,7 +1163,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
             //§ cdata-section-state
             states::CdataSection
-                => fail!("FIXME: state {:?} not implemented", self.state),
+                => fail!("FIXME: state {} not implemented", self.state),
             //§ END
         }
     }
@@ -1205,7 +1205,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 states::AttributeValue(_)
                     => go!(self: push_value c),
 
-                _ => fail!("state {:?} should not be reachable in process_char_ref", self.state),
+                _ => fail!("state {} should not be reachable in process_char_ref", self.state),
             }
         }
     }
@@ -1256,12 +1256,12 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
         for (k, v) in results.into_iter() {
             let pct = 100.0 * (v as f64) / (total as f64);
-            println!("{:12u}  {:4.1f}%  {:?}", v, pct, k);
+            println!("{:12u}  {:4.1f}%  {}", v, pct, k);
         }
     }
 
     fn eof_step(&mut self) -> bool {
-        h5e_debug!("processing EOF in state {:?}", self.state);
+        h5e_debug!("processing EOF in state {}", self.state);
         match self.state {
             states::Data | states::RawData(Rcdata) | states::RawData(Rawtext)
             | states::RawData(ScriptData) | states::Plaintext
@@ -1326,7 +1326,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 => go!(self: error; to BogusComment),
 
             states::CdataSection
-                => fail!("FIXME: state {:?} not implemented in EOF", self.state),
+                => fail!("FIXME: state {} not implemented in EOF", self.state),
         }
     }
 }

--- a/src/tokenizer/states.rs
+++ b/src/tokenizer/states.rs
@@ -14,19 +14,19 @@
 
 use core::prelude::*;
 
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Show)]
 pub enum ScriptEscapeKind {
     Escaped,
     DoubleEscaped,
 }
 
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Show)]
 pub enum DoctypeIdKind {
     Public,
     System,
 }
 
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Show)]
 pub enum RawKind {
     Rcdata,
     Rawtext,
@@ -34,14 +34,14 @@ pub enum RawKind {
     ScriptDataEscaped(ScriptEscapeKind),
 }
 
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Show)]
 pub enum AttrValueKind {
     Unquoted,
     SingleQuoted,
     DoubleQuoted,
 }
 
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Show)]
 pub enum State {
     Data,
     Plaintext,

--- a/src/tree_builder/mod.rs
+++ b/src/tree_builder/mod.rs
@@ -222,7 +222,7 @@ impl<Handle: Clone, Sink: TreeSink<Handle>> TreeBuilder<Handle, Sink> {
     #[cfg(not(for_c))]
     fn debug_step(&self, mode: InsertionMode, token: &Token) {
         use util::str::to_escaped_string;
-        h5e_debug!("processing {} in insertion mode {:?}", to_escaped_string(token), mode);
+        h5e_debug!("processing {} in insertion mode {}", to_escaped_string(token), mode);
     }
 
     fn process_to_completion(&mut self, mut token: Token) {
@@ -305,7 +305,7 @@ impl<Handle: Clone, Sink: TreeSink<Handle>> TokenSink for TreeBuilder<Handle, Si
                 self.sink.parse_error(format_if!(
                     self.opts.exact_errors,
                     "DOCTYPE in body",
-                    "DOCTYPE in insertion mode {:?}", self.mode));
+                    "DOCTYPE in insertion mode {}", self.mode));
                 return;
             },
 

--- a/tests/html5ever-external-test.rs
+++ b/tests/html5ever-external-test.rs
@@ -14,7 +14,6 @@
 
 extern crate test;
 extern crate serialize;
-extern crate debug;
 extern crate string_cache;
 #[phase(plugin)] extern crate string_cache_macros;
 

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -225,7 +225,7 @@ fn json_to_token(js: &Json) -> Token {
         // We don't need to produce NullCharacterToken because
         // the TokenLogger will convert them to CharacterTokens.
 
-        _ => fail!("don't understand token {:?}", parts),
+        _ => fail!("don't understand token {}", parts),
     }
 }
 
@@ -343,7 +343,7 @@ fn mk_tests(tests: &mut Vec<TestDescAndFn>, path_str: &str, js: &Json) {
                 "PLAINTEXT state" => Plaintext,
                 "RAWTEXT state"   => RawData(Rawtext),
                 "RCDATA state"    => RawData(Rcdata),
-                s => fail!("don't know state {:?}", s),
+                s => fail!("don't know state {}", s),
             })).collect(),
         None => vec!(None),
         _ => fail!("don't understand initialStates value"),
@@ -354,7 +354,7 @@ fn mk_tests(tests: &mut Vec<TestDescAndFn>, path_str: &str, js: &Json) {
         for &exact_errors in [false, true].iter() {
             let mut newdesc = desc.clone();
             match state {
-                Some(s) => newdesc = format!("{:s} (in state {:?})", newdesc, s),
+                Some(s) => newdesc = format!("{:s} (in state {})", newdesc, s),
                 None  => (),
             };
             if exact_errors {


### PR DESCRIPTION
In Rustc 0.13 crate debug was removed. 
- This patch removes all uses of `extern crate debug` and `{:?}` usages with `{}`, add `Show` trait to any affected structure or enum.
