### PR TITLE
Implements zero-copy html parsing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [ "The html5ever Project Developers" ]
 phf = "0"
 phf_mac = "0"
 time = "0"
+iobuf = "3"
 
 [dependencies.string_cache]
 git = "https://github.com/servo/string-cache"
@@ -19,3 +20,10 @@ path = "macros"
 
 [[test]]
 name = "html5ever-external-test"
+
+[profile.release]
+
+opt-level = 3
+debug = false
+rpath = false
+lto = false

--- a/examples/html2html.rs
+++ b/examples/html2html.rs
@@ -23,11 +23,11 @@ use std::default::Default;
 use html5ever::sink::rcdom::RcDom;
 use html5ever::driver::ParseOpts;
 use html5ever::tree_builder::TreeBuilderOpts;
-use html5ever::{parse, one_input, serialize};
+use html5ever::{ROIobuf, parse, one_input, serialize};
 
 fn main() {
     let input = io::stdin().read_to_string().unwrap();
-    let dom: RcDom = parse(one_input(input), ParseOpts {
+    let dom: RcDom = parse(one_input(ROIobuf::from_str_copy(input.as_slice())), ParseOpts {
         tree_builder: TreeBuilderOpts {
             drop_doctype: true,
             ..Default::default()

--- a/examples/noop-tokenize.rs
+++ b/examples/noop-tokenize.rs
@@ -17,6 +17,7 @@ use std::default::Default;
 
 use test::black_box;
 
+use html5ever::ROIobuf;
 use html5ever::tokenizer::{TokenSink, Token, TokenizerOpts};
 use html5ever::driver::{tokenize_to, one_input};
 
@@ -38,7 +39,7 @@ fn main() {
     let mut file = io::File::open(&path).ok().expect("can't open file");
     let file_input = file.read_to_string().ok().expect("can't read file");
 
-    tokenize_to(Sink, one_input(file_input), TokenizerOpts {
+    tokenize_to(Sink, one_input(ROIobuf::from_str_copy(file_input.as_slice())), TokenizerOpts {
         profile: true,
         .. Default::default()
     });

--- a/examples/noop-tree-builder.rs
+++ b/examples/noop-tree-builder.rs
@@ -13,12 +13,11 @@ extern crate html5ever;
 
 use std::io;
 use std::default::Default;
-use std::string::String;
 use std::collections::HashMap;
 use std::str::MaybeOwned;
-use string_cache::QualName;
+use string_cache::{QualName, Atom};
 
-use html5ever::{parse_to, one_input};
+use html5ever::{ROIobuf, parse_to, one_input, Span};
 use html5ever::tokenizer::Attribute;
 use html5ever::tree_builder::{TreeSink, QuirksMode, NodeOrText};
 
@@ -54,7 +53,7 @@ impl TreeSink<uint> for Sink {
         id
     }
 
-    fn create_comment(&mut self, _text: String) -> uint {
+    fn create_comment(&mut self, _text: Span) -> uint {
         self.get_id()
     }
 
@@ -70,7 +69,7 @@ impl TreeSink<uint> for Sink {
     fn set_quirks_mode(&mut self, _mode: QuirksMode) { }
     fn append(&mut self, _parent: uint, _child: NodeOrText<uint>) { }
 
-    fn append_doctype_to_document(&mut self, _name: String, _public_id: String, _system_id: String) { }
+    fn append_doctype_to_document(&mut self, _name: Atom, _public_id: Span, _system_id: Span) { }
     fn add_attrs_if_missing(&mut self, _target: uint, _attrs: Vec<Attribute>) { }
     fn remove_from_parent(&mut self, _target: uint) { }
     fn mark_script_already_started(&mut self, _node: uint) { }
@@ -83,5 +82,5 @@ fn main() {
     };
 
     let input = io::stdin().read_to_string().unwrap();
-    parse_to(sink, one_input(input), Default::default());
+    parse_to(sink, one_input(ROIobuf::from_str_copy(input.as_slice())), Default::default());
 }

--- a/examples/tokenize.rs
+++ b/examples/tokenize.rs
@@ -13,6 +13,7 @@ extern crate html5ever;
 use std::io;
 use std::default::Default;
 
+use html5ever::{ROIobuf, ValidatedSpanUtils};
 use html5ever::tokenizer::{TokenSink, Token, TokenizerOpts, ParseError};
 use html5ever::tokenizer::{CharacterTokens, NullCharacterToken, TagToken, StartTag, EndTag};
 use html5ever::driver::{tokenize_to, one_input};
@@ -43,7 +44,7 @@ impl TokenSink for TokenPrinter {
     fn process_token(&mut self, token: Token) {
         match token {
             CharacterTokens(b) => {
-                for c in b.as_slice().chars() {
+                for c in b.iter_chars() {
                     self.do_char(c);
                 }
             }
@@ -81,7 +82,7 @@ fn main() {
         in_char_run: false,
     };
     let input = io::stdin().read_to_string().unwrap();
-    tokenize_to(sink, one_input(input), TokenizerOpts {
+    tokenize_to(sink, one_input(ROIobuf::from_str_copy(input.as_slice())), TokenizerOpts {
         profile: true,
         .. Default::default()
     });

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -16,10 +16,11 @@ use tree_builder::{TreeBuilderOpts, TreeBuilder, TreeSink};
 
 use core::default::Default;
 use core::option;
-use collections::string::String;
+
+use iobuf::ROIobuf;
 
 /// Convenience function to turn a single `String` into an iterator.
-pub fn one_input(x: String) -> option::Item<String> {
+pub fn one_input(x: ROIobuf<'static>) -> option::Item<ROIobuf<'static>> {
     Some(x).into_iter()
 }
 
@@ -33,7 +34,7 @@ pub fn one_input(x: String) -> option::Item<String> {
 /// ```
 pub fn tokenize_to<
         Sink: TokenSink,
-        It: Iterator<String>
+        It: Iterator<ROIobuf<'static>>
     >(
         sink: Sink,
         mut input: It,
@@ -68,7 +69,7 @@ pub struct ParseOpts {
 pub fn parse_to<
         Handle: Clone,
         Sink: TreeSink<Handle>,
-        It: Iterator<String>
+        It: Iterator<ROIobuf<'static>>
     >(
         sink: Sink,
         mut input: It,
@@ -102,7 +103,7 @@ pub fn parse<
         Handle: Clone,
         Sink: Default + TreeSink<Handle>,
         Output: ParseResult<Sink>,
-        It: Iterator<String>
+        It: Iterator<ROIobuf<'static>>
     >(
         input: It,
         opts: ParseOpts) -> Output {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -17,10 +17,10 @@ use tree_builder::{TreeBuilderOpts, TreeBuilder, TreeSink};
 use core::default::Default;
 use core::option;
 
-use iobuf::ROIobuf;
+use util::span::Buf;
 
 /// Convenience function to turn a single `String` into an iterator.
-pub fn one_input(x: ROIobuf<'static>) -> option::Item<ROIobuf<'static>> {
+pub fn one_input(x: Buf) -> option::Item<Buf> {
     Some(x).into_iter()
 }
 
@@ -34,7 +34,7 @@ pub fn one_input(x: ROIobuf<'static>) -> option::Item<ROIobuf<'static>> {
 /// ```
 pub fn tokenize_to<
         Sink: TokenSink,
-        It: Iterator<ROIobuf<'static>>
+        It: Iterator<Buf>
     >(
         sink: Sink,
         mut input: It,
@@ -69,7 +69,7 @@ pub struct ParseOpts {
 pub fn parse_to<
         Handle: Clone,
         Sink: TreeSink<Handle>,
-        It: Iterator<ROIobuf<'static>>
+        It: Iterator<Buf>
     >(
         sink: Sink,
         mut input: It,
@@ -103,7 +103,7 @@ pub fn parse<
         Handle: Clone,
         Sink: Default + TreeSink<Handle>,
         Output: ParseResult<Sink>,
-        It: Iterator<ROIobuf<'static>>
+        It: Iterator<Buf>
     >(
         input: It,
         opts: ParseOpts) -> Output {

--- a/src/for_c/tokenizer.rs
+++ b/src/for_c/tokenizer.rs
@@ -11,8 +11,10 @@
 
 use core::prelude::*;
 
-use for_c::common::{LifetimeBuf, AsLifetimeBuf, h5e_buf, c_bool};
+use for_c::common::{h5e_buf, h5e_bufset, c_bool};
+use for_c::common::{LifetimeBuf, AsLifetimeBuf, LifetimeBufSet, AsLifetimeBufSet};
 
+use util::span::Span;
 use tokenizer::{TokenSink, Token, Doctype, Tag, ParseError, DoctypeToken};
 use tokenizer::{CommentToken, CharacterTokens, NullCharacterToken};
 use tokenizer::{TagToken, StartTag, EndTag, EOFToken, Tokenizer};
@@ -20,21 +22,24 @@ use tokenizer::{TagToken, StartTag, EndTag, EOFToken, Tokenizer};
 use core::mem;
 use core::default::Default;
 use alloc::boxed::Box;
-use collections::String;
 use libc::{c_void, c_int, size_t};
+
+use iobuf::ROIobuf;
+
+use string_cache::Atom;
 
 #[repr(C)]
 pub struct h5e_token_ops {
     do_doctype: Option<extern "C" fn(user: *mut c_void, name: h5e_buf,
-        public: h5e_buf, system: h5e_buf, force_quirks: c_int)>,
+        public: h5e_bufset, system: h5e_bufset, force_quirks: c_int)>,
 
     do_start_tag: Option<extern "C" fn(user: *mut c_void, name: h5e_buf,
         self_closing: c_int, num_attrs: size_t)>,
 
-    do_tag_attr:      Option<extern "C" fn(user: *mut c_void, name: h5e_buf, value: h5e_buf)>,
+    do_tag_attr:      Option<extern "C" fn(user: *mut c_void, name: h5e_buf, value: h5e_bufset)>,
     do_end_tag:       Option<extern "C" fn(user: *mut c_void, name: h5e_buf)>,
-    do_comment:       Option<extern "C" fn(user: *mut c_void, text: h5e_buf)>,
-    do_chars:         Option<extern "C" fn(user: *mut c_void, text: h5e_buf)>,
+    do_comment:       Option<extern "C" fn(user: *mut c_void, text: h5e_bufset)>,
+    do_chars:         Option<extern "C" fn(user: *mut c_void, text: h5e_bufset)>,
     do_null_char:     Option<extern "C" fn(user: *mut c_void)>,
     do_eof:           Option<extern "C" fn(user: *mut c_void)>,
     do_error:         Option<extern "C" fn(user: *mut c_void, message: h5e_buf)>,
@@ -57,7 +62,14 @@ impl TokenSink for *mut h5e_token_sink {
             }
         ))
 
-        fn opt_str_to_buf<'a>(s: &'a Option<String>) -> LifetimeBuf<'a> {
+        fn opt_span_to_bufset<'a>(s: &'a Option<Span>) -> LifetimeBufSet<'a> {
+            match *s {
+                None => LifetimeBufSet::null(),
+                Some(ref s) => s.as_lifetime_bufset(),
+            }
+        }
+
+        fn opt_atom_to_buf<'a>(s: &'a Option<Atom>) -> LifetimeBuf<'a> {
             match *s {
                 None => LifetimeBuf::null(),
                 Some(ref s) => s.as_lifetime_buf(),
@@ -66,9 +78,9 @@ impl TokenSink for *mut h5e_token_sink {
 
         match token {
             DoctypeToken(Doctype { name, public_id, system_id, force_quirks }) => {
-                let name = opt_str_to_buf(&name);
-                let public_id = opt_str_to_buf(&public_id);
-                let system_id = opt_str_to_buf(&system_id);
+                let name = opt_atom_to_buf(&name);
+                let public_id = opt_span_to_bufset(&public_id);
+                let system_id = opt_span_to_bufset(&system_id);
                 call!(do_doctype, name.get(), public_id.get(), system_id.get(),
                     c_bool(force_quirks));
             }
@@ -83,7 +95,7 @@ impl TokenSink for *mut h5e_token_sink {
                             // All attribute names from the tokenizer are local.
                             assert!(attr.name.ns == ns!(""));
                             let name = attr.name.local.as_lifetime_buf();
-                            let value = attr.value.as_lifetime_buf();
+                            let value = attr.value.as_lifetime_bufset();
                             call!(do_tag_attr, name.get(), value.get());
                         }
                     }
@@ -92,12 +104,12 @@ impl TokenSink for *mut h5e_token_sink {
             }
 
             CommentToken(text) => {
-                let text = text.as_lifetime_buf();
+                let text = text.as_lifetime_bufset();
                 call!(do_comment, text.get());
             }
 
             CharacterTokens(text) => {
-                let text = text.as_lifetime_buf();
+                let text = text.as_lifetime_bufset();
                 call!(do_chars, text.get());
             }
 
@@ -131,7 +143,9 @@ pub unsafe extern "C" fn h5e_tokenizer_free(tok: h5e_tokenizer_ptr) {
 #[no_mangle]
 pub unsafe extern "C" fn h5e_tokenizer_feed(tok: h5e_tokenizer_ptr, buf: h5e_buf) {
     let tok: &mut Tokenizer<*mut h5e_token_sink> = mem::transmute(tok);
-    tok.feed(String::from_str(buf.as_slice()));
+    // TODO(cgaebel): Allow C to create and fill Iobufs, to actually be zero-copy,
+    // instead of just being "zero-copy iff we're called from rust code".
+    tok.feed(ROIobuf::from_str_copy(buf.as_slice()));
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![crate_name="html5ever"]
 #![crate_type="dylib"]
 
-#![feature(macro_rules, phase, globs)]
+#![feature(macro_rules, phase, globs, unsafe_destructor)]
 #![deny(warnings)]
 #![allow(unused_parens)]
 
@@ -37,6 +37,8 @@ extern crate collections;
 #[phase(plugin, link)]
 extern crate log;
 
+extern crate iobuf;
+
 #[phase(plugin)]
 extern crate phf_mac;
 
@@ -57,11 +59,17 @@ pub use driver::{one_input, ParseOpts, parse_to, parse};
 #[cfg(not(for_c))]
 pub use serialize::serialize;
 
+pub use iobuf::{BufSpan, Iobuf, ROIobuf};
+pub use util::span::{Span, ValidatedSpanUtils};
+
 mod macros;
 
 mod util {
     #![macro_escape]
 
+    pub mod fast_option;
+    pub mod single_char;
+    pub mod span;
     pub mod str;
     pub mod smallcharset;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use driver::{one_input, ParseOpts, parse_to, parse};
 pub use serialize::serialize;
 
 pub use iobuf::{BufSpan, Iobuf, ROIobuf};
-pub use util::span::{Span, ValidatedSpanUtils};
+pub use util::span::{Buf, Span, ValidatedSpanUtils};
 
 mod macros;
 

--- a/src/sink/common.rs
+++ b/src/sink/common.rs
@@ -10,8 +10,9 @@
 use tokenizer::Attribute;
 
 use collections::vec::Vec;
-use collections::string::String;
-use string_cache::QualName;
+use string_cache::{QualName, Atom};
+
+use util::span::Span;
 
 pub use self::NodeEnum::{Document, Doctype, Text, Comment, Element};
 
@@ -22,13 +23,13 @@ pub enum NodeEnum {
     Document,
 
     /// A `DOCTYPE` with name, public id, and system id.
-    Doctype(String, String, String),
+    Doctype(Atom, Span, Span),
 
     /// A text node.
-    Text(String),
+    Text(Span),
 
     /// A comment.
-    Comment(String),
+    Comment(Span),
 
     /// An element with attributes.
     Element(QualName, Vec<Attribute>),

--- a/src/tokenizer/buffer_queue.rs
+++ b/src/tokenizer/buffer_queue.rs
@@ -12,7 +12,7 @@ use core::prelude::*;
 use util::fast_option::{Uninit, Full, FastOption, OptValue};
 use util::single_char::SingleChar;
 use util::smallcharset::SmallCharSet;
-use util::span::Span;
+use util::span::{Buf, Span};
 use util::str::Ascii;
 
 use core::mem;
@@ -176,7 +176,7 @@ impl BufferQueue {
     /// is represented as a bitmask and so can only contain the first 64
     /// ASCII characters.
     #[inline(always)]
-    pub fn pop_except_from(&mut self, set: SmallCharSet, char_dst: &mut FastOption<SingleChar>, run_dst: &mut FastOption<ROIobuf<'static>>) -> (OptValue, OptValue) {
+    pub fn pop_except_from(&mut self, set: SmallCharSet, char_dst: &mut FastOption<SingleChar>, run_dst: &mut FastOption<Buf>) -> (OptValue, OptValue) {
         // Load the front buffer into run_dst.
         match self.buffers.front() {
             None => return (Uninit, Uninit),

--- a/src/tokenizer/buffer_queue.rs
+++ b/src/tokenizer/buffer_queue.rs
@@ -9,168 +9,265 @@
 
 use core::prelude::*;
 
-use util::str::AsciiCast;
+use util::fast_option::{Uninit, Full, FastOption, OptValue};
+use util::single_char::SingleChar;
 use util::smallcharset::SmallCharSet;
+use util::span::Span;
+use util::str::Ascii;
 
-use core::str::CharRange;
-use collections::string::String;
+use core::mem;
+use core::str;
 use collections::RingBuf;
 
-pub use self::SetResult::{FromSet, NotFromSet};
+use iobuf::{BufSpan, Iobuf, ROIobuf};
 
-struct Buffer {
-    /// Byte position within the buffer.
-    pub pos: uint,
-    /// The buffer.
-    pub buf: String,
+#[allow(dead_code)]
+struct PaddedIobuf {
+    buf: ROIobuf<'static>,
+    #[cfg(target_word_size = "64")]
+    pad: u8,
+    #[cfg(target_word_size = "32")]
+    pad: [u8, ..12],
 }
 
-/// Result from `pop_except_from`.
-#[deriving(PartialEq, Eq, Show)]
-pub enum SetResult {
-    FromSet(char),
-    NotFromSet(String),
+impl PaddedIobuf {
+    #[inline(always)]
+    fn new(buf: ROIobuf<'static>) -> PaddedIobuf {
+        unsafe {
+            PaddedIobuf {
+                buf: buf,
+                pad: mem::uninitialized(),
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn as_ref(&self) -> &ROIobuf<'static> {
+        &self.buf
+    }
+
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut ROIobuf<'static> {
+        &mut self.buf
+    }
+
+    #[inline(always)]
+    fn unwrap(self) -> ROIobuf<'static> {
+        self.buf
+    }
+}
+
+#[test]
+fn test_iobuf_padded_size() {
+    assert_eq!(mem::size_of::<ROIobuf<'static>>(), 24);
+    assert_eq!(mem::size_of::<PaddedIobuf>(), 32);
 }
 
 /// A queue of owned string buffers, which supports incrementally
 /// consuming characters.
 pub struct BufferQueue {
     /// Buffers to process.
-    buffers: RingBuf<Buffer>,
+    buffers: RingBuf<PaddedIobuf>,
+}
+
+#[inline]
+fn first_char_len_of_buf(buf: &ROIobuf<'static>) -> u32 {
+    unsafe {
+        let first_byte: u8 = buf.unsafe_peek_be(0);
+        if first_byte < 0x80 { 1 } else { str::utf8_char_width(first_byte) as u32 }
+    }
 }
 
 impl BufferQueue {
     /// Create an empty BufferQueue.
     pub fn new() -> BufferQueue {
         BufferQueue {
-            buffers: RingBuf::with_capacity(3),
+            buffers: RingBuf::with_capacity(4),
         }
     }
 
     /// Add a buffer to the beginning of the queue.
-    pub fn push_front(&mut self, buf: String) {
-        if buf.len() == 0 {
-            return;
-        }
-        self.buffers.push_front(Buffer {
-            pos: 0,
-            buf: buf,
-        });
+    ///
+    /// Only push buffers that have been utf-8 validated. If the buffer _came_
+    /// from the buffer queue, it's already been validated.
+    pub fn push_front(&mut self, buf: ROIobuf<'static>) {
+        if buf.is_empty() { return; }
+
+        self.buffers.push_front(PaddedIobuf::new(buf));
     }
 
     /// Add a buffer to the end of the queue.
-    /// 'pos' can be non-zero to remove that many bytes
-    /// from the beginning.
-    pub fn push_back(&mut self, buf: String, pos: uint) {
-        if pos >= buf.len() {
-            return;
+    /// The buffer will be validated as utf-8, panicing if it isn't.
+    pub fn push_back(&mut self, buf: ROIobuf<'static>) {
+        if buf.is_empty() { return; }
+
+        if unsafe { !str::is_utf8(buf.as_window_slice()) } {
+            panic!("Invalid utf-8 passed to html5ever: {}", buf);
         }
-        self.buffers.push_back(Buffer {
-            pos: pos,
-            buf: buf,
-        });
+
+        self.buffers.push_back(PaddedIobuf::new(buf));
     }
 
     /// Look at the next available character, if any.
-    pub fn peek(&mut self) -> Option<char> {
+    pub fn peek(&self, dst: &mut FastOption<SingleChar>) -> OptValue {
         match self.buffers.front() {
-            Some(&Buffer { pos, ref buf }) => Some(buf.as_slice().char_at(pos)),
-            None => None,
+            None => Uninit,
+            Some(buf) => unsafe {
+                let buf = buf.as_ref();
+                let len = first_char_len_of_buf(buf);
+                let mut ret_buf = (*buf).clone();
+                ret_buf.unsafe_resize(len);
+                dst.fill(SingleChar::new(ret_buf))
+            }
         }
     }
 
     /// Get the next character, if one is available.
-    pub fn next(&mut self) -> Option<char> {
-        let (result, now_empty) = match self.buffers.front_mut() {
-            None => (None, false),
-            Some(&Buffer { ref mut pos, ref buf }) => {
-                let CharRange { ch, next } = buf.as_slice().char_range_at(*pos);
-                *pos = next;
-                (Some(ch), next >= buf.len())
-            }
-        };
+    #[inline(always)]
+    pub fn next(&mut self, dst: &mut FastOption<SingleChar>) -> OptValue {
+        let needs_pop =
+            match self.buffers.front_mut() {
+                None => return Uninit,
+                Some(front_buf) => unsafe {
+                    let front_buf = front_buf.as_mut();
+                    let len = first_char_len_of_buf(front_buf);
+                    let will_be_empty = front_buf.len() == len;
+                    if dst.is_filled() {
+                        let dst = dst.as_mut().as_mut();
+                        dst.clone_from(front_buf);
+                        dst.unsafe_resize(len);
+                        front_buf.unsafe_advance(len);
+                    } else {
+                        dst.fill(SingleChar::new(front_buf.unsafe_split_start_at(len)));
+                    }
+                    will_be_empty
+                }
+            };
 
-        if now_empty {
+        if needs_pop {
             self.buffers.pop_front();
         }
 
-        result
+        Full
+    }
+
+    #[inline(always)]
+    pub fn next_simple(&mut self) -> Option<char> {
+        let (needs_pop, result) =
+            match self.buffers.front_mut() {
+                None => return None,
+                Some(buf) => unsafe {
+                    let front_buf = buf.as_mut();
+                    let s: &str = mem::transmute(front_buf.as_window_slice());
+                    let str::CharRange { ch, next } = s.char_range_at(0);
+                    front_buf.unsafe_advance(next as u32);
+                    (front_buf.is_empty(), ch)
+                }
+            };
+
+        if needs_pop {
+            self.buffers.pop_front();
+        }
+
+        Some(result)
     }
 
     /// Pops and returns either a single character from the given set, or
     /// a `String` of characters none of which are in the set.  The set
     /// is represented as a bitmask and so can only contain the first 64
     /// ASCII characters.
-    pub fn pop_except_from(&mut self, set: SmallCharSet) -> Option<SetResult> {
-        let (result, now_empty) = match self.buffers.front_mut() {
-            Some(&Buffer { ref mut pos, ref buf }) => {
-                let n = set.nonmember_prefix_len(buf.as_slice().slice_from(*pos));
-                if n > 0 {
-                    let new_pos = *pos + n;
-                    let out = String::from_str(buf.as_slice().slice(*pos, new_pos));
-                    *pos = new_pos;
-                    (Some(NotFromSet(out)), new_pos >= buf.len())
+    #[inline(always)]
+    pub fn pop_except_from(&mut self, set: SmallCharSet, char_dst: &mut FastOption<SingleChar>, run_dst: &mut FastOption<ROIobuf<'static>>) -> (OptValue, OptValue) {
+        // Load the front buffer into run_dst.
+        match self.buffers.front() {
+            None => return (Uninit, Uninit),
+            Some(buf) => {
+                let buf = buf.as_ref();
+                // If the old run_dst is the same as the current buffer, just copy
+                // in the new limits and bounds.
+                if run_dst.is_filled() {
+                    run_dst.as_mut().clone_from(buf);
                 } else {
-                    let CharRange { ch, next } = buf.as_slice().char_range_at(*pos);
-                    *pos = next;
-                    (Some(FromSet(ch)), next >= buf.len())
+                    run_dst.fill((*buf).clone());
                 }
-            }
-            _ => (None, false),
+            },
         };
 
-        // Unborrow self for this part.
-        if now_empty {
-            self.buffers.pop_front();
-        }
+        let front_buf = run_dst.as_mut();
 
-        result
+        let front_buf_len = front_buf.len();
+        let n = unsafe { set.nonmember_prefix_len(front_buf.as_window_slice()) };
+
+        if n == 0 {
+            (self.next(char_dst), Uninit)
+        } else if n != front_buf_len {
+            unsafe {
+                front_buf.unsafe_resize(n);
+                match self.buffers.front_mut() {
+                    None      => {},
+                    Some(buf) => buf.as_mut().unsafe_advance(n),
+                };
+                (Uninit, Full)
+            }
+        } else {
+            self.buffers.pop_front();
+            (Uninit, Full)
+        }
     }
 
     // Check if the next characters are an ASCII case-insensitive match for
     // `pat`, which must be non-empty.
     //
-    // If so, consume them and return Some(true).
-    // If they do not match, return Some(false).
+    // If so, consume them and return the span consumed: Some(Span (non-empty)).
+    // If they do not match, return Some(Span (empty)).
     // If not enough characters are available to know, return None.
-    pub fn eat(&mut self, pat: &str) -> Option<bool> {
-        let mut buffers_exhausted = 0u;
-        let mut consumed_from_last = match self.buffers.front() {
-            None => return None,
-            Some(ref buf) => buf.pos,
-        };
+    pub fn eat(&mut self, pat: &[u8]) -> Option<Span> {
+        let mut buffers_exhausted  = 0u;
+        let mut consumed_from_last = 0u32;
 
-        for c in pat.chars() {
-            if buffers_exhausted >= self.buffers.len() {
-                return None;
-            }
-            let ref buf = self.buffers[buffers_exhausted];
+        {
+            let mut buffers = self.buffers.iter().peekable();
 
-            let d = buf.buf.as_slice().char_at(consumed_from_last);
-            match (c.to_ascii_opt(), d.to_ascii_opt()) {
-                (Some(c), Some(d)) if c.eq_ignore_case(d) => (),
-                _ => return Some(false),
-            }
+            for &c in pat.iter() {
+                let buflen = {
+                    let buf = unwrap_or_return!(buffers.peek(), None).as_ref();
 
-            // d was an ASCII character; size must be 1 byte
-            consumed_from_last += 1;
-            if consumed_from_last >= buf.buf.len() {
-                buffers_exhausted += 1;
-                consumed_from_last = 0;
+                    match Ascii::new(buf.peek_be(consumed_from_last).unwrap()) {
+                        Some(d) if c == d.to_lowercase().to_u8() => (),
+                        _ => return Some(BufSpan::new()),
+                    }
+
+                    buf.len()
+                };
+
+                // d was an ASCII character; size must be 1 byte
+                consumed_from_last += 1;
+                if consumed_from_last >= buflen {
+                    buffers_exhausted += 1;
+                    buffers.next();
+                    consumed_from_last = 0;
+                }
             }
         }
 
+        let mut ret = BufSpan::new();
+
         // We have a match. Commit changes to the BufferQueue.
         for _ in range(0, buffers_exhausted) {
-            self.buffers.pop_front();
+            ret.push(self.buffers.pop_front().unwrap().unwrap());
         }
 
         match self.buffers.front_mut() {
             None => assert_eq!(consumed_from_last, 0),
-            Some(ref mut buf) => buf.pos = consumed_from_last,
+            Some(buf) => unsafe {
+                let buf = buf.as_mut();
+                let (begin, end) = buf.unsafe_split_at(consumed_from_last);
+                *buf = end;
+                ret.push(begin);
+            }
         }
 
-        Some(true)
+        Some(ret)
     }
 }
 
@@ -179,58 +276,110 @@ impl BufferQueue {
 mod test {
     use core::prelude::*;
     use collections::string::String;
-    use super::{BufferQueue, FromSet, NotFromSet};
+    use iobuf::{BufSpan, Iobuf, ROIobuf};
+    use util::fast_option::{Uninit, Full, FastOption};
+    use util::smallcharset::SmallCharSet;
+    use util::span::ValidatedSpanUtils;
+    use super::BufferQueue;
+
+    use self::TestSetResult::*;
+
+    #[deriving(Eq, PartialEq, Show)]
+    enum TestSetResult {
+        In(u8),
+        Out(String),
+    }
+
+    fn peek(bq: &mut BufferQueue) -> Option<u8> {
+        let mut chr = FastOption::new();
+        match bq.peek(&mut chr) {
+            Uninit => None,
+            Full   => Some(chr.as_ref().as_u8()),
+        }
+    }
+
+    fn next(bq: &mut BufferQueue) -> Option<u8> {
+        let mut chr = FastOption::new();
+        match bq.next(&mut chr) {
+            Uninit => None,
+            Full   => Some(chr.as_ref().as_u8()),
+        }
+    }
+
+    fn pop_except_from(bq: &mut BufferQueue, sc: SmallCharSet) -> Option<TestSetResult> {
+        let mut chr = FastOption::new();
+        let mut buf = FastOption::new();
+
+        match bq.pop_except_from(sc, &mut chr, &mut buf) {
+            (Uninit, Uninit) => {
+                return None;
+            }
+            (Full, Uninit) => {
+                Some(In(chr.as_ref().as_u8()))
+            }
+            (Uninit, Full) => {
+                let span = BufSpan::from_buf(buf.take());
+                Some(Out(span.iter_chars().collect()))
+            }
+            (Full, Full) => panic!("pop_except_from returned two full options"),
+        }
+    }
 
     #[test]
     fn smoke_test() {
         let mut bq = BufferQueue::new();
-        assert_eq!(bq.peek(), None);
-        assert_eq!(bq.next(), None);
+        let bq = &mut bq;
+        assert_eq!(peek(bq), None);
+        assert_eq!(next(bq), None);
 
-        bq.push_back(String::from_str("abc"), 0);
-        assert_eq!(bq.peek(), Some('a'));
-        assert_eq!(bq.next(), Some('a'));
-        assert_eq!(bq.peek(), Some('b'));
-        assert_eq!(bq.peek(), Some('b'));
-        assert_eq!(bq.next(), Some('b'));
-        assert_eq!(bq.peek(), Some('c'));
-        assert_eq!(bq.next(), Some('c'));
-        assert_eq!(bq.peek(), None);
-        assert_eq!(bq.next(), None);
+        bq.push_back(ROIobuf::from_str("abc"));
+        assert_eq!(peek(bq), Some(b'a'));
+        assert_eq!(next(bq), Some(b'a'));
+        assert_eq!(peek(bq), Some(b'b'));
+        assert_eq!(peek(bq), Some(b'b'));
+        assert_eq!(next(bq), Some(b'b'));
+        assert_eq!(peek(bq), Some(b'c'));
+        assert_eq!(next(bq), Some(b'c'));
+        assert_eq!(peek(bq), None);
+        assert_eq!(peek(bq), None);
     }
 
     #[test]
     fn can_unconsume() {
         let mut bq = BufferQueue::new();
-        bq.push_back(String::from_str("abc"), 0);
-        assert_eq!(bq.next(), Some('a'));
+        bq.push_back(ROIobuf::from_str("abc"));
+        let bq = &mut bq;
+        assert_eq!(next(bq), Some(b'a'));
 
-        bq.push_front(String::from_str("xy"));
-        assert_eq!(bq.next(), Some('x'));
-        assert_eq!(bq.next(), Some('y'));
-        assert_eq!(bq.next(), Some('b'));
-        assert_eq!(bq.next(), Some('c'));
-        assert_eq!(bq.next(), None);
+        bq.push_front(ROIobuf::from_str("xy"));
+        assert_eq!(next(bq), Some(b'x'));
+        assert_eq!(next(bq), Some(b'y'));
+        assert_eq!(next(bq), Some(b'b'));
+        assert_eq!(next(bq), Some(b'c'));
+        assert_eq!(next(bq), None);
     }
 
     #[test]
     fn can_pop_except_set() {
         let mut bq = BufferQueue::new();
-        bq.push_back(String::from_str("abc&def"), 0);
-        let pop = || bq.pop_except_from(small_char_set!('&'));
-        assert_eq!(pop(), Some(NotFromSet(String::from_str("abc"))));
-        assert_eq!(pop(), Some(FromSet('&')));
-        assert_eq!(pop(), Some(NotFromSet(String::from_str("def"))));
+        bq.push_back(ROIobuf::from_str("abc&def"));
+        let pop = || pop_except_from(&mut bq, small_char_set!('&'));
+        assert_eq!(pop(), Some(Out(String::from_str("abc"))));
+        assert_eq!(pop(), Some(In(b'&')));
+        assert_eq!(pop(), Some(Out(String::from_str("def"))));
         assert_eq!(pop(), None);
     }
 
     #[test]
     fn can_push_truncated() {
         let mut bq = BufferQueue::new();
-        bq.push_back(String::from_str("abc"), 1);
-        assert_eq!(bq.next(), Some('b'));
-        assert_eq!(bq.next(), Some('c'));
-        assert_eq!(bq.next(), None);
+        let mut buf = ROIobuf::from_str("abc");
+        buf.advance(1).unwrap();
+        bq.push_back(buf);
+        let bq = &mut bq;
+        assert_eq!(next(bq), Some(b'b'));
+        assert_eq!(next(bq), Some(b'c'));
+        assert_eq!(next(bq), None);
     }
 
     #[test]
@@ -239,12 +388,13 @@ mod test {
         // integration tests for more thorough testing with many
         // different input buffer splits.
         let mut bq = BufferQueue::new();
-        bq.push_back(String::from_str("a"), 0);
-        bq.push_back(String::from_str("bc"), 0);
-        assert_eq!(bq.eat("abcd"), None);
-        assert_eq!(bq.eat("ax"), Some(false));
-        assert_eq!(bq.eat("ab"), Some(true));
-        assert_eq!(bq.next(), Some('c'));
-        assert_eq!(bq.next(), None);
+        bq.push_back(ROIobuf::from_str("a"));
+        bq.push_back(ROIobuf::from_str("bc"));
+        let bq = &mut bq;
+        assert_eq!(bq.eat(b"abcd"), None);
+        assert_eq!(bq.eat(b"ax"), Some(BufSpan::new()));
+        assert_eq!(bq.eat(b"ab"), Some(BufSpan::from_buf(ROIobuf::from_str("ab"))));
+        assert_eq!(next(bq), Some(b'c'));
+        assert_eq!(next(bq), None);
     }
 }

--- a/src/tokenizer/buffer_queue.rs
+++ b/src/tokenizer/buffer_queue.rs
@@ -59,7 +59,6 @@ impl PaddedIobuf {
 
 #[test]
 fn test_iobuf_padded_size() {
-    assert_eq!(mem::size_of::<ROIobuf<'static>>(), 24);
     assert_eq!(mem::size_of::<PaddedIobuf>(), 32);
 }
 

--- a/src/tokenizer/char_ref/data.rs
+++ b/src/tokenizer/char_ref/data.rs
@@ -8,23 +8,76 @@
 // except according to those terms.
 
 use core::prelude::*;
+use core::slice::bytes::copy_memory;
+use core::str;
 
+use iobuf::{Iobuf, ROIobuf};
 use phf::Map;
+
+use util::single_char::SingleChar;
+use util::span::Span;
 
 /// The spec replaces most characters in the ISO-2022 C1 control code range
 /// (U+0080 through U+009F) with these characters, based on Windows 8-bit
 /// codepages.
-pub static C1_REPLACEMENTS: [Option<char>, ..32] = [
-    Some('\u20ac'), None,           Some('\u201a'), Some('\u0192'),
-    Some('\u201e'), Some('\u2026'), Some('\u2020'), Some('\u2021'),
-    Some('\u02c6'), Some('\u2030'), Some('\u0160'), Some('\u2039'),
-    Some('\u0152'), None,           Some('\u017d'), None,
-    None,           Some('\u2018'), Some('\u2019'), Some('\u201c'),
-    Some('\u201d'), Some('\u2022'), Some('\u2013'), Some('\u2014'),
-    Some('\u02dc'), Some('\u2122'), Some('\u0161'), Some('\u203a'),
-    Some('\u0153'), None,           Some('\u017e'), Some('\u0178'),
+static C1_REPLACEMENTS: [Option<&'static str>, ..32] = [
+    Some("\u20ac"), None,           Some("\u201a"), Some("\u0192"),
+    Some("\u201e"), Some("\u2026"), Some("\u2020"), Some("\u2021"),
+    Some("\u02c6"), Some("\u2030"), Some("\u0160"), Some("\u2039"),
+    Some("\u0152"), None,           Some("\u017d"), None,
+    None,           Some("\u2018"), Some("\u2019"), Some("\u201c"),
+    Some("\u201d"), Some("\u2022"), Some("\u2013"), Some("\u2014"),
+    Some("\u02dc"), Some("\u2122"), Some("\u0161"), Some("\u203a"),
+    Some("\u0153"), None,           Some("\u017e"), Some("\u0178"),
 ];
 
 // The named_entities! macro is defined in html5/macros/named_entities.rs.
-pub static NAMED_ENTITIES: Map<&'static str, [u32, ..2]>
+static NAMED_ENTITIES: Map<&'static str, (&'static str, u8)>
     = named_entities!("../../../data/entities.json");
+
+pub fn lookup_c1_replacement(idx: uint) -> Option<SingleChar> {
+    match C1_REPLACEMENTS.get(idx) {
+        None | Some(&None) => None,
+        Some(&Some(s))     => Some(SingleChar::new(ROIobuf::from_str(s))),
+    }
+}
+
+/// An HTML named entity.
+#[deriving(Show, Clone)]
+pub struct NamedEntity {
+    pub key:          &'static str,
+
+    // The chars themselves.
+    pub chars:        ROIobuf<'static>,
+
+    // Either 0, 1, or 2 unicode codepoints.
+    pub num_chars:    u8,
+}
+
+pub fn lookup_named_entity(span: &Span) -> Option<NamedEntity> {
+    // We have to copy into a temporary stack buffer, since PhfHash doesn't know
+    // that it must treat `Span`s and `str`s the same.
+    let mut to_look_up = [0u8, ..64];
+    let to_look_up     = to_look_up.as_mut_slice();
+
+    let mut copied = 0u;
+
+    for buf in span.iter() {
+        // Safe because we're not copying both into and out of a buffer; only
+        // out of one.
+        unsafe {
+            copy_memory(to_look_up.slice_from_mut(copied), buf.as_window_slice());
+            copied += buf.len() as uint;
+        }
+    }
+
+    let buf = str::from_utf8(to_look_up.slice_to(copied)).unwrap();
+
+    NAMED_ENTITIES.get_entry(buf)
+                  .map(|(k, &(s, n))|
+                       NamedEntity {
+                           key:       *k,
+                           chars:     ROIobuf::from_str(s),
+                           num_chars: n,
+                       })
+}

--- a/src/tokenizer/interface.rs
+++ b/src/tokenizer/interface.rs
@@ -10,25 +10,24 @@
 use core::prelude::*;
 
 use tokenizer::states;
+use util::span::Span;
 
 use collections::vec::Vec;
 use collections::slice::OrdSliceAllocPrelude;
-use collections::string::String;
 use collections::str::MaybeOwned;
 
 use string_cache::{Atom, QualName};
 
-pub use self::TagKind::{StartTag, EndTag};
-pub use self::Token::{DoctypeToken, TagToken, CommentToken, CharacterTokens};
-pub use self::Token::{NullCharacterToken, EOFToken, ParseError};
+pub use self::TagKind::*;
+pub use self::Token::*;
 
 /// A `DOCTYPE` token.
 // FIXME: already exists in Servo DOM
 #[deriving(PartialEq, Eq, Clone, Show)]
 pub struct Doctype {
-    pub name: Option<String>,
-    pub public_id: Option<String>,
-    pub system_id: Option<String>,
+    pub name:      Option<Atom>,
+    pub public_id: Option<Span>,
+    pub system_id: Option<Span>,
     pub force_quirks: bool,
 }
 
@@ -52,7 +51,7 @@ impl Doctype {
 #[deriving(PartialEq, Eq, PartialOrd, Ord, Clone, Show)]
 pub struct Attribute {
     pub name: QualName,
-    pub value: String,
+    pub value: Span,
 }
 
 #[deriving(PartialEq, Eq, Clone, Show)]
@@ -91,8 +90,8 @@ impl Tag {
 pub enum Token {
     DoctypeToken(Doctype),
     TagToken(Tag),
-    CommentToken(String),
-    CharacterTokens(String),
+    CommentToken(Span),
+    CharacterTokens(Span),
     NullCharacterToken,
     EOFToken,
     ParseError(MaybeOwned<'static>),

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -11,6 +11,8 @@
 
 use core::prelude::*;
 
+pub use util::span::{Span, ValidatedSpanUtils};
+
 pub use self::interface::{Doctype, Attribute, TagKind, StartTag, EndTag, Tag};
 pub use self::interface::{Token, DoctypeToken, TagToken, CommentToken};
 pub use self::interface::{CharacterTokens, NullCharacterToken, EOFToken, ParseError};
@@ -21,12 +23,16 @@ use self::states::{Rcdata, Rawtext, ScriptData, ScriptDataEscaped};
 use self::states::{Escaped, DoubleEscaped};
 use self::states::{Unquoted, SingleQuoted, DoubleQuoted};
 use self::states::{DoctypeIdKind, Public, System};
+use self::states::{ScriptEscapeKind, RawKind};
 
-use self::char_ref::{CharRef, CharRefTokenizer};
+use self::char_ref::CharRefTokenizer;
 
-use self::buffer_queue::{BufferQueue, SetResult, FromSet, NotFromSet};
+use self::buffer_queue::BufferQueue;
 
-use util::str::{lower_ascii, lower_ascii_letter, empty_str};
+use util::fast_option::{Uninit, Full, FastOption, OptValue};
+use util::single_char::{SingleChar, MayAppendSingleChar};
+
+use util::str::{is_alphabetic, lower_ascii};
 use util::smallcharset::SmallCharSet;
 
 use core::mem::replace;
@@ -39,6 +45,8 @@ use collections::string::String;
 use collections::str::{MaybeOwned, Slice};
 use collections::TreeMap;
 
+use iobuf::{BufSpan, Iobuf, ROIobuf};
+
 use string_cache::{Atom, QualName};
 
 pub mod states;
@@ -46,18 +54,18 @@ mod interface;
 mod char_ref;
 mod buffer_queue;
 
-fn option_push(opt_str: &mut Option<String>, c: char) {
+fn option_push(opt_str: &mut Option<Span>, c: SingleChar) {
     match *opt_str {
-        Some(ref mut s) => s.push(c),
-        None => *opt_str = Some(String::from_char(1, c)),
+        Some(ref mut s) => s.push_sc(c),
+        None => *opt_str = Some(c.into_span()),
     }
 }
 
-fn append_strings(lhs: &mut String, rhs: String) {
-    if lhs.is_empty() {
-        *lhs = rhs;
-    } else {
-        lhs.push_str(rhs.as_slice());
+fn is_errorful_char(c: u32) -> bool {
+    match c {
+        0x01...0x08 | 0x0B | 0x0E...0x1F | 0x7F...0x9F | 0xFDD0...0xFDEF => true,
+        n if (n & 0xFFFE) == 0xFFFE => true,
+        _ => false,
     }
 }
 
@@ -97,10 +105,60 @@ impl Default for TokenizerOpts {
     }
 }
 
-/// The HTML tokenizer.
+/// Shared state in the tokenizer that the step function needs, but we don't mutate
+/// except via get_char and pop_except_from.
+struct Shared {
+    c: FastOption<SingleChar>,
+    r: FastOption<ROIobuf<'static>>,
+}
+
 pub struct Tokenizer<Sink> {
+    shared: Shared,
+    inner:  TokenizerInner<Sink>,
+}
+
+impl<Sink: TokenSink> Tokenizer<Sink> {
+    pub fn new(sink: Sink, opts: TokenizerOpts) -> Tokenizer<Sink> {
+        Tokenizer {
+            shared: Shared {
+                c: FastOption::new(),
+                r: FastOption::new(),
+            },
+            inner: TokenizerInner::new(sink, opts),
+        }
+    }
+
+    pub fn unwrap(self) -> Sink {
+        self.inner.sink
+    }
+
+    pub fn sink<'a>(&'a self) -> &'a Sink {
+        &self.inner.sink
+    }
+
+    pub fn sink_mut<'a>(&'a mut self) -> &'a mut Sink {
+        &mut self.inner.sink
+    }
+
+    /// Feed an input string into the tokenizer.
+    pub fn feed(&mut self, input: ROIobuf<'static>) {
+        self.inner.feed(input, &mut self.shared)
+    }
+
+    pub fn end(&mut self) {
+        self.inner.end(&mut self.shared)
+    }
+}
+
+
+/// The HTML tokenizer.
+struct TokenizerInner<Sink> {
     /// Options controlling the behavior of the tokenizer.
     opts: TokenizerOpts,
+
+    /// Discard a U+FEFF BYTE ORDER MARK if we see one?  Only done at the
+    /// beginning of the stream.
+    discard_bom: bool,
 
     /// Destination for tokens we emit.
     sink: Sink,
@@ -108,30 +166,15 @@ pub struct Tokenizer<Sink> {
     /// The abstract machine state as described in the spec.
     state: states::State,
 
-    /// Input ready to be tokenized.
-    input_buffers: BufferQueue,
-
-    /// Are we at the end of the file, once buffers have been processed
-    /// completely? This affects whether we will wait for lookahead or not.
-    at_eof: bool,
-
     /// Tokenizer for character references, if we're tokenizing
     /// one at the moment.
     char_ref_tokenizer: Option<Box<CharRefTokenizer>>,
 
+    /// Input ready to be tokenized.
+    input_buffers: BufferQueue,
+
     /// Current input character.  Just consumed, may reconsume.
-    current_char: char,
-
-    /// Should we reconsume the current input character?
-    reconsume: bool,
-
-    /// Did we just consume \r, translating it to \n?  In that case we need
-    /// to ignore the next character if it's \n.
-    ignore_lf: bool,
-
-    /// Discard a U+FEFF BYTE ORDER MARK if we see one?  Only done at the
-    /// beginning of the stream.
-    discard_bom: bool,
+    current_char: Option<SingleChar>,
 
     /// Current tag kind.
     current_tag_kind: TagKind,
@@ -149,30 +192,55 @@ pub struct Tokenizer<Sink> {
     current_attr_name: String,
 
     /// Current attribute value.
-    current_attr_value: String,
+    current_attr_value: Span,
 
     /// Current comment.
-    current_comment: String,
+    current_comment: Span,
+
+    /// The buffer representing the first '-' that's ending a comment.
+    first_comment_end_dash:  Option<ROIobuf<'static>>,
+    /// The buffer representing the second '-' that's ending a comment.
+    second_comment_end_dash: Option<ROIobuf<'static>>,
+
+    /// Another "temporary buffer" not mentioned in the spec. This is used for
+    /// when we drop into states that we might soon drop out of, and lets us
+    /// keep around the characters that caused the state transitions.
+    another_temp_buf: Span,
+
+    /// The "temporary buffer" mentioned in the spec.
+    temp_buf: Span,
 
     /// Current doctype token.
     current_doctype: Doctype,
 
+    /// Current doctype name. This will need to be atomized before loading into
+    //// the `current_doctype`.
+    current_doctype_name: Option<Span>,
+
     /// Last start tag name, for use in checking "appropriate end tag".
     last_start_tag_name: Option<Atom>,
 
-    /// The "temporary buffer" mentioned in the spec.
-    temp_buf: String,
+    /// Are we at the end of the file, once buffers have been processed
+    /// completely? This affects whether we will wait for lookahead or not.
+    at_eof: bool,
 
     /// Record of how many ns we spent in each state, if profiling is enabled.
     state_profile: TreeMap<states::State, u64>,
 
     /// Record of how many ns we spent in the token sink.
     time_in_sink: u64,
+
+    /// Did we just consume \r, translating it to \n?  In that case we need
+    /// to ignore the next character if it's \n.
+    ignore_lf: bool,
+
+    /// A cached copy of a single newline character, to deal with CRLF replacement.
+    newline: SingleChar,
 }
 
-impl<Sink: TokenSink> Tokenizer<Sink> {
+impl<Sink: TokenSink> TokenizerInner<Sink> {
     /// Create a new tokenizer which feeds tokens to a particular `TokenSink`.
-    pub fn new(sink: Sink, mut opts: TokenizerOpts) -> Tokenizer<Sink> {
+    fn new(sink: Sink, mut opts: TokenizerOpts) -> TokenizerInner<Sink> {
         if opts.profile && cfg!(for_c) {
             panic!("Can't profile tokenizer when built as a C library");
         }
@@ -181,78 +249,106 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             .map(|s| Atom::from_slice(s.as_slice()));
         let state = *opts.initial_state.as_ref().unwrap_or(&states::Data);
         let discard_bom = opts.discard_bom;
-        Tokenizer {
+        TokenizerInner {
             opts: opts,
             sink: sink,
             state: state,
             char_ref_tokenizer: None,
             input_buffers: BufferQueue::new(),
             at_eof: false,
-            current_char: '\0',
-            reconsume: false,
+            current_char: None,
             ignore_lf: false,
             discard_bom: discard_bom,
             current_tag_kind: StartTag,
-            current_tag_name: empty_str(),
+            current_tag_name: String::new(),
             current_tag_self_closing: false,
             current_tag_attrs: vec!(),
-            current_attr_name: empty_str(),
-            current_attr_value: empty_str(),
-            current_comment: empty_str(),
+            current_attr_name: String::new(),
+            current_attr_value: BufSpan::new(),
+            current_comment: BufSpan::new(),
             current_doctype: Doctype::new(),
+            current_doctype_name: None,
             last_start_tag_name: start_tag_name,
-            temp_buf: empty_str(),
+            temp_buf: BufSpan::new(),
+            another_temp_buf: BufSpan::new(),
+            first_comment_end_dash: None,
+            second_comment_end_dash: None,
             state_profile: TreeMap::new(),
             time_in_sink: 0,
+            newline: SingleChar::new(ROIobuf::from_str("\n")),
         }
     }
 
-    pub fn unwrap(self) -> Sink {
-        self.sink
-    }
-
-    pub fn sink<'a>(&'a self) -> &'a Sink {
-        &self.sink
-    }
-
-    pub fn sink_mut<'a>(&'a mut self) -> &'a mut Sink {
-        &mut self.sink
-    }
-
     /// Feed an input string into the tokenizer.
-    pub fn feed(&mut self, input: String) {
+    fn feed(&mut self, mut input: ROIobuf<'static>, shared: &mut Shared) {
         if input.len() == 0 {
             return;
         }
 
-        let pos = if self.discard_bom && input.as_slice().char_at(0) == '\ufeff' {
-            self.discard_bom = false;
-            3  // length of BOM in UTF-8
-        } else {
-            0
-        };
+        if self.discard_bom {
+            let mut first_three_bytes = [0u8, ..3];
+            static UTF8_BOM: [u8, ..3] = [ 0xEF, 0xBB, 0xBF ];
 
-        self.input_buffers.push_back(input, pos);
-        self.run();
+            unsafe {
+                match input.peek(0, &mut first_three_bytes) {
+                    Err(()) => {},
+                    Ok (()) => {
+                        if first_three_bytes.as_slice() == UTF8_BOM.as_slice() {
+                            input.unsafe_advance(first_three_bytes.len() as u32);
+                        }
+                    }
+                }
+            }
+        }
+
+        self.input_buffers.push_back(input);
+        self.run(shared);
     }
 
+    #[inline(never)]
     fn process_token(&mut self, token: Token) {
         if self.opts.profile {
-            let (_, dt) = time!(self.sink.process_token(token));
-            self.time_in_sink += dt;
+            self.process_token_slow(token);
         } else {
             self.sink.process_token(token);
         }
     }
 
-    //§ preprocessing-the-input-stream
-    // Get the next input character, which might be the character
-    // 'c' that we already consumed from the buffers.
-    fn get_preprocessed_char(&mut self, mut c: char) -> Option<char> {
+    #[inline(never)]
+    fn process_token_slow(&mut self, token: Token) {
+        let (_, dt) = time!(self.sink.process_token(token));
+        self.time_in_sink += dt;
+    }
+
+    /// This function is unsafe because the input option `c` MUST be `some` when
+    /// you call this function.
+    #[inline]
+    fn get_preprocessed_char(&mut self, c: &mut FastOption<SingleChar>) -> OptValue {
+        if !self.ignore_lf && c.as_ref().as_u8() != b'\r' && !self.opts.exact_errors {
+            Full
+        } else {
+            self.get_preprocessed_char_slow(c)
+        }
+    }
+
+    #[inline]
+    fn get_preprocessed_char_simple(&mut self, c: char) -> Option<char> {
+        if !self.ignore_lf && c != '\r' && !self.opts.exact_errors {
+            Some(c)
+        } else {
+            self.get_preprocessed_char_simple_slow(c)
+        }
+    }
+
+    #[inline(never)]
+    fn get_preprocessed_char_simple_slow(&mut self, mut c: char) -> Option<char> {
         if self.ignore_lf {
             self.ignore_lf = false;
             if c == '\n' {
-                c = unwrap_or_return!(self.input_buffers.next(), None);
+                c = match self.input_buffers.next_simple() {
+                    None => return None,
+                    Some(c) => c,
+                };
             }
         }
 
@@ -261,11 +357,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             c = '\n';
         }
 
-        if self.opts.exact_errors && match c as u32 {
-            0x01...0x08 | 0x0B | 0x0E...0x1F | 0x7F...0x9F | 0xFDD0...0xFDEF => true,
-            n if (n & 0xFFFE) == 0xFFFE => true,
-            _ => false,
-        } {
+        if self.opts.exact_errors && is_errorful_char(c as u32) {
             // format_if!(true) will still use the static error when built for C.
             let msg = format_if!(true, "Bad character",
                 "Bad character {}", c);
@@ -273,41 +365,103 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         }
 
         h5e_debug!("got character {}", c);
-        self.current_char = c;
         Some(c)
+    }
+
+    //§ preprocessing-the-input-stream
+    // Get the next input character, which might be the character
+    // 'c' that we already consumed from the buffers.
+    //
+    // `c` must be a previously filled FastOption<SingleChar>
+    #[inline(never)]
+    fn get_preprocessed_char_slow(&mut self, c: &mut FastOption<SingleChar>) -> OptValue {
+        if self.ignore_lf {
+            self.ignore_lf = false;
+            if c.as_ref().as_u8() == b'\n' {
+                match self.input_buffers.next(c) {
+                    Full   => {},
+                    Uninit => return Uninit,
+                }
+            }
+        }
+
+        if c.as_ref().as_u8() == b'\r' {
+            self.ignore_lf = true;
+            c.fill(self.newline.clone());
+        }
+
+        let c_char = c.as_ref().decode_as_char();
+
+        // TODO: This should be possible without actually decoding the char.
+        if self.opts.exact_errors && is_errorful_char(c_char as u32) {
+            // format_if!(true) will still use the static error when built for C.
+            let msg = format_if!(true, "Bad character",
+                "Bad character {}", c_char);
+            self.emit_error(msg);
+        }
+
+        h5e_debug!("got character {}", c_char);
+        Full
     }
 
     //§ tokenization
     // Get the next input character, if one is available.
-    fn get_char(&mut self) -> Option<char> {
-        if self.reconsume {
-            self.reconsume = false;
-            Some(self.current_char)
+    #[inline(always)]
+    fn get_char(&mut self, dst: &mut FastOption<SingleChar>) -> OptValue {
+        if self.current_char.is_none() {
+            match self.input_buffers.next(dst) {
+                Full   => self.get_preprocessed_char(dst),
+                Uninit => Uninit,
+            }
         } else {
-            self.input_buffers.next()
-                .and_then(|c| self.get_preprocessed_char(c))
+            self.get_char_slow(dst)
         }
     }
 
-    fn pop_except_from(&mut self, set: SmallCharSet) -> Option<SetResult> {
+    #[inline(never)]
+    fn get_char_slow(&mut self, dst: &mut FastOption<SingleChar>) -> OptValue {
+        dst.fill(self.current_char.take().unwrap())
+    }
+
+    #[inline(always)]
+    fn get_char_simple(&mut self) -> Option<char> {
+        if self.current_char.is_none() {
+            self.input_buffers.next_simple().and_then(|c| self.get_preprocessed_char_simple(c))
+        } else {
+            self.get_char_simple_slow()
+        }
+    }
+
+    #[inline(never)]
+    fn get_char_simple_slow(&mut self) -> Option<char> {
+        Some(self.current_char.take().unwrap().decode_as_char())
+    }
+
+    /// If neither of the `FastOption`s are full, then we're at end of input.
+    /// This function will never fill both. Either one or the other. If a char
+    /// got popped, `char_dst` will be filled. If a run got popped, `run_dst` will
+    /// be filled. The left hand side of the tuple refers to char_dst, and the right
+    /// hand side refers to `run_dst`.
+    #[inline(always)]
+    fn pop_except_from(&mut self, set: SmallCharSet, char_dst: &mut FastOption<SingleChar>, run_dst: &mut FastOption<ROIobuf<'static>>) -> (OptValue, OptValue) {
         // Bail to the slow path for various corner cases.
         // This means that `FromSet` can contain characters not in the set!
         // It shouldn't matter because the fallback `FromSet` case should
         // always do the same thing as the `NotFromSet` case.
-        if self.opts.exact_errors || self.reconsume || self.ignore_lf {
-            return self.get_char().map(|x| FromSet(x));
+        if self.opts.exact_errors || self.current_char.is_some() || self.ignore_lf {
+            return (self.get_char(char_dst), Uninit);
         }
 
-        let d = self.input_buffers.pop_except_from(set);
-        h5e_debug!("got characters {}", d);
-        match d {
-            Some(FromSet(c)) => self.get_preprocessed_char(c).map(|x| FromSet(x)),
+        let ret = self.input_buffers.pop_except_from(set, char_dst, run_dst);
 
-            // NB: We don't set self.current_char for a run of characters not
-            // in the set.  It shouldn't matter for the codepaths that use
-            // this.
-            _ => d
-        }
+        match ret {
+            (Full, Uninit) => {
+                self.get_preprocessed_char(char_dst);
+            }
+            _ => {},
+        };
+
+        ret
     }
 
     // Check if the next characters are an ASCII case-insensitive match.  See
@@ -315,20 +469,20 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
     //
     // NB: this doesn't do input stream preprocessing or set the current input
     // character.
-    fn eat(&mut self, pat: &str) -> Option<bool> {
+    fn eat(&mut self, pat: &[u8]) -> Option<Span> {
         match self.input_buffers.eat(pat) {
-            None if self.at_eof => Some(false),
+            None if self.at_eof => Some(BufSpan::new()),
             r => r,
         }
     }
 
     // Run the state machine for as long as we can.
-    fn run(&mut self) {
+    fn run(&mut self, shared: &mut Shared) {
         if self.opts.profile {
             loop {
                 let state = self.state;
                 let old_sink = self.time_in_sink;
-                let (run, mut dt) = time!(self.step());
+                let (run, mut dt) = time!(self.step(shared));
                 dt -= (self.time_in_sink - old_sink);
                 let new = match self.state_profile.get_mut(&state) {
                     Some(x) => {
@@ -344,19 +498,27 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 if !run { break; }
             }
         } else {
-            while self.step() {
+            while self.step(shared) {
             }
         }
     }
 
-    fn bad_char_error(&mut self) {
+    #[inline(never)]
+    fn bad_char_error(&mut self, c: &SingleChar) {
+        self.bad_char_error_simple(c.decode_as_char())
+    }
+
+    #[inline(never)]
+    fn bad_char_error_simple(&mut self, c: char) {
+        let _ignored_when_for_c = c;
         let msg = format_if!(
             self.opts.exact_errors,
             "Bad character",
-            "Saw {} in state {}", self.current_char, self.state);
+            "Saw {} in state {}", c, self.state);
         self.emit_error(msg);
     }
 
+    #[inline(never)]
     fn bad_eof_error(&mut self) {
         let msg = format_if!(
             self.opts.exact_errors,
@@ -365,23 +527,48 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         self.emit_error(msg);
     }
 
-    fn emit_char(&mut self, c: char) {
-        self.process_token(match c {
-            '\0' => NullCharacterToken,
-            _ => CharacterTokens(String::from_char(1, c)),
-        });
+    #[inline]
+    fn emit_unicode_replacement(&mut self, _: SingleChar) {
+        self.emit_char(SingleChar::unicode_replacement())
+    }
+
+    #[inline(never)]
+    fn emit_null(&mut self, _: SingleChar) {
+        self.process_token(NullCharacterToken);
+    }
+
+    #[inline]
+    fn emit_char(&mut self, c: SingleChar) {
+        self.process_token(CharacterTokens(c.into_span()))
+    }
+
+    #[inline]
+    fn emit_buf(&mut self, buf: ROIobuf<'static>) {
+        self.process_token(CharacterTokens(BufSpan::from_buf(buf)));
     }
 
     // The string must not contain '\0'!
-    fn emit_chars(&mut self, b: String) {
+    #[inline]
+    fn emit_span(&mut self, b: Span) {
         self.process_token(CharacterTokens(b));
+    }
+
+    fn push_doctype_name_unicode_replacement(&mut self, _: SingleChar) {
+        option_push(&mut self.current_doctype_name, SingleChar::unicode_replacement())
+    }
+
+    fn push_doctype_id_unicode_replacement(&mut self, k: states::DoctypeIdKind, _: SingleChar) {
+        option_push(self.doctype_id(k), SingleChar::unicode_replacement())
+    }
+
+    fn push_tag_unicode_replacement(&mut self) {
+        self.current_tag_name.push('\ufffd')
     }
 
     fn emit_current_tag(&mut self) {
         self.finish_attribute();
-
-        let name = replace(&mut self.current_tag_name, String::new());
-        let name = Atom::from_slice(name.as_slice());
+        let name = Atom::from_slice(self.current_tag_name.as_slice());
+        self.current_tag_name.truncate(0);
 
         match self.current_tag_kind {
             StartTag => {
@@ -397,7 +584,8 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             }
         }
 
-        let token = TagToken(Tag { kind: self.current_tag_kind,
+        let token = TagToken(Tag {
+            kind: self.current_tag_kind,
             name: name,
             self_closing: self.current_tag_self_closing,
             attrs: replace(&mut self.current_tag_attrs, vec!()),
@@ -412,39 +600,109 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         }
     }
 
+    fn push_value_unicode_replacement(&mut self, _: SingleChar) {
+        self.current_attr_value.push_sc(SingleChar::unicode_replacement())
+    }
+
     fn emit_temp_buf(&mut self) {
         // FIXME: Make sure that clearing on emit is spec-compatible.
-        let buf = replace(&mut self.temp_buf, empty_str());
-        self.emit_chars(buf);
+        let span = replace(&mut self.temp_buf, BufSpan::new());
+        self.emit_span(span);
     }
 
     fn clear_temp_buf(&mut self) {
-        // Do this without a new allocation.
-        self.temp_buf.truncate(0);
+        self.temp_buf = BufSpan::new();
+    }
+
+    fn emit_another_temp_buf(&mut self) {
+        let span = replace(&mut self.another_temp_buf, BufSpan::new());
+        self.emit_span(span);
+    }
+
+    fn clear_another_temp_buf(&mut self) {
+        self.replace_another_temp_buf_span(BufSpan::new());
+    }
+
+    fn replace_another_temp_buf(&mut self, c: SingleChar) {
+        self.replace_another_temp_buf_span(c.into_span());
+    }
+
+    fn replace_another_temp_buf_span(&mut self, s: Span) {
+        self.another_temp_buf = s;
+    }
+
+    fn append_another_temp_buf_to_comment(&mut self) {
+        self.current_comment.append(replace(&mut self.another_temp_buf, BufSpan::new()));
+    }
+
+    fn push_comment_unicode_replacement(&mut self, _: SingleChar) {
+        self.current_comment.push_sc(SingleChar::unicode_replacement());
+    }
+
+    fn clear_comment_end_dashes(&mut self) {
+        self.first_comment_end_dash  = None;
+        self.second_comment_end_dash = None;
+    }
+
+    fn push_comment_end_dash(&mut self, c: SingleChar) {
+        match replace(&mut self.second_comment_end_dash, Some(c.into_buf())) {
+            None => {},
+            Some(old_second) => {
+                match replace(&mut self.first_comment_end_dash, Some(old_second)) {
+                    None => {},
+                    Some(old_first) => {
+                        self.current_comment.push(old_first);
+                    }
+                }
+            }
+        }
+    }
+
+    fn flush_comment_end_dashes_to_comment(&mut self) {
+        match self.first_comment_end_dash.take() {
+            None => {},
+            Some(buf) => self.current_comment.push(buf),
+        }
+        match self.second_comment_end_dash.take() {
+            None => {},
+            Some(buf) => self.current_comment.push(buf),
+        }
     }
 
     fn emit_current_comment(&mut self) {
-        let comment = replace(&mut self.current_comment, empty_str());
-        self.process_token(CommentToken(comment));
+        let span = replace(&mut self.current_comment, BufSpan::new());
+        self.process_token(CommentToken(span));
     }
 
     fn discard_tag(&mut self) {
-        self.current_tag_name = String::new();
+        self.current_tag_name.truncate(0);
         self.current_tag_self_closing = false;
         self.current_tag_attrs = vec!();
     }
 
     fn create_tag(&mut self, kind: TagKind, c: char) {
-        self.discard_tag();
+        self.current_tag_name.truncate(0);
         self.current_tag_name.push(c);
+        self.current_tag_self_closing = false;
+        self.current_tag_attrs = vec!();
         self.current_tag_kind = kind;
+    }
+
+    #[inline]
+    fn create_start_tag(&mut self, c: char) {
+        self.create_tag(StartTag, c)
+    }
+
+    #[inline]
+    fn create_end_tag(&mut self, c: char) {
+        self.create_tag(EndTag, c)
     }
 
     fn have_appropriate_end_tag(&self) -> bool {
         match self.last_start_tag_name.as_ref() {
             Some(last) =>
                 (self.current_tag_kind == EndTag)
-                && (self.current_tag_name.as_slice() == last.as_slice()),
+                && self.current_tag_name.as_slice() == last.as_slice(),
             None => false,
         }
     }
@@ -455,8 +713,12 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         self.current_attr_name.push(c);
     }
 
+    fn create_attribute_unicode_replacement(&mut self) {
+        self.create_attribute('\ufffd');
+    }
+
     fn finish_attribute(&mut self) {
-        if self.current_attr_name.len() == 0 {
+        if self.current_attr_name.is_empty() {
             return;
         }
 
@@ -470,25 +732,39 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
         if dup {
             self.emit_error(Slice("Duplicate attribute"));
-            self.current_attr_name.truncate(0);
-            self.current_attr_value.truncate(0);
+            self.current_attr_value = BufSpan::new();
         } else {
-            let name = replace(&mut self.current_attr_name, String::new());
             self.current_tag_attrs.push(Attribute {
                 // The tree builder will adjust the namespace if necessary.
                 // This only happens in foreign elements.
-                name: QualName::new(ns!(""), Atom::from_slice(name.as_slice())),
-                value: replace(&mut self.current_attr_value, empty_str()),
+                name: QualName::new(ns!(""), Atom::from_slice(self.current_attr_name.as_slice())),
+                value: replace(&mut self.current_attr_value, BufSpan::new()),
             });
         }
+
+        self.current_attr_name.truncate(0);
+    }
+
+    fn push_name_unicode_replacement(&mut self) {
+        self.current_attr_name.push('\ufffd');
+    }
+
+    fn create_doctype(&mut self) {
+        self.current_doctype      = Doctype::new();
+        self.current_doctype_name = None;
     }
 
     fn emit_current_doctype(&mut self) {
-        let doctype = replace(&mut self.current_doctype, Doctype::new());
+        let mut doctype = replace(&mut self.current_doctype, Doctype::new());
+
+        doctype.name =
+            replace(&mut self.current_doctype_name, None)
+            .map(|name| name.with_lower_str_copy(Atom::from_slice));
+
         self.process_token(DoctypeToken(doctype));
     }
 
-    fn doctype_id<'a>(&'a mut self, kind: DoctypeIdKind) -> &'a mut Option<String> {
+    fn doctype_id<'a>(&'a mut self, kind: DoctypeIdKind) -> &'a mut Option<Span> {
         match kind {
             Public => &mut self.current_doctype.public_id,
             System => &mut self.current_doctype.system_id,
@@ -496,38 +772,38 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
     }
 
     fn clear_doctype_id(&mut self, kind: DoctypeIdKind) {
-        let id = self.doctype_id(kind);
-        match *id {
-            Some(ref mut s) => s.truncate(0),
-            None => *id = Some(empty_str()),
-        }
+        *self.doctype_id(kind) = Some(BufSpan::new());
     }
 
-    fn consume_char_ref(&mut self, addnl_allowed: Option<char>) {
+    fn consume_char_ref(&mut self, amp: SingleChar, addnl_allowed: Option<u8>) {
         // NB: The char ref tokenizer assumes we have an additional allowed
         // character iff we're tokenizing in an attribute value.
-        self.char_ref_tokenizer = Some(box CharRefTokenizer::new(addnl_allowed));
+        self.char_ref_tokenizer = Some(box CharRefTokenizer::new(amp, addnl_allowed));
     }
 
     fn emit_eof(&mut self) {
         self.process_token(EOFToken);
     }
 
-    fn peek(&mut self) -> Option<char> {
-        if self.reconsume {
-            Some(self.current_char)
-        } else {
-            self.input_buffers.peek()
+    fn peek(&mut self, dst: &mut FastOption<SingleChar>) -> OptValue {
+        match self.current_char {
+            Some(ref c) => dst.fill((*c).clone()),
+            None => self.input_buffers.peek(dst),
         }
     }
 
     fn discard_char(&mut self) {
-        let c = self.get_char();
-        assert!(c.is_some());
+        let mut c = FastOption::new();
+        match self.get_char(&mut c) {
+            Uninit => panic!("Should be discarding a valid char."),
+            Full   => {},
+        }
     }
 
-    fn unconsume(&mut self, buf: String) {
-        self.input_buffers.push_front(buf);
+    fn unconsume(&mut self, span: Span) {
+        for buf in span.into_iter().rev() {
+            self.input_buffers.push_front(buf);
+        }
     }
 
     fn emit_error(&mut self, error: MaybeOwned<'static>) {
@@ -538,36 +814,65 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
 // Shorthand for common state machine behaviors.
 macro_rules! shorthand (
-    ( $me:expr : emit $c:expr                    ) => ( $me.emit_char($c);                                   );
-    ( $me:expr : create_tag $kind:expr $c:expr   ) => ( $me.create_tag($kind, $c);                           );
-    ( $me:expr : push_tag $c:expr                ) => ( $me.current_tag_name.push($c);                       );
-    ( $me:expr : discard_tag                     ) => ( $me.discard_tag();                                   );
-    ( $me:expr : push_temp $c:expr               ) => ( $me.temp_buf.push($c);                               );
-    ( $me:expr : emit_temp                       ) => ( $me.emit_temp_buf();                                 );
-    ( $me:expr : clear_temp                      ) => ( $me.clear_temp_buf();                                );
-    ( $me:expr : create_attr $c:expr             ) => ( $me.create_attribute($c);                            );
-    ( $me:expr : push_name $c:expr               ) => ( $me.current_attr_name.push($c);                      );
-    ( $me:expr : push_value $c:expr              ) => ( $me.current_attr_value.push($c);                     );
-    ( $me:expr : append_value $c:expr            ) => ( append_strings(&mut $me.current_attr_value, $c);     );
-    ( $me:expr : push_comment $c:expr            ) => ( $me.current_comment.push($c);                        );
-    ( $me:expr : append_comment $c:expr          ) => ( $me.current_comment.push_str($c);                    );
-    ( $me:expr : emit_comment                    ) => ( $me.emit_current_comment();                          );
-    ( $me:expr : clear_comment                   ) => ( $me.current_comment.truncate(0);                     );
-    ( $me:expr : create_doctype                  ) => ( $me.current_doctype = Doctype::new();                );
-    ( $me:expr : push_doctype_name $c:expr       ) => ( option_push(&mut $me.current_doctype.name, $c);      );
-    ( $me:expr : push_doctype_id $k:expr $c:expr ) => ( option_push($me.doctype_id($k), $c);                 );
-    ( $me:expr : clear_doctype_id $k:expr        ) => ( $me.clear_doctype_id($k);                            );
-    ( $me:expr : force_quirks                    ) => ( $me.current_doctype.force_quirks = true;             );
-    ( $me:expr : emit_doctype                    ) => ( $me.emit_current_doctype();                          );
-    ( $me:expr : error                           ) => ( $me.bad_char_error();                                );
-    ( $me:expr : error_eof                       ) => ( $me.bad_eof_error();                                 );
+    ( $me:expr : emit_null $c:expr                  ) => ( $me.emit_null($c.take());                               );
+    ( $me:expr : emit $c:expr                       ) => ( $me.emit_char($c.take());                               );
+    ( $me:expr : emit_ur $c:expr                    ) => ( $me.emit_unicode_replacement($c.take());                );
+    ( $me:expr : emit_buf $b:expr                   ) => ( $me.emit_buf($b.take());                                );
+    ( $me:expr : emit_span $s:expr                  ) => ( $me.emit_span($s.take());                               );
+    ( $me:expr : emit_span_raw $s:expr              ) => ( $me.emit_span($s);                                      );
+    ( $me:expr : create_start_tag $c:expr           ) => ( $me.create_start_tag(lower_ascii($c as char));          );
+    ( $me:expr : create_end_tag $c:expr             ) => ( $me.create_end_tag(lower_ascii($c as char));            );
+    ( $me:expr : push_tag $c:expr                   ) => ( go!($me: push_tag_char ($c as char));                   );
+    ( $me:expr : push_tag_char $c:expr              ) => ( $me.current_tag_name.push(lower_ascii($c));             );
+    ( $me:expr : push_tag_ur                        ) => ( $me.push_tag_unicode_replacement();                     );
+    ( $me:expr : discard_tag                        ) => ( $me.discard_tag();                                      );
+    ( $me:expr : push_temp $c:expr                  ) => ( $me.temp_buf.push_sc($c.take());                        );
+    ( $me:expr : push_temp_clone $c:expr            ) => ( $me.temp_buf.push_sc((*$c.as_ref()).clone());           );
+    ( $me:expr : emit_temp                          ) => ( $me.emit_temp_buf();                                    );
+    ( $me:expr : clear_temp                         ) => ( $me.clear_temp_buf();                                   );
+    ( $me:expr : push_temp2 $c: expr                ) => ( $me.another_temp_buf.push_sc($c.take());                );
+    ( $me:expr : push_temp2_span $s: expr           ) => ( $me.another_temp_buf.append($s.take());                 );
+    ( $me:expr : emit_temp2                         ) => ( $me.emit_another_temp_buf();                            );
+    ( $me:expr : clear_temp2                        ) => ( $me.clear_another_temp_buf();                           );
+    ( $me:expr : replace_temp2 $c: expr             ) => ( $me.replace_another_temp_buf($c.take());                );
+    ( $me:expr : replace_temp2_span $s: expr        ) => ( $me.replace_another_temp_buf_span($s.take());           );
+    ( $me:expr : append_temp2_to_comment            ) => ( $me.append_another_temp_buf_to_comment();               );
+    ( $me:expr : clear_comment_end_dashes           ) => ( $me.clear_comment_end_dashes();                         );
+    ( $me:expr : push_comment_end_dash $c: expr     ) => ( $me.push_comment_end_dash($c.take());                   );
+    ( $me:expr : flush_comment_end_dashes           ) => ( $me.flush_comment_end_dashes_to_comment();              );
+    ( $me:expr : create_attr $c:expr                ) => ( $me.create_attribute(lower_ascii($c));                  );
+    ( $me:expr : create_attr_ur                     ) => ( $me.create_attribute_unicode_replacement();             );
+    ( $me:expr : push_name $c:expr                  ) => ( $me.current_attr_name.push(lower_ascii($c));            );
+    ( $me:expr : push_name_ur                       ) => ( $me.push_name_unicode_replacement();                    );
+    ( $me:expr : append_value $b:expr               ) => ( $me.current_attr_value.push($b.take());                 );
+    ( $me:expr : push_value $c:expr                 ) => ( $me.current_attr_value.push_sc($c.take());              );
+    ( $me:expr : push_value_ur $c:expr              ) => ( $me.push_value_unicode_replacement($c.take());          );
+    ( $me:expr : append_value_span $s:expr          ) => ( $me.current_attr_value.append($s.take());               );
+    ( $me:expr : append_value_span_raw $s:expr      ) => ( $me.current_attr_value.append($s);                      );
+    ( $me:expr : push_comment $c:expr               ) => ( $me.current_comment.push_sc($c.take());                 );
+    ( $me:expr : push_comment_ur $c:expr            ) => ( $me.push_comment_unicode_replacement($c.take());        );
+    ( $me:expr : append_comment $c:expr             ) => ( $me.current_comment.append($c.take());                  );
+    ( $me:expr : emit_comment                       ) => ( $me.emit_current_comment();                             );
+    ( $me:expr : clear_comment                      ) => ( $me.current_comment = BufSpan::new();                   );
+    ( $me:expr : create_doctype                     ) => ( $me.create_doctype();                                   );
+    ( $me:expr : push_doctype_name $c:expr          ) => ( option_push(&mut $me.current_doctype_name, $c.take());  );
+    ( $me:expr : push_doctype_name_ur $c:expr       ) => ( $me.push_doctype_name_unicode_replacement($c.take());   );
+    ( $me:expr : push_doctype_id $k:expr $c:expr    ) => ( option_push($me.doctype_id($k), $c.take());             );
+    ( $me:expr : push_doctype_id_ur $k:expr $c:expr ) => ( $me.push_doctype_id_unicode_replacement($k, $c.take()); );
+    ( $me:expr : clear_doctype_id $k:expr           ) => ( $me.clear_doctype_id($k);                               );
+    ( $me:expr : force_quirks                       ) => ( $me.current_doctype.force_quirks = true;                );
+    ( $me:expr : emit_doctype                       ) => ( $me.emit_current_doctype();                             );
+    ( $me:expr : error $c:expr                      ) => ( $me.bad_char_error($c.as_ref());                        );
+    ( $me:expr : error_simple $c:expr               ) => ( $me.bad_char_error_simple($c);                          );
+    ( $me:expr : error_raw $c:expr                  ) => ( $me.bad_char_error(&$c);                                );
+    ( $me:expr : error_eof                          ) => ( $me.bad_eof_error();                                    );
 )
 
 // Tracing of tokenizer actions.  This adds significant bloat and compile time,
 // so it's behind a cfg flag.
 #[cfg(trace_tokenizer)]
 macro_rules! sh_trace ( ( $me:expr : $($cmds:tt)* ) => ({
-    h5e_debug!("  {:s}", stringify!($($cmds)*));
+    h5e_debug!("  {}", stringify!($($cmds)*));
     shorthand!($me:expr : $($cmds)*);
 }))
 
@@ -590,12 +895,12 @@ macro_rules! go (
     ( $me:expr : to $s:ident $k1:expr          ) => ({ $me.state = states::$s($k1); return true;      });
     ( $me:expr : to $s:ident $k1:expr $k2:expr ) => ({ $me.state = states::$s($k1($k2)); return true; });
 
-    ( $me:expr : reconsume $s:ident                   ) => ({ $me.reconsume = true; go!($me: to $s);         });
-    ( $me:expr : reconsume $s:ident $k1:expr          ) => ({ $me.reconsume = true; go!($me: to $s $k1);     });
-    ( $me:expr : reconsume $s:ident $k1:expr $k2:expr ) => ({ $me.reconsume = true; go!($me: to $s $k1 $k2); });
+    ( $me:expr : reconsume $c:expr $s:ident                   ) => ({ $me.current_char = Some($c.take()); go!($me: to $s);         });
+    ( $me:expr : reconsume $c:expr $s:ident $k1:expr          ) => ({ $me.current_char = Some($c.take()); go!($me: to $s $k1);     });
+    ( $me:expr : reconsume $c:expr $s:ident $k1:expr $k2:expr ) => ({ $me.current_char = Some($c.take()); go!($me: to $s $k1 $k2); });
 
-    ( $me:expr : consume_char_ref             ) => ({ $me.consume_char_ref(None); return true;         });
-    ( $me:expr : consume_char_ref $addnl:expr ) => ({ $me.consume_char_ref(Some($addnl)); return true; });
+    ( $me:expr : consume_char_ref $amp:expr             ) => ({ $me.consume_char_ref($amp.take(), None);         return true; });
+    ( $me:expr : consume_char_ref $amp:expr $addnl:expr ) => ({ $me.consume_char_ref($amp.take(), Some($addnl)); return true; });
 
     // We have a default next state after emitting a tag, but the sink can override.
     ( $me:expr : emit_tag $s:ident ) => ({
@@ -622,23 +927,43 @@ macro_rules! go_match ( ( $me:expr : $x:expr, $($pats:pat)|+ => $($cmds:tt)* ) =
 
 // This is a macro because it can cause early return
 // from the function where it is used.
-macro_rules! get_char ( ($me:expr) => (
-    unwrap_or_return!($me.get_char(), false)
+macro_rules! get_char ( ($me:expr, $s:expr) => (
+    {
+        match $me.get_char(&mut $s.c) {
+            Uninit => { return false },
+            Full   => {},
+        };
+        ($s.c).as_ref().as_u8()
+    }
 ))
 
-macro_rules! pop_except_from ( ($me:expr, $set:expr) => (
-    unwrap_or_return!($me.pop_except_from($set), false)
+macro_rules! get_char_simple ( ($me:expr) => (
+    match $me.get_char_simple() { None => return false, Some(c) => c }
+))
+
+macro_rules! pop_except_from ( ($me:expr, $s:expr, $set:expr) => (
+    {
+        let ret = $me.pop_except_from($set, &mut $s.c, &mut $s.r);
+        match ret {
+            (Uninit, Uninit) => return false,
+            ret => ret,
+        }
+    }
 ))
 
 macro_rules! eat ( ($me:expr, $pat:expr) => (
     unwrap_or_return!($me.eat($pat), false)
 ))
 
-impl<Sink: TokenSink> Tokenizer<Sink> {
+// Clean up the state machine type signatures a little bit.
+type TI<Sink> = TokenizerInner<Sink>;
+
+impl<Sink: TokenSink> TokenizerInner<Sink> {
     // Run the state machine for a while.
     // Return true if we should be immediately re-invoked
     // (this just simplifies control flow vs. break / continue).
-    fn step(&mut self) -> bool {
+    #[inline(always)]
+    fn step(&mut self, s: &mut Shared) -> bool {
         if self.char_ref_tokenizer.is_some() {
             return self.step_char_ref_tokenizer();
         }
@@ -646,525 +971,919 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         h5e_debug!("processing in state {}", self.state);
         match self.state {
             //§ data-state
-            states::Data => loop {
-                match pop_except_from!(self, small_char_set!('\r' '\0' '&' '<')) {
-                    FromSet('\0') => go!(self: error; emit '\0'),
-                    FromSet('&')  => go!(self: consume_char_ref),
-                    FromSet('<')  => go!(self: to TagOpen),
-                    FromSet(c)    => go!(self: emit c),
-                    NotFromSet(b) => self.emit_chars(b),
+            states::Data => {
+                #[inline(never)]
+                fn data_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '\0' '&' '<')) {
+                            (_, Full) => go!(this: emit_buf s.r),
+                                  _   => match s.c.as_ref().as_u8() {
+                                b'<'  => go!(this: replace_temp2 s.c; to TagOpen),
+                                b'&'  => go!(this: consume_char_ref s.c),
+                                b'\0' => go!(this: error s.c; emit_null s.c),
+                                  _   => go!(this: emit s.c),
+                            },
+                        }
+                    }
                 }
+                data_state(self, s)
             },
 
             //§ rcdata-state
-            states::RawData(Rcdata) => loop {
-                match pop_except_from!(self, small_char_set!('\r' '\0' '&' '<')) {
-                    FromSet('\0') => go!(self: error; emit '\ufffd'),
-                    FromSet('&') => go!(self: consume_char_ref),
-                    FromSet('<') => go!(self: to RawLessThanSign Rcdata),
-                    FromSet(c) => go!(self: emit c),
-                    NotFromSet(b) => self.emit_chars(b),
+            states::RawData(Rcdata) => {
+                #[inline(never)]
+                fn rcdata_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '\0' '&' '<')) {
+                            (Full, Uninit) => match s.c.as_ref().as_u8() {
+                                b'\0' => go!(this: error s.c; emit_ur s.c),
+                                b'&'  => go!(this: consume_char_ref s.c),
+                                b'<'  => go!(this: replace_temp2 s.c; to RawLessThanSign Rcdata),
+                                  _   => go!(this: emit s.c),
+                            },
+                            (Uninit, Full) => go!(this: emit_buf s.r),
+                            _ => unreachable!(),
+                        }
+                    }
                 }
+                rcdata_state(self, s)
             },
 
             //§ rawtext-state
-            states::RawData(Rawtext) => loop {
-                match pop_except_from!(self, small_char_set!('\r' '\0' '<')) {
-                    FromSet('\0') => go!(self: error; emit '\ufffd'),
-                    FromSet('<') => go!(self: to RawLessThanSign Rawtext),
-                    FromSet(c) => go!(self: emit c),
-                    NotFromSet(b) => self.emit_chars(b),
+            states::RawData(Rawtext) => {
+                #[inline(never)]
+                fn rawtext_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '\0' '<')) {
+                            (Full, Uninit) => match s.c.as_ref().as_u8() {
+                                b'\0' => go!(this: error s.c; emit_ur s.c),
+                                b'<'  => go!(this: replace_temp2 s.c; to RawLessThanSign Rawtext),
+                                  _   => go!(this: emit s.c),
+                            },
+                            (Uninit, Full) => go!(this: emit_buf s.r),
+                            _ => unreachable!(),
+                        }
+                    }
                 }
+                rawtext_state(self, s)
             },
 
             //§ script-data-state
-            states::RawData(ScriptData) => loop {
-                match pop_except_from!(self, small_char_set!('\r' '\0' '<')) {
-                    FromSet('\0') => go!(self: error; emit '\ufffd'),
-                    FromSet('<') => go!(self: to RawLessThanSign ScriptData),
-                    FromSet(c) => go!(self: emit c),
-                    NotFromSet(b) => self.emit_chars(b),
+            states::RawData(ScriptData) => {
+                #[inline(never)]
+                fn script_data_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '\0' '<')) {
+                            (Full, Uninit) => match s.c.as_ref().as_u8() {
+                                b'\0' => go!(this: error s.c; emit_ur s.c),
+                                b'<'  => go!(this: replace_temp2 s.c; to RawLessThanSign ScriptData),
+                                  _   => go!(this: emit s.c),
+                            },
+                            (Uninit, Full) => go!(this: emit_buf s.r),
+                            _ => unreachable!(),
+                        }
+                    }
                 }
+                script_data_state(self, s)
             },
 
             //§ script-data-escaped-state
-            states::RawData(ScriptDataEscaped(Escaped)) => loop {
-                match pop_except_from!(self, small_char_set!('\r' '\0' '-' '<')) {
-                    FromSet('\0') => go!(self: error; emit '\ufffd'),
-                    FromSet('-') => go!(self: emit '-'; to ScriptDataEscapedDash Escaped),
-                    FromSet('<') => go!(self: to RawLessThanSign ScriptDataEscaped Escaped),
-                    FromSet(c) => go!(self: emit c),
-                    NotFromSet(b) => self.emit_chars(b),
+            states::RawData(ScriptDataEscaped(Escaped)) => {
+                #[inline(never)]
+                fn script_data_escaped_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '\0' '-' '<')) {
+                            (Full, Uninit) => match s.c.as_ref().as_u8() {
+                                b'\0' => go!(this: error s.c; emit_ur s.c),
+                                b'-'  => go!(this: emit s.c; to ScriptDataEscapedDash Escaped),
+                                b'<'  => go!(this: replace_temp2 s.c; to RawLessThanSign ScriptDataEscaped Escaped),
+                                  _   => go!(this: emit s.c),
+                            },
+                            (Uninit, Full) => go!(this: emit_buf s.r),
+                            _ => unreachable!(),
+                        }
+                    }
                 }
+                script_data_escaped_state(self, s)
             },
 
             //§ script-data-double-escaped-state
-            states::RawData(ScriptDataEscaped(DoubleEscaped)) => loop {
-                match pop_except_from!(self, small_char_set!('\r' '\0' '-' '<')) {
-                    FromSet('\0') => go!(self: error; emit '\ufffd'),
-                    FromSet('-') => go!(self: emit '-'; to ScriptDataEscapedDash DoubleEscaped),
-                    FromSet('<') => go!(self: emit '<'; to RawLessThanSign ScriptDataEscaped DoubleEscaped),
-                    FromSet(c) => go!(self: emit c),
-                    NotFromSet(b) => self.emit_chars(b),
+            states::RawData(ScriptDataEscaped(DoubleEscaped)) => {
+                #[inline(never)]
+                fn script_data_double_escaped_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '\0' '-' '<')) {
+                            (Full, Uninit) => match s.c.as_ref().as_u8() {
+                                b'\0' => go!(this: error s.c; emit_ur s.c),
+                                b'-'  => go!(this: emit s.c; to ScriptDataEscapedDash DoubleEscaped),
+                                b'<'  => go!(this: emit s.c; to RawLessThanSign ScriptDataEscaped DoubleEscaped),
+                                  _   => go!(this: emit s.c),
+                            },
+                            (Uninit, Full) => go!(this: emit_buf s.r),
+                            _ => unreachable!(),
+                        }
+                    }
                 }
+                script_data_double_escaped_state(self, s)
             },
 
             //§ plaintext-state
-            states::Plaintext => loop {
-                match pop_except_from!(self, small_char_set!('\r' '\0')) {
-                    FromSet('\0') => go!(self: error; emit '\ufffd'),
-                    FromSet(c)    => go!(self: emit c),
-                    NotFromSet(b) => self.emit_chars(b),
+            states::Plaintext => {
+                #[inline(never)]
+                fn plaintext_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '\0')) {
+                            (Full, Uninit) => match s.c.as_ref().as_u8() {
+                                b'\0' => go!(this: error s.c; emit_ur s.c),
+                                  _   => go!(this: emit s.c),
+                            },
+                            (Uninit, Full) => go!(this: emit_buf s.r),
+                            _ => unreachable!(),
+                        }
+                    }
                 }
+                plaintext_state(self, s)
             },
 
             //§ tag-open-state
-            states::TagOpen => loop { match get_char!(self) {
-                '!' => go!(self: to MarkupDeclarationOpen),
-                '/' => go!(self: to EndTagOpen),
-                '?' => go!(self: error; clear_comment; push_comment '?'; to BogusComment),
-                c => match lower_ascii_letter(c) {
-                    Some(cl) => go!(self: create_tag StartTag cl; to TagName),
-                    None     => go!(self: error; emit '<'; reconsume Data),
+            states::TagOpen => {
+                #[inline(never)]
+                fn tag_open_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'!' => go!(this: push_temp2 s.c; to MarkupDeclarationOpen),
+                            b'/' => go!(this: push_temp2 s.c; to EndTagOpen),
+                            b'?' => go!(this: error s.c; clear_comment; push_comment s.c; to BogusComment),
+                            chr if is_alphabetic(chr) => go!(this: create_start_tag chr; to TagName),
+                            _ => go!(this: error s.c; emit_temp2; reconsume s.c Data)
+                        }
+                    }
                 }
-            }},
+                tag_open_state(self, s)
+            },
 
             //§ end-tag-open-state
-            states::EndTagOpen => loop { match get_char!(self) {
-                '>'  => go!(self: error; to Data),
-                '\0' => go!(self: error; clear_comment; push_comment '\ufffd'; to BogusComment),
-                c => match lower_ascii_letter(c) {
-                    Some(cl) => go!(self: create_tag EndTag cl; to TagName),
-                    None     => go!(self: error; clear_comment; push_comment c; to BogusComment),
+            states::EndTagOpen => {
+                #[inline(never)]
+                fn end_tag_open_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'>'  => go!(this: error s.c; to Data),
+                            b'\0' => go!(this: error s.c; clear_comment; push_comment_ur s.c; to BogusComment),
+                            chr if is_alphabetic(chr) => go!(this: create_end_tag chr; to TagName),
+                            _ => go!(this: error s.c; clear_comment; push_comment s.c; to BogusComment),
+                        }
+                    }
                 }
-            }},
+                end_tag_open_state(self, s)
+            },
 
             //§ tag-name-state
-            states::TagName => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' '
-                     => go!(self: to BeforeAttributeName),
-                '/'  => go!(self: to SelfClosingStartTag),
-                '>'  => go!(self: emit_tag Data),
-                '\0' => go!(self: error; push_tag '\ufffd'),
-                c    => go!(self: push_tag (lower_ascii(c))),
-            }},
+            states::TagName => {
+                #[inline(never)]
+                fn tag_name_state<S: TokenSink>(this: &mut TI<S>, _s: &mut Shared) -> bool {
+                    loop {
+                        let c = get_char_simple!(this);
+                        match c {
+                            '\t' | '\n' | '\x0C' | ' '
+                                  => go!(this: to BeforeAttributeName),
+                            '/'   => go!(this: to SelfClosingStartTag),
+                            '>'   => go!(this: emit_tag Data),
+                            '\0'  => go!(this: error_simple c; push_tag_ur),
+                              c   => go!(this: push_tag_char c)
+                        }
+                    }
+                }
+                tag_name_state(self, s)
+            },
 
             //§ script-data-escaped-less-than-sign-state
-            states::RawLessThanSign(ScriptDataEscaped(Escaped)) => loop { match get_char!(self) {
-                '/' => go!(self: clear_temp; to RawEndTagOpen ScriptDataEscaped Escaped),
-                c => match lower_ascii_letter(c) {
-                    Some(cl) => go!(self: clear_temp; push_temp cl; emit '<'; emit c;
-                                    to ScriptDataEscapeStart DoubleEscaped),
-                    None => go!(self: emit '<'; reconsume RawData ScriptDataEscaped Escaped),
+            states::RawLessThanSign(ScriptDataEscaped(Escaped)) => {
+                #[inline(never)]
+                fn script_data_escaped_less_than_sign_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'/' => go!(this: clear_temp; push_temp2 s.c; to RawEndTagOpen ScriptDataEscaped Escaped),
+                            chr if is_alphabetic(chr) => go!(this: clear_temp; push_temp_clone s.c; emit_temp2; emit s.c; to ScriptDataEscapeStart DoubleEscaped),
+                            _    => go!(this: emit_temp2; reconsume s.c RawData ScriptDataEscaped Escaped),
+                        }
+                    }
                 }
-            }},
+                script_data_escaped_less_than_sign_state(self, s)
+            },
 
             //§ script-data-double-escaped-less-than-sign-state
-            states::RawLessThanSign(ScriptDataEscaped(DoubleEscaped)) => loop { match get_char!(self) {
-                '/' => go!(self: clear_temp; emit '/'; to ScriptDataDoubleEscapeEnd),
-                _   => go!(self: reconsume RawData ScriptDataEscaped DoubleEscaped),
-            }},
+            states::RawLessThanSign(ScriptDataEscaped(DoubleEscaped)) => {
+                #[inline(never)]
+                fn script_data_double_escaped_less_than_sign_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'/' => go!(this: clear_temp; emit s.c; to ScriptDataDoubleEscapeEnd),
+                              _  => go!(this: reconsume s.c RawData ScriptDataEscaped DoubleEscaped),
+                        }
+                    }
+                }
+                script_data_double_escaped_less_than_sign_state(self, s)
+            },
 
             //§ rcdata-less-than-sign-state rawtext-less-than-sign-state script-data-less-than-sign-state
             // otherwise
-            states::RawLessThanSign(kind) => loop { match get_char!(self) {
-                '/' => go!(self: clear_temp; to RawEndTagOpen kind),
-                '!' if kind == ScriptData => go!(self: emit '<'; emit '!'; to ScriptDataEscapeStart Escaped),
-                _   => go!(self: emit '<'; reconsume RawData kind),
-            }},
+            states::RawLessThanSign(kind) => {
+                #[inline(never)]
+                fn other_less_than_sign_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared, kind: RawKind) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'/' => go!(this: clear_temp; push_temp2 s.c; to RawEndTagOpen kind),
+                            b'!' if kind == ScriptData => go!(this: emit_temp2; emit s.c; to ScriptDataEscapeStart Escaped),
+                              _  => go!(this: emit_temp2; reconsume s.c RawData kind),
+                        }
+                    }
+                }
+                other_less_than_sign_state(self, s, kind)
+            },
 
             //§ rcdata-end-tag-open-state rawtext-end-tag-open-state script-data-end-tag-open-state script-data-escaped-end-tag-open-state
-            states::RawEndTagOpen(kind) => loop {
-                let c = get_char!(self);
-                match lower_ascii_letter(c) {
-                    Some(cl) => go!(self: create_tag EndTag cl; push_temp c; to RawEndTagName kind),
-                    None     => go!(self: emit '<'; emit '/'; reconsume RawData kind),
+            states::RawEndTagOpen(kind) => {
+                #[inline(never)]
+                fn other_end_tag_open_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared, kind: RawKind) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            chr if is_alphabetic(chr) => go!(this: push_temp_clone s.c; create_end_tag chr; to RawEndTagName kind),
+                            _                         => go!(this: emit_temp2; reconsume s.c RawData kind)
+                        }
+                    }
                 }
+                other_end_tag_open_state(self, s, kind)
             },
 
             //§ rcdata-end-tag-name-state rawtext-end-tag-name-state script-data-end-tag-name-state script-data-escaped-end-tag-name-state
-            states::RawEndTagName(kind) => loop {
-                let c = get_char!(self);
-                if self.have_appropriate_end_tag() {
-                    match c {
-                        '\t' | '\n' | '\x0C' | ' '
-                            => go!(self: to BeforeAttributeName),
-                        '/' => go!(self: to SelfClosingStartTag),
-                        '>' => go!(self: emit_tag Data),
-                        _ => (),
+            states::RawEndTagName(kind) => {
+                #[inline(never)]
+                fn other_end_tag_name_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared, kind: RawKind) -> bool {
+                    loop {
+                        let c_u8 = get_char!(this, s);
+
+                        if this.have_appropriate_end_tag() {
+                            match c_u8 {
+                                b'\t' | b'\n' | b'\x0C' | b' '
+                                     => go!(this: to BeforeAttributeName),
+                                b'/' => go!(this: to SelfClosingStartTag),
+                                b'>' => go!(this: emit_tag Data),
+                                _    => {},
+                            }
+                        }
+
+                        if is_alphabetic(c_u8) {
+                            go!(this: push_temp_clone s.c; push_tag c_u8)
+                        } else {
+                            go!(this: discard_tag; emit_temp2; emit_temp; reconsume s.c RawData kind)
+                        }
                     }
                 }
-
-                match lower_ascii_letter(c) {
-                    Some(cl) => go!(self: push_tag cl; push_temp c),
-                    None     => go!(self: discard_tag; emit '<'; emit '/'; emit_temp; reconsume RawData kind),
-                }
+                other_end_tag_name_state(self, s, kind)
             },
 
             //§ script-data-double-escape-start-state
-            states::ScriptDataEscapeStart(DoubleEscaped) => loop {
-                let c = get_char!(self);
-                match c {
-                    '\t' | '\n' | '\x0C' | ' ' | '/' | '>' => {
-                        let esc = if self.temp_buf.as_slice() == "script" { DoubleEscaped } else { Escaped };
-                        go!(self: emit c; to RawData ScriptDataEscaped esc);
-                    }
-                    _ => match lower_ascii_letter(c) {
-                        Some(cl) => go!(self: push_temp cl; emit c),
-                        None     => go!(self: reconsume RawData ScriptDataEscaped Escaped),
+            states::ScriptDataEscapeStart(DoubleEscaped) => {
+                #[inline(never)]
+                fn script_data_double_escape_start_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        let chr = get_char!(this, s);
+                        match chr {
+                            b'\t' | b'\n' | b'\x0C' | b' ' | b'/' | b'>' => {
+                                let esc = if this.temp_buf.byte_equal_slice_lower(b"script") { DoubleEscaped } else { Escaped };
+                                go!(this: emit s.c; to RawData ScriptDataEscaped esc);
+                            }
+                            chr if is_alphabetic(chr) => go!(this: push_temp_clone s.c; emit s.c),
+                            _ => go!(this: reconsume s.c RawData ScriptDataEscaped Escaped),
+                        }
                     }
                 }
+                script_data_double_escape_start_state(self, s)
             },
 
             //§ script-data-escape-start-state
-            states::ScriptDataEscapeStart(Escaped) => loop { match get_char!(self) {
-                '-' => go!(self: emit '-'; to ScriptDataEscapeStartDash),
-                _   => go!(self: reconsume RawData ScriptData),
-            }},
+            states::ScriptDataEscapeStart(Escaped) => {
+                #[inline(never)]
+                fn script_data_escape_start_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'-' => go!(this: emit s.c; to ScriptDataEscapeStartDash),
+                              _  => go!(this: reconsume s.c RawData ScriptData),
+                        }
+                    }
+                }
+                script_data_escape_start_state(self, s)
+            },
 
             //§ script-data-escape-start-dash-state
-            states::ScriptDataEscapeStartDash => loop { match get_char!(self) {
-                '-' => go!(self: emit '-'; to ScriptDataEscapedDashDash Escaped),
-                _   => go!(self: reconsume RawData ScriptData),
-            }},
+            states::ScriptDataEscapeStartDash => {
+                #[inline(never)]
+                fn script_data_escape_start_dash_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'-' => go!(this: emit s.c; to ScriptDataEscapedDashDash Escaped),
+                              _  => go!(this: reconsume s.c RawData ScriptData),
+                        }
+                    }
+                }
+                script_data_escape_start_dash_state(self, s)
+            },
 
             //§ script-data-escaped-dash-state script-data-double-escaped-dash-state
-            states::ScriptDataEscapedDash(kind) => loop { match get_char!(self) {
-                '-'  => go!(self: emit '-'; to ScriptDataEscapedDashDash kind),
-                '<'  => {
-                    if kind == DoubleEscaped { go!(self: emit '<'); }
-                    go!(self: to RawLessThanSign ScriptDataEscaped kind);
+            states::ScriptDataEscapedDash(kind) => {
+                #[inline(never)]
+                fn script_data_escaped_dash_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared, kind: ScriptEscapeKind) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'-'  => go!(this: emit s.c; to ScriptDataEscapedDashDash kind),
+                            b'<' if kind == DoubleEscaped => go!(this: emit s.c; to RawLessThanSign ScriptDataEscaped kind),
+                            b'<'                          => go!(this: replace_temp2 s.c; to RawLessThanSign ScriptDataEscaped kind),
+                            b'\0' => go!(this: error s.c; emit_ur s.c; to RawData ScriptDataEscaped kind),
+                              _   => go!(this: emit s.c; to RawData ScriptDataEscaped kind),
+                        }
+                    }
                 }
-                '\0' => go!(self: error; emit '\ufffd'; to RawData ScriptDataEscaped kind),
-                c    => go!(self: emit c; to RawData ScriptDataEscaped kind),
-            }},
+                script_data_escaped_dash_state(self, s, kind)
+            },
 
             //§ script-data-escaped-dash-dash-state script-data-double-escaped-dash-dash-state
-            states::ScriptDataEscapedDashDash(kind) => loop { match get_char!(self) {
-                '-'  => go!(self: emit '-'),
-                '<'  => {
-                    if kind == DoubleEscaped { go!(self: emit '<'); }
-                    go!(self: to RawLessThanSign ScriptDataEscaped kind);
+            states::ScriptDataEscapedDashDash(kind) => {
+                #[inline(never)]
+                fn script_data_escaped_dash_dash_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared, kind: ScriptEscapeKind) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'-'  => go!(this: emit s.c),
+                            b'<' if kind == DoubleEscaped => go!(this: emit s.c; to RawLessThanSign ScriptDataEscaped kind),
+                            b'<'                          => go!(this: replace_temp2 s.c; to RawLessThanSign ScriptDataEscaped kind),
+                            b'>'  => go!(this: emit s.c; to RawData ScriptData),
+                            b'\0' => go!(this: error s.c; emit_ur s.c; to RawData ScriptDataEscaped kind),
+                              _   => go!(this: emit s.c; to RawData ScriptDataEscaped kind),
+                        }
+                    }
                 }
-                '>'  => go!(self: emit '>'; to RawData ScriptData),
-                '\0' => go!(self: error; emit '\ufffd'; to RawData ScriptDataEscaped kind),
-                c    => go!(self: emit c; to RawData ScriptDataEscaped kind),
-            }},
+                script_data_escaped_dash_dash_state(self, s, kind)
+            },
 
             //§ script-data-double-escape-end-state
-            states::ScriptDataDoubleEscapeEnd => loop {
-                let c = get_char!(self);
-                match c {
-                    '\t' | '\n' | '\x0C' | ' ' | '/' | '>' => {
-                        let esc = if self.temp_buf.as_slice() == "script" { Escaped } else { DoubleEscaped };
-                        go!(self: emit c; to RawData ScriptDataEscaped esc);
-                    }
-                    _ => match lower_ascii_letter(c) {
-                        Some(cl) => go!(self: push_temp cl; emit c),
-                        None     => go!(self: reconsume RawData ScriptDataEscaped DoubleEscaped),
+            states::ScriptDataDoubleEscapeEnd => {
+                #[inline(never)]
+                fn script_data_double_escape_end_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        let chr = get_char!(this, s);
+                        match chr {
+                            b'\t' | b'\n' | b'\x0C' | b' ' | b'/' | b'>' => {
+                                let esc = if this.temp_buf.byte_equal_slice_lower(b"script") { Escaped } else { DoubleEscaped };
+                                go!(this: emit s.c; to RawData ScriptDataEscaped esc);
+                            }
+                            chr if is_alphabetic(chr) => go!(this: push_temp_clone s.c; emit s.c),
+                            _ => go!(this: reconsume s.c RawData ScriptDataEscaped DoubleEscaped),
+                        }
                     }
                 }
+                script_data_double_escape_end_state(self, s)
             },
 
             //§ before-attribute-name-state
-            states::BeforeAttributeName => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' ' => (),
-                '/'  => go!(self: to SelfClosingStartTag),
-                '>'  => go!(self: emit_tag Data),
-                '\0' => go!(self: error; create_attr '\ufffd'; to AttributeName),
-                c    => match lower_ascii_letter(c) {
-                    Some(cl) => go!(self: create_attr cl; to AttributeName),
-                    None => {
-                        go_match!(self: c,
-                            '"' | '\'' | '<' | '=' => error);
-                        go!(self: create_attr c; to AttributeName);
+            states::BeforeAttributeName => {
+                #[inline(never)]
+                fn before_attribute_name_state<S: TokenSink>(this: &mut TI<S>, _s: &mut Shared) -> bool {
+                    loop {
+                        let c = get_char_simple!(this);
+                        match c {
+                            '\t' | '\n' | '\x0C' | ' ' => {},
+                            '/'  => go!(this: to SelfClosingStartTag),
+                            '>'  => go!(this: emit_tag Data),
+                            '\0' => go!(this: error_simple c; create_attr_ur; to AttributeName),
+                            chr => {
+                                go_match!(this: chr,
+                                    '"' | '\'' | '<' | '=' => error_simple chr);
+                                go!(this: create_attr c; to AttributeName)
+                            }
+                        }
                     }
                 }
-            }},
+                before_attribute_name_state(self, s)
+            },
 
             //§ attribute-name-state
-            states::AttributeName => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' '
-                     => go!(self: to AfterAttributeName),
-                '/'  => go!(self: to SelfClosingStartTag),
-                '='  => go!(self: to BeforeAttributeValue),
-                '>'  => go!(self: emit_tag Data),
-                '\0' => go!(self: error; push_name '\ufffd'),
-                c    => match lower_ascii_letter(c) {
-                    Some(cl) => go!(self: push_name cl),
-                    None => {
-                        go_match!(self: c,
-                            '"' | '\'' | '<' => error);
-                        go!(self: push_name c);
+            states::AttributeName => {
+                #[inline(never)]
+                fn attribute_name_state<S: TokenSink>(this: &mut TI<S>, _s: &mut Shared) -> bool {
+                    loop {
+                        let c = get_char_simple!(this);
+                        match c {
+                            '\t' | '\n' | '\x0C' | ' '
+                                 => go!(this: to AfterAttributeName),
+                            '/'  => go!(this: to SelfClosingStartTag),
+                            '='  => go!(this: to BeforeAttributeValue),
+                            '>'  => go!(this: emit_tag Data),
+                            '\0' => go!(this: error_simple c; push_name_ur),
+                            chr => {
+                                go_match!(this: chr,
+                                    '"' | '\'' | '<' => error_simple chr);
+                                go!(this: push_name chr);
+                            }
+                        }
                     }
                 }
-            }},
+                attribute_name_state(self, s)
+            },
 
             //§ after-attribute-name-state
-            states::AfterAttributeName => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' ' => (),
-                '/'  => go!(self: to SelfClosingStartTag),
-                '='  => go!(self: to BeforeAttributeValue),
-                '>'  => go!(self: emit_tag Data),
-                '\0' => go!(self: error; create_attr '\ufffd'; to AttributeName),
-                c    => match lower_ascii_letter(c) {
-                    Some(cl) => go!(self: create_attr cl; to AttributeName),
-                    None => {
-                        go_match!(self: c,
-                            '"' | '\'' | '<' => error);
-                        go!(self: create_attr c; to AttributeName);
+            states::AfterAttributeName => {
+                #[inline(never)]
+                fn after_attribute_name_state<S: TokenSink>(this: &mut TI<S>, _s: &mut Shared) -> bool {
+                    loop {
+                        let c = get_char_simple!(this);
+                        match c {
+                            '\t' | '\n' | '\x0C' | ' ' => {},
+                            '/'  => go!(this: to SelfClosingStartTag),
+                            '='  => go!(this: to BeforeAttributeValue),
+                            '>'  => go!(this: emit_tag Data),
+                            '\0' => go!(this: error_simple c; create_attr_ur; to AttributeName),
+                            chr => {
+                                go_match!(this: chr,
+                                    '"' | '\'' | '<' => error_simple chr);
+                                go!(this: create_attr chr; to AttributeName);
+                            }
+                        }
                     }
                 }
-            }},
+                after_attribute_name_state(self, s)
+            },
 
             //§ before-attribute-value-state
-            states::BeforeAttributeValue => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' ' => (),
-                '"'  => go!(self: to AttributeValue DoubleQuoted),
-                '&'  => go!(self: reconsume AttributeValue Unquoted),
-                '\'' => go!(self: to AttributeValue SingleQuoted),
-                '\0' => go!(self: error; push_value '\ufffd'; to AttributeValue Unquoted),
-                '>'  => go!(self: error; emit_tag Data),
-                c => {
-                    go_match!(self: c,
-                        '<' | '=' | '`' => error);
-                    go!(self: push_value c; to AttributeValue Unquoted);
+            states::BeforeAttributeValue => {
+                #[inline(never)]
+                fn before_attribute_value_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' ' => {},
+                            b'"'  => go!(this: to AttributeValue DoubleQuoted),
+                            b'&'  => go!(this: reconsume s.c AttributeValue Unquoted),
+                            b'\'' => go!(this: to AttributeValue SingleQuoted),
+                            b'\0' => go!(this: error s.c; push_value_ur s.c; to AttributeValue Unquoted),
+                            b'>'  => go!(this: error s.c; emit_tag Data),
+                            chr => {
+                                go_match!(this: chr,
+                                    b'<' | b'=' | b'`' => error s.c);
+                                go!(this: push_value s.c; to AttributeValue Unquoted);
+                            }
+                        }
+                    }
                 }
-            }},
+                before_attribute_value_state(self, s)
+            },
 
             //§ attribute-value-(double-quoted)-state
-            states::AttributeValue(DoubleQuoted) => loop {
-                match pop_except_from!(self, small_char_set!('\r' '"' '&' '\0')) {
-                    FromSet('"')  => go!(self: to AfterAttributeValueQuoted),
-                    FromSet('&')  => go!(self: consume_char_ref '"'),
-                    FromSet('\0') => go!(self: error; push_value '\ufffd'),
-                    FromSet(c)    => go!(self: push_value c),
-                    NotFromSet(b) => go!(self: append_value b),
+            states::AttributeValue(DoubleQuoted) => {
+                #[inline(never)]
+                fn attribute_value_double_quoted_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '"' '&' '\0')) {
+                            (Full, Uninit) => {
+                                match s.c.as_ref().as_u8() {
+                                    b'"'  => go!(this: to AfterAttributeValueQuoted),
+                                    b'&'  => go!(this: consume_char_ref s.c b'"'),
+                                    b'\0' => go!(this: error s.c; push_value_ur s.c),
+                                    _     => go!(this: push_value s.c),
+                                }
+                            },
+                            (Uninit, Full) => go!(this: append_value s.r),
+                            _ => unreachable!(),
+                        }
+                    }
                 }
+                attribute_value_double_quoted_state(self, s)
             },
 
             //§ attribute-value-(single-quoted)-state
-            states::AttributeValue(SingleQuoted) => loop {
-                match pop_except_from!(self, small_char_set!('\r' '\'' '&' '\0')) {
-                    FromSet('\'') => go!(self: to AfterAttributeValueQuoted),
-                    FromSet('&')  => go!(self: consume_char_ref '\''),
-                    FromSet('\0') => go!(self: error; push_value '\ufffd'),
-                    FromSet(c)    => go!(self: push_value c),
-                    NotFromSet(b) => go!(self: append_value b),
+            states::AttributeValue(SingleQuoted) => {
+                #[inline(never)]
+                fn attribute_value_single_quoted_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '\'' '&' '\0')) {
+                            (Full, Uninit) => {
+                                match s.c.as_ref().as_u8() {
+                                    b'\'' => go!(this: to AfterAttributeValueQuoted),
+                                    b'&'  => go!(this: consume_char_ref s.c b'\''),
+                                    b'\0' => go!(this: error s.c; push_value_ur s.c),
+                                    _     => go!(this: push_value s.c),
+                                }
+                            },
+                            (Uninit, Full) => go!(this: append_value s.r),
+                            _ => unreachable!(),
+                        }
+                    }
                 }
+                attribute_value_single_quoted_state(self, s)
             },
 
             //§ attribute-value-(unquoted)-state
-            states::AttributeValue(Unquoted) => loop {
-                match pop_except_from!(self, small_char_set!('\r' '\t' '\n' '\x0C' ' ' '&' '>' '\0')) {
-                    FromSet('\t') | FromSet('\n') | FromSet('\x0C') | FromSet(' ')
-                     => go!(self: to BeforeAttributeName),
-                    FromSet('&')  => go!(self: consume_char_ref '>'),
-                    FromSet('>')  => go!(self: emit_tag Data),
-                    FromSet('\0') => go!(self: error; push_value '\ufffd'),
-                    FromSet(c) => {
-                        go_match!(self: c,
-                            '"' | '\'' | '<' | '=' | '`' => error);
-                        go!(self: push_value c);
+            states::AttributeValue(Unquoted) => {
+                #[inline(never)]
+                fn attribute_value_unquoted_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match pop_except_from!(this, s, small_char_set!('\r' '\t' '\n' '\x0C' ' ' '&' '>' '\0')) {
+                            (Full, Uninit) => {
+                                match s.c.as_ref().as_u8() {
+                                    b'\t' | b'\n' | b'\x0C' | b' ' => go!(this: to BeforeAttributeName),
+                                    b'&'  => go!(this: consume_char_ref s.c b'>'),
+                                    b'>'  => go!(this: emit_tag Data),
+                                    b'\0' => go!(this: error s.c; push_value_ur s.c),
+                                    chr => {
+                                        go_match!(this: chr,
+                                            b'"' | b'\'' | b'<' | b'=' | b'`' => error s.c);
+                                        go!(this: push_value s.c);
+                                    }
+                                }
+                            },
+                            (Uninit, Full) => go!(this: append_value s.r),
+                            _ => unreachable!(),
+                        }
                     }
-                    NotFromSet(b) => go!(self: append_value b),
                 }
+                attribute_value_unquoted_state(self, s)
             },
 
             //§ after-attribute-value-(quoted)-state
-            states::AfterAttributeValueQuoted => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' '
-                     => go!(self: to BeforeAttributeName),
-                '/'  => go!(self: to SelfClosingStartTag),
-                '>'  => go!(self: emit_tag Data),
-                _    => go!(self: error; reconsume BeforeAttributeName),
-            }},
-
-            //§ self-closing-start-tag-state
-            states::SelfClosingStartTag => loop { match get_char!(self) {
-                '>' => {
-                    self.current_tag_self_closing = true;
-                    go!(self: emit_tag Data);
-                }
-                _ => go!(self: error; reconsume BeforeAttributeName),
-            }},
-
-            //§ comment-start-state
-            states::CommentStart => loop { match get_char!(self) {
-                '-'  => go!(self: to CommentStartDash),
-                '\0' => go!(self: error; push_comment '\ufffd'; to Comment),
-                '>'  => go!(self: error; emit_comment; to Data),
-                c    => go!(self: push_comment c; to Comment),
-            }},
-
-            //§ comment-start-dash-state
-            states::CommentStartDash => loop { match get_char!(self) {
-                '-'  => go!(self: to CommentEnd),
-                '\0' => go!(self: error; append_comment "-\ufffd"; to Comment),
-                '>'  => go!(self: error; emit_comment; to Data),
-                c    => go!(self: push_comment '-'; push_comment c; to Comment),
-            }},
-
-            //§ comment-state
-            states::Comment => loop { match get_char!(self) {
-                '-'  => go!(self: to CommentEndDash),
-                '\0' => go!(self: error; push_comment '\ufffd'),
-                c    => go!(self: push_comment c),
-            }},
-
-            //§ comment-end-dash-state
-            states::CommentEndDash => loop { match get_char!(self) {
-                '-'  => go!(self: to CommentEnd),
-                '\0' => go!(self: error; append_comment "-\ufffd"; to Comment),
-                c    => go!(self: push_comment '-'; push_comment c; to Comment),
-            }},
-
-            //§ comment-end-state
-            states::CommentEnd => loop { match get_char!(self) {
-                '>'  => go!(self: emit_comment; to Data),
-                '\0' => go!(self: error; append_comment "--\ufffd"; to Comment),
-                '!'  => go!(self: error; to CommentEndBang),
-                '-'  => go!(self: error; push_comment '-'),
-                c    => go!(self: error; append_comment "--"; push_comment c; to Comment),
-            }},
-
-            //§ comment-end-bang-state
-            states::CommentEndBang => loop { match get_char!(self) {
-                '-'  => go!(self: append_comment "--!"; to CommentEndDash),
-                '>'  => go!(self: emit_comment; to Data),
-                '\0' => go!(self: error; append_comment "--!\ufffd"; to Comment),
-                c    => go!(self: append_comment "--!"; push_comment c; to Comment),
-            }},
-
-            //§ doctype-state
-            states::Doctype => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' '
-                    => go!(self: to BeforeDoctypeName),
-                _   => go!(self: error; reconsume BeforeDoctypeName),
-            }},
-
-            //§ before-doctype-name-state
-            states::BeforeDoctypeName => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' ' => (),
-                '\0' => go!(self: error; create_doctype; push_doctype_name '\ufffd'; to DoctypeName),
-                '>'  => go!(self: error; create_doctype; force_quirks; emit_doctype; to Data),
-                c    => go!(self: create_doctype; push_doctype_name (lower_ascii(c)); to DoctypeName),
-            }},
-
-            //§ doctype-name-state
-            states::DoctypeName => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' '
-                     => go!(self: to AfterDoctypeName),
-                '>'  => go!(self: emit_doctype; to Data),
-                '\0' => go!(self: error; push_doctype_name '\ufffd'),
-                c    => go!(self: push_doctype_name (lower_ascii(c))),
-            }},
-
-            //§ after-doctype-name-state
-            states::AfterDoctypeName => loop {
-                if eat!(self, "public") {
-                    go!(self: to AfterDoctypeKeyword Public);
-                } else if eat!(self, "system") {
-                    go!(self: to AfterDoctypeKeyword System);
-                } else {
-                    match get_char!(self) {
-                        '\t' | '\n' | '\x0C' | ' ' => (),
-                        '>' => go!(self: emit_doctype; to Data),
-                        _   => go!(self: error; force_quirks; to BogusDoctype),
+            states::AfterAttributeValueQuoted => {
+                #[inline(never)]
+                fn after_attribute_value_quoted_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' '
+                                  => go!(this: to BeforeAttributeName),
+                            b'/'  => go!(this: to SelfClosingStartTag),
+                            b'>'  => go!(this: emit_tag Data),
+                            _     => go!(this: error s.c; reconsume s.c BeforeAttributeName),
+                        }
                     }
                 }
+                after_attribute_value_quoted_state(self, s)
+            },
+
+            //§ self-closing-start-tag-state
+            states::SelfClosingStartTag => {
+                #[inline(never)]
+                fn self_closing_start_tag_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'>' => {
+                                this.current_tag_self_closing = true;
+                                go!(this: emit_tag Data);
+                            }
+                            _ => go!(this: error s.c; reconsume s.c BeforeAttributeName),
+                        }
+                    }
+                }
+                self_closing_start_tag_state(self, s)
+            },
+
+            //§ comment-start-state
+            states::CommentStart => {
+                #[inline(never)]
+                fn comment_start_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'-'  => go!(this: clear_comment_end_dashes; push_comment_end_dash s.c; to CommentStartDash),
+                            b'\0' => go!(this: error s.c; push_comment_ur s.c; to Comment),
+                            b'>'  => go!(this: error s.c; emit_comment; to Data),
+                            _     => go!(this: push_comment s.c; to Comment),
+                        }
+                    }
+                }
+                comment_start_state(self, s)
+            },
+
+            //§ comment-start-dash-state
+            states::CommentStartDash => {
+                #[inline(never)]
+                fn comment_start_dash_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'-'  => go!(this: push_comment_end_dash s.c; to CommentEnd),
+                            b'\0' => go!(this: error s.c; flush_comment_end_dashes; push_comment_ur s.c; to Comment),
+                            b'>'  => go!(this: error s.c; emit_comment; to Data),
+                            _     => go!(this: flush_comment_end_dashes; push_comment s.c; to Comment),
+                        }
+                    }
+                }
+                comment_start_dash_state(self, s)
+            },
+
+            //§ comment-state
+            states::Comment => {
+                #[inline(never)]
+                fn comment_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'-'  => go!(this: clear_comment_end_dashes; push_comment_end_dash s.c; to CommentEndDash),
+                            b'\0' => go!(this: error s.c; push_comment_ur s.c),
+                            _     => go!(this: append_temp2_to_comment; push_comment s.c),
+                        }
+                    }
+                }
+                comment_state(self, s)
+            },
+
+            //§ comment-end-dash-state
+            states::CommentEndDash => {
+                #[inline(never)]
+                fn comment_end_dash_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'-'  => go!(this: push_comment_end_dash s.c; to CommentEnd),
+                            b'\0' => go!(this: error s.c; flush_comment_end_dashes; push_comment_ur s.c; to Comment),
+                            _     => go!(this: flush_comment_end_dashes; push_comment s.c; to Comment),
+                        }
+                    }
+                }
+                comment_end_dash_state(self, s)
+            },
+
+            //§ comment-end-state
+            states::CommentEnd => {
+                #[inline(never)]
+                fn comment_end_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'>'  => go!(this: emit_comment; to Data),
+                            b'\0' => go!(this: error s.c; flush_comment_end_dashes; push_comment_ur s.c; to Comment),
+                            b'!'  => go!(this: error s.c; clear_temp2; push_temp2 s.c; to CommentEndBang),
+                            b'-'  => go!(this: error s.c; push_comment_end_dash s.c),
+                            _     => go!(this: error s.c; flush_comment_end_dashes; push_comment s.c; to Comment),
+                        }
+                    }
+                }
+                comment_end_state(self, s)
+            },
+
+            //§ comment-end-bang-state
+            states::CommentEndBang => {
+                #[inline(never)]
+                fn comment_end_bang_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'-'  => go!(this: flush_comment_end_dashes; append_temp2_to_comment; to CommentEndDash),
+                            b'>'  => go!(this: emit_comment; to Data),
+                            b'\0' => go!(this: error s.c; flush_comment_end_dashes; append_temp2_to_comment; push_comment_ur s.c; to Comment),
+                            _     => go!(this: flush_comment_end_dashes; append_temp2_to_comment; push_comment s.c; to Comment),
+                        }
+                    }
+                }
+                comment_end_bang_state(self, s)
+            },
+
+            //§ doctype-state
+            states::Doctype => {
+                #[inline(never)]
+                fn doctype_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' '
+                                => go!(this: to BeforeDoctypeName),
+                            _   => go!(this: error s.c; reconsume s.c BeforeDoctypeName),
+                        }
+                    }
+                }
+                doctype_state(self, s)
+            },
+
+            //§ before-doctype-name-state
+            states::BeforeDoctypeName => {
+                #[inline(never)]
+                fn before_doctype_name_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' ' => {},
+                            b'\0' => go!(this: error s.c; create_doctype; push_doctype_name_ur s.c; to DoctypeName),
+                            b'>'  => go!(this: error s.c; create_doctype; force_quirks; emit_doctype; to Data),
+                            _     => go!(this: create_doctype; push_doctype_name s.c; to DoctypeName),
+                        }
+                    }
+                }
+                before_doctype_name_state(self, s)
+            },
+
+            //§ doctype-name-state
+            states::DoctypeName => {
+                #[inline(never)]
+                fn doctype_name_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' '
+                                  => go!(this: to AfterDoctypeName),
+                            b'>'  => go!(this: emit_doctype; to Data),
+                            b'\0' => go!(this: error s.c; push_doctype_name_ur s.c),
+                            _     => go!(this: push_doctype_name s.c),
+                        }
+                    }
+                }
+                doctype_name_state(self, s)
+            },
+
+            //§ after-doctype-name-state
+            states::AfterDoctypeName => {
+                #[inline(never)]
+                fn after_doctype_name_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        if !eat!(this, b"public").is_empty() {
+                            go!(this: to AfterDoctypeKeyword Public);
+                        } else if !eat!(this, b"system").is_empty() {
+                            go!(this: to AfterDoctypeKeyword System);
+                        } else {
+                            match get_char!(this, s) {
+                                b'\t' | b'\n' | b'\x0C' | b' ' => {},
+                                b'>' => go!(this: emit_doctype; to Data),
+                                _    => go!(this: error s.c; force_quirks; to BogusDoctype),
+                            }
+                        }
+                    }
+                }
+                after_doctype_name_state(self, s)
             },
 
             //§ after-doctype-public-keyword-state after-doctype-system-keyword-state
-            states::AfterDoctypeKeyword(kind) => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' '
-                     => go!(self: to BeforeDoctypeIdentifier kind),
-                '"'  => go!(self: error; clear_doctype_id kind; to DoctypeIdentifierDoubleQuoted kind),
-                '\'' => go!(self: error; clear_doctype_id kind; to DoctypeIdentifierSingleQuoted kind),
-                '>'  => go!(self: error; force_quirks; emit_doctype; to Data),
-                _    => go!(self: error; force_quirks; to BogusDoctype),
-            }},
+            states::AfterDoctypeKeyword(kind) => {
+                #[inline(never)]
+                fn after_doctype_keyword_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared, kind: DoctypeIdKind) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' '
+                                 => go!(this: to BeforeDoctypeIdentifier kind),
+                            b'"'  => go!(this: error s.c; clear_doctype_id kind; to DoctypeIdentifierDoubleQuoted kind),
+                            b'\'' => go!(this: error s.c; clear_doctype_id kind; to DoctypeIdentifierSingleQuoted kind),
+                            b'>'  => go!(this: error s.c; force_quirks; emit_doctype; to Data),
+                            _     => go!(this: error s.c; force_quirks; to BogusDoctype),
+                        }
+                    }
+                }
+                after_doctype_keyword_state(self, s, kind)
+            },
 
             //§ before-doctype-public-identifier-state before-doctype-system-identifier-state
-            states::BeforeDoctypeIdentifier(kind) => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' ' => (),
-                '"'  => go!(self: clear_doctype_id kind; to DoctypeIdentifierDoubleQuoted kind),
-                '\'' => go!(self: clear_doctype_id kind; to DoctypeIdentifierSingleQuoted kind),
-                '>'  => go!(self: error; force_quirks; emit_doctype; to Data),
-                _    => go!(self: error; force_quirks; to BogusDoctype),
-            }},
+            states::BeforeDoctypeIdentifier(kind) => {
+                #[inline(never)]
+                fn before_doctype_identifier_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared, kind: DoctypeIdKind) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' ' => {},
+                            b'"'  => go!(this: clear_doctype_id kind; to DoctypeIdentifierDoubleQuoted kind),
+                            b'\'' => go!(this: clear_doctype_id kind; to DoctypeIdentifierSingleQuoted kind),
+                            b'>'  => go!(this: error s.c; force_quirks; emit_doctype; to Data),
+                            _     => go!(this: error s.c; force_quirks; to BogusDoctype),
+                        }
+                    }
+                }
+                before_doctype_identifier_state(self, s, kind)
+            },
 
             //§ doctype-public-identifier-(double-quoted)-state doctype-system-identifier-(double-quoted)-state
-            states::DoctypeIdentifierDoubleQuoted(kind) => loop { match get_char!(self) {
-                '"'  => go!(self: to AfterDoctypeIdentifier kind),
-                '\0' => go!(self: error; push_doctype_id kind '\ufffd'),
-                '>'  => go!(self: error; force_quirks; emit_doctype; to Data),
-                c    => go!(self: push_doctype_id kind c),
-            }},
+            states::DoctypeIdentifierDoubleQuoted(kind) => {
+                #[inline(never)]
+                fn doctype_identifier_double_quoted_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared, kind: DoctypeIdKind) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'"'  => go!(this: to AfterDoctypeIdentifier kind),
+                            b'\0' => go!(this: error s.c; push_doctype_id_ur kind s.c),
+                            b'>'  => go!(this: error s.c; force_quirks; emit_doctype; to Data),
+                            _     => go!(this: push_doctype_id kind s.c),
+                        }
+                    }
+                }
+                doctype_identifier_double_quoted_state(self, s, kind)
+            },
 
             //§ doctype-public-identifier-(single-quoted)-state doctype-system-identifier-(single-quoted)-state
-            states::DoctypeIdentifierSingleQuoted(kind) => loop { match get_char!(self) {
-                '\'' => go!(self: to AfterDoctypeIdentifier kind),
-                '\0' => go!(self: error; push_doctype_id kind '\ufffd'),
-                '>'  => go!(self: error; force_quirks; emit_doctype; to Data),
-                c    => go!(self: push_doctype_id kind c),
-            }},
+            states::DoctypeIdentifierSingleQuoted(kind) => {
+                #[inline(never)]
+                fn doctype_identifier_single_quoted_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared, kind: DoctypeIdKind) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\'' => go!(this: to AfterDoctypeIdentifier kind),
+                            b'\0' => go!(this: error s.c; push_doctype_id_ur kind s.c),
+                            b'>'  => go!(this: error s.c; force_quirks; emit_doctype; to Data),
+                            _     => go!(this: push_doctype_id kind s.c),
+                        }
+                    }
+                }
+                doctype_identifier_single_quoted_state(self, s, kind)
+            },
 
             //§ after-doctype-public-identifier-state
-            states::AfterDoctypeIdentifier(Public) => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' '
-                     => go!(self: to BetweenDoctypePublicAndSystemIdentifiers),
-                '>'  => go!(self: emit_doctype; to Data),
-                '"'  => go!(self: error; clear_doctype_id System; to DoctypeIdentifierDoubleQuoted System),
-                '\'' => go!(self: error; clear_doctype_id System; to DoctypeIdentifierSingleQuoted System),
-                _    => go!(self: error; force_quirks; to BogusDoctype),
-            }},
+            states::AfterDoctypeIdentifier(Public) => {
+                #[inline(never)]
+                fn after_doctype_public_identifier_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' '
+                                 => go!(this: to BetweenDoctypePublicAndSystemIdentifiers),
+                            b'>'  => go!(this: emit_doctype; to Data),
+                            b'"'  => go!(this: error s.c; clear_doctype_id System; to DoctypeIdentifierDoubleQuoted System),
+                            b'\'' => go!(this: error s.c; clear_doctype_id System; to DoctypeIdentifierSingleQuoted System),
+                            _     => go!(this: error s.c; force_quirks; to BogusDoctype),
+                        }
+                    }
+                }
+                after_doctype_public_identifier_state(self, s)
+            },
 
             //§ after-doctype-system-identifier-state
-            states::AfterDoctypeIdentifier(System) => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' ' => (),
-                '>' => go!(self: emit_doctype; to Data),
-                _   => go!(self: error; to BogusDoctype),
-            }},
+            states::AfterDoctypeIdentifier(System) => {
+                #[inline(never)]
+                fn after_doctype_system_identifier_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' ' => {},
+                            b'>' => go!(this: emit_doctype; to Data),
+                            _    => go!(this: error s.c; to BogusDoctype),
+                        }
+                    }
+                }
+                after_doctype_system_identifier_state(self, s)
+            },
 
             //§ between-doctype-public-and-system-identifiers-state
-            states::BetweenDoctypePublicAndSystemIdentifiers => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' ' => (),
-                '>'  => go!(self: emit_doctype; to Data),
-                '"'  => go!(self: clear_doctype_id System; to DoctypeIdentifierDoubleQuoted System),
-                '\'' => go!(self: clear_doctype_id System; to DoctypeIdentifierSingleQuoted System),
-                _    => go!(self: error; force_quirks; to BogusDoctype),
-            }},
+            states::BetweenDoctypePublicAndSystemIdentifiers => {
+                #[inline(never)]
+                fn between_doctype_public_and_system_identifiers_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'\t' | b'\n' | b'\x0C' | b' ' => {},
+                            b'>'  => go!(this: emit_doctype; to Data),
+                            b'"'  => go!(this: clear_doctype_id System; to DoctypeIdentifierDoubleQuoted System),
+                            b'\'' => go!(this: clear_doctype_id System; to DoctypeIdentifierSingleQuoted System),
+                            _     => go!(this: error s.c; force_quirks; to BogusDoctype),
+                        }
+                    }
+                }
+                between_doctype_public_and_system_identifiers_state(self, s)
+            },
 
             //§ bogus-doctype-state
-            states::BogusDoctype => loop { match get_char!(self) {
-                '>'  => go!(self: emit_doctype; to Data),
-                _    => (),
-            }},
+            states::BogusDoctype => {
+                #[inline(never)]
+                fn bogus_doctype_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'>'  => go!(this: emit_doctype; to Data),
+                            _     => {},
+                        }
+                    }
+                }
+                bogus_doctype_state(self, s)
+            },
 
             //§ bogus-comment-state
-            states::BogusComment => loop { match get_char!(self) {
-                '>'  => go!(self: emit_comment; to Data),
-                '\0' => go!(self: push_comment '\ufffd'),
-                c    => go!(self: push_comment c),
-            }},
+            states::BogusComment => {
+                #[inline(never)]
+                fn bogus_comment_state<S: TokenSink>(this: &mut TI<S>, s: &mut Shared) -> bool {
+                    loop {
+                        match get_char!(this, s) {
+                            b'>'  => go!(this: emit_comment; to Data),
+                            b'\0' => go!(this: push_comment_ur s.c),
+                            _     => go!(this: push_comment s.c),
+                        }
+                    }
+                }
+                bogus_comment_state(self, s)
+            },
 
             //§ markup-declaration-open-state
-            states::MarkupDeclarationOpen => loop {
-                if eat!(self, "--") {
-                    go!(self: clear_comment; to CommentStart);
-                } else if eat!(self, "doctype") {
-                    go!(self: to Doctype);
-                } else {
-                    // FIXME: CDATA, requires "adjusted current node" from tree builder
-                    // FIXME: 'error' gives wrong message
-                    go!(self: error; to BogusComment);
+            states::MarkupDeclarationOpen => {
+                #[inline(never)]
+                fn markup_declaration_open_state<S: TokenSink>(this: &mut TI<S>, _s: &mut Shared) -> bool {
+                    loop {
+                        let span = eat!(this, b"--");
+                        if !span.is_empty() {
+                            go!(this: clear_temp2; clear_comment; to CommentStart);
+                        }
+
+                        let span = eat!(this, b"doctype");
+                        if !span.is_empty() {
+                            go!(this: to Doctype);
+                        }
+
+                        // FIXME: CDATA, requires "adjusted current node" from tree builder
+                        // FIXME: 'error' gives wrong message
+                        let nil = SingleChar::null();
+                        let c = (*this.current_char.as_ref().unwrap_or(&nil)).clone();
+                        go!(this: error_raw c; to BogusComment);
+                    }
                 }
+                markup_declaration_open_state(self, s)
             },
 
             //§ cdata-section-state
-            states::CdataSection
-                => panic!("FIXME: state {} not implemented", self.state),
+            states::CdataSection => {
+                #[inline(never)]
+                fn cdata_section_state<S: TokenSink>(this: &mut TI<S>, _s: &mut Shared) -> bool {
+                    panic!("FIXME: state {} not implemented", this.state)
+                }
+                cdata_section_state(self, s)
+            }
             //§ END
         }
     }
@@ -1189,30 +1908,17 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         progress
     }
 
-    fn process_char_ref(&mut self, char_ref: CharRef) {
-        let CharRef { mut chars, mut num_chars } = char_ref;
-
-        if num_chars == 0 {
-            chars[0] = '&';
-            num_chars = 1;
-        }
-
-        for i in range(0, num_chars) {
-            let c = chars[i as uint];
-            match self.state {
-                states::Data | states::RawData(states::Rcdata)
-                    => go!(self: emit c),
-
-                states::AttributeValue(_)
-                    => go!(self: push_value c),
-
-                _ => panic!("state {} should not be reachable in process_char_ref", self.state),
-            }
+    #[inline(never)]
+    fn process_char_ref(&mut self, chars: Span) {
+        match self.state {
+            states::Data | states::RawData(states::Rcdata) => go!(self: emit_span_raw chars),
+            states::AttributeValue(_) => go!(self: append_value_span_raw chars),
+            _ => panic!("state {} should not be reachable in process_char_ref", self.state),
         }
     }
 
     /// Indicate that we have reached the end of the input.
-    pub fn end(&mut self) {
+    fn end(&mut self, shared: &mut Shared) {
         // Handle EOF in the char ref sub-tokenizer, if there is one.
         // Do this first because it might un-consume stuff.
         match self.char_ref_tokenizer.take() {
@@ -1226,7 +1932,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         // Process all remaining buffered input.
         // If we're waiting for lookahead, we're not gonna get it.
         self.at_eof = true;
-        self.run();
+        self.run(shared);
 
         while self.eof_step() {
             // loop
@@ -1277,22 +1983,26 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 => go!(self: error_eof; to Data),
 
             states::TagOpen
-                => go!(self: error_eof; emit '<'; to Data),
+                => go!(self: error_eof; emit_temp2; to Data),
 
             states::EndTagOpen
-                => go!(self: error_eof; emit '<'; emit '/'; to Data),
+                => go!(self: error_eof; emit_temp2; to Data),
 
             states::RawLessThanSign(ScriptDataEscaped(DoubleEscaped))
                 => go!(self: to RawData ScriptDataEscaped DoubleEscaped),
 
             states::RawLessThanSign(kind)
-                => go!(self: emit '<'; to RawData kind),
+                => go!(self: emit_temp2; to RawData kind),
 
             states::RawEndTagOpen(kind)
-                => go!(self: emit '<'; emit '/'; to RawData kind),
+                => {
+                    go!(self: emit_temp2; to RawData kind)
+            },
 
             states::RawEndTagName(kind)
-                => go!(self: emit '<'; emit '/'; emit_temp; to RawData kind),
+                => {
+                    go!(self: emit_temp2; emit_temp; to RawData kind)
+            },
 
             states::ScriptDataEscapeStart(kind)
                 => go!(self: to RawData ScriptDataEscaped kind),
@@ -1324,61 +2034,13 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 => go!(self: emit_comment; to Data),
 
             states::MarkupDeclarationOpen
-                => go!(self: error; to BogusComment),
+                => {
+                    let c = (*self.current_char.as_ref().unwrap()).clone();
+                    go!(self: error_raw c; to BogusComment)
+                },
 
             states::CdataSection
                 => panic!("FIXME: state {} not implemented in EOF", self.state),
         }
-    }
-}
-
-#[cfg(test)]
-#[allow(non_snake_case)]
-mod test {
-    use core::prelude::*;
-    use collections::vec::Vec;
-    use collections::string::String;
-    use collections::slice::CloneSliceAllocPrelude;
-    use super::{option_push, append_strings}; // private items
-
-    #[test]
-    fn push_to_None_gives_singleton() {
-        let mut s: Option<String> = None;
-        option_push(&mut s, 'x');
-        assert_eq!(s, Some(String::from_str("x")));
-    }
-
-    #[test]
-    fn push_to_empty_appends() {
-        let mut s: Option<String> = Some(String::new());
-        option_push(&mut s, 'x');
-        assert_eq!(s, Some(String::from_str("x")));
-    }
-
-    #[test]
-    fn push_to_nonempty_appends() {
-        let mut s: Option<String> = Some(String::from_str("y"));
-        option_push(&mut s, 'x');
-        assert_eq!(s, Some(String::from_str("yx")));
-    }
-
-    #[test]
-    fn append_appends() {
-        let mut s = String::from_str("foo");
-        append_strings(&mut s, String::from_str("bar"));
-        assert_eq!(s, String::from_str("foobar"));
-    }
-
-    #[test]
-    fn append_to_empty_does_not_copy() {
-        let mut lhs: String = String::from_str("");
-        let rhs: Vec<u8> = b"foo".to_vec();
-        let ptr_old = rhs[0] as *const u8;
-
-        append_strings(&mut lhs, String::from_utf8(rhs).unwrap());
-        assert_eq!(lhs, String::from_str("foo"));
-
-        let ptr_new = lhs.into_bytes()[0] as *const u8;
-        assert_eq!(ptr_old, ptr_new);
     }
 }

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -623,10 +623,12 @@ impl<Sink: TokenSink> TokenizerInner<Sink> {
         self.replace_another_temp_buf_span(BufSpan::new());
     }
 
+    #[inline]
     fn replace_another_temp_buf(&mut self, c: SingleChar) {
         self.replace_another_temp_buf_span(c.into_span());
     }
 
+    #[inline]
     fn replace_another_temp_buf_span(&mut self, s: Span) {
         self.another_temp_buf = s;
     }

--- a/src/tree_builder/data.rs
+++ b/src/tree_builder/data.rs
@@ -11,138 +11,166 @@ use core::prelude::*;
 
 use tokenizer::Doctype;
 use tree_builder::interface::{QuirksMode, Quirks, LimitedQuirks, NoQuirks};
-use util::str::AsciiExt;
+use util::span::Span;
+use util::str::AsciiCast;
 
-use collections::string::String;
+use iobuf::Iobuf;
+use string_cache::atom::Atom;
 
 // These should all be lowercase, for ASCII-case-insensitive matching.
-static QUIRKY_PUBLIC_PREFIXES: &'static [&'static str] = &[
-    "-//advasoft ltd//dtd html 3.0 aswedit + extensions//",
-    "-//as//dtd html 3.0 aswedit + extensions//",
-    "-//ietf//dtd html 2.0 level 1//",
-    "-//ietf//dtd html 2.0 level 2//",
-    "-//ietf//dtd html 2.0 strict level 1//",
-    "-//ietf//dtd html 2.0 strict level 2//",
-    "-//ietf//dtd html 2.0 strict//",
-    "-//ietf//dtd html 2.0//",
-    "-//ietf//dtd html 2.1e//",
-    "-//ietf//dtd html 3.0//",
-    "-//ietf//dtd html 3.2 final//",
-    "-//ietf//dtd html 3.2//",
-    "-//ietf//dtd html 3//",
-    "-//ietf//dtd html level 0//",
-    "-//ietf//dtd html level 1//",
-    "-//ietf//dtd html level 2//",
-    "-//ietf//dtd html level 3//",
-    "-//ietf//dtd html strict level 0//",
-    "-//ietf//dtd html strict level 1//",
-    "-//ietf//dtd html strict level 2//",
-    "-//ietf//dtd html strict level 3//",
-    "-//ietf//dtd html strict//",
-    "-//ietf//dtd html//",
-    "-//metrius//dtd metrius presentational//",
-    "-//microsoft//dtd internet explorer 2.0 html strict//",
-    "-//microsoft//dtd internet explorer 2.0 html//",
-    "-//microsoft//dtd internet explorer 2.0 tables//",
-    "-//microsoft//dtd internet explorer 3.0 html strict//",
-    "-//microsoft//dtd internet explorer 3.0 html//",
-    "-//microsoft//dtd internet explorer 3.0 tables//",
-    "-//netscape comm. corp.//dtd html//",
-    "-//netscape comm. corp.//dtd strict html//",
-    "-//o'reilly and associates//dtd html 2.0//",
-    "-//o'reilly and associates//dtd html extended 1.0//",
-    "-//o'reilly and associates//dtd html extended relaxed 1.0//",
-    "-//softquad software//dtd hotmetal pro 6.0::19990601::extensions to html 4.0//",
-    "-//softquad//dtd hotmetal pro 4.0::19971010::extensions to html 4.0//",
-    "-//spyglass//dtd html 2.0 extended//",
-    "-//sq//dtd html 2.0 hotmetal + extensions//",
-    "-//sun microsystems corp.//dtd hotjava html//",
-    "-//sun microsystems corp.//dtd hotjava strict html//",
-    "-//w3c//dtd html 3 1995-03-24//",
-    "-//w3c//dtd html 3.2 draft//",
-    "-//w3c//dtd html 3.2 final//",
-    "-//w3c//dtd html 3.2//",
-    "-//w3c//dtd html 3.2s draft//",
-    "-//w3c//dtd html 4.0 frameset//",
-    "-//w3c//dtd html 4.0 transitional//",
-    "-//w3c//dtd html experimental 19960712//",
-    "-//w3c//dtd html experimental 970421//",
-    "-//w3c//dtd w3 html//",
-    "-//w3o//dtd w3 html 3.0//",
-    "-//webtechs//dtd mozilla html 2.0//",
-    "-//webtechs//dtd mozilla html//",
+static QUIRKY_PUBLIC_PREFIXES: &'static [&'static [u8]] = &[
+    b"-//advasoft ltd//dtd html 3.0 aswedit + extensions//",
+    b"-//as//dtd html 3.0 aswedit + extensions//",
+    b"-//ietf//dtd html 2.0 level 1//",
+    b"-//ietf//dtd html 2.0 level 2//",
+    b"-//ietf//dtd html 2.0 strict level 1//",
+    b"-//ietf//dtd html 2.0 strict level 2//",
+    b"-//ietf//dtd html 2.0 strict//",
+    b"-//ietf//dtd html 2.0//",
+    b"-//ietf//dtd html 2.1e//",
+    b"-//ietf//dtd html 3.0//",
+    b"-//ietf//dtd html 3.2 final//",
+    b"-//ietf//dtd html 3.2//",
+    b"-//ietf//dtd html 3//",
+    b"-//ietf//dtd html level 0//",
+    b"-//ietf//dtd html level 1//",
+    b"-//ietf//dtd html level 2//",
+    b"-//ietf//dtd html level 3//",
+    b"-//ietf//dtd html strict level 0//",
+    b"-//ietf//dtd html strict level 1//",
+    b"-//ietf//dtd html strict level 2//",
+    b"-//ietf//dtd html strict level 3//",
+    b"-//ietf//dtd html strict//",
+    b"-//ietf//dtd html//",
+    b"-//metrius//dtd metrius presentational//",
+    b"-//microsoft//dtd internet explorer 2.0 html strict//",
+    b"-//microsoft//dtd internet explorer 2.0 html//",
+    b"-//microsoft//dtd internet explorer 2.0 tables//",
+    b"-//microsoft//dtd internet explorer 3.0 html strict//",
+    b"-//microsoft//dtd internet explorer 3.0 html//",
+    b"-//microsoft//dtd internet explorer 3.0 tables//",
+    b"-//netscape comm. corp.//dtd html//",
+    b"-//netscape comm. corp.//dtd strict html//",
+    b"-//o'reilly and associates//dtd html 2.0//",
+    b"-//o'reilly and associates//dtd html extended 1.0//",
+    b"-//o'reilly and associates//dtd html extended relaxed 1.0//",
+    b"-//softquad software//dtd hotmetal pro 6.0::19990601::extensions to html 4.0//",
+    b"-//softquad//dtd hotmetal pro 4.0::19971010::extensions to html 4.0//",
+    b"-//spyglass//dtd html 2.0 extended//",
+    b"-//sq//dtd html 2.0 hotmetal + extensions//",
+    b"-//sun microsystems corp.//dtd hotjava html//",
+    b"-//sun microsystems corp.//dtd hotjava strict html//",
+    b"-//w3c//dtd html 3 1995-03-24//",
+    b"-//w3c//dtd html 3.2 draft//",
+    b"-//w3c//dtd html 3.2 final//",
+    b"-//w3c//dtd html 3.2//",
+    b"-//w3c//dtd html 3.2s draft//",
+    b"-//w3c//dtd html 4.0 frameset//",
+    b"-//w3c//dtd html 4.0 transitional//",
+    b"-//w3c//dtd html experimental 19960712//",
+    b"-//w3c//dtd html experimental 970421//",
+    b"-//w3c//dtd w3 html//",
+    b"-//w3o//dtd w3 html 3.0//",
+    b"-//webtechs//dtd mozilla html 2.0//",
+    b"-//webtechs//dtd mozilla html//",
 ];
 
-static QUIRKY_PUBLIC_MATCHES: &'static [&'static str] = &[
-    "-//w3o//dtd w3 html strict 3.0//en//",
-    "-/w3c/dtd html 4.0 transitional/en",
-    "html",
+static QUIRKY_PUBLIC_MATCHES: &'static [&'static [u8]] = &[
+    b"-//w3o//dtd w3 html strict 3.0//en//",
+    b"-/w3c/dtd html 4.0 transitional/en",
+    b"html",
 ];
 
-static QUIRKY_SYSTEM_MATCHES: &'static [&'static str] = &[
-    "http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd",
+static QUIRKY_SYSTEM_MATCHES: &'static [&'static [u8]] = &[
+    b"http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd",
 ];
 
-static LIMITED_QUIRKY_PUBLIC_PREFIXES: &'static [&'static str] = &[
-    "-//w3c//dtd xhtml 1.0 frameset//",
-    "-//w3c//dtd xhtml 1.0 transitional//",
+static LIMITED_QUIRKY_PUBLIC_PREFIXES: &'static [&'static [u8]] = &[
+    b"-//w3c//dtd xhtml 1.0 frameset//",
+    b"-//w3c//dtd xhtml 1.0 transitional//",
 ];
 
-static HTML4_PUBLIC_PREFIXES: &'static [&'static str] = &[
-    "-//w3c//dtd html 4.01 frameset//",
-    "-//w3c//dtd html 4.01 transitional//",
+static HTML4_PUBLIC_PREFIXES: &'static [&'static [u8]] = &[
+    b"-//w3c//dtd html 4.01 frameset//",
+    b"-//w3c//dtd html 4.01 transitional//",
 ];
 
 pub fn doctype_error_and_quirks(doctype: &Doctype, iframe_srcdoc: bool) -> (bool, QuirksMode) {
-    fn opt_as_slice<'t>(x: &'t Option<String>) -> Option<&'t str> {
-        x.as_ref().map(|y| y.as_slice())
+    fn byte_equal(s: &Option<Span>, b: &[u8]) -> bool {
+        s.as_ref().map(|s| s.byte_equal_slice(b)).unwrap_or(b.is_empty())
     }
 
-    fn opt_to_ascii_lower(x: Option<&str>) -> Option<String> {
-        x.map(|y| y.to_ascii_lower())
+    fn atom_byte_equal(a: &Option<Atom>, b: &[u8]) -> bool {
+        a.as_ref().map(|a| a.as_slice().as_bytes() == b.as_slice()).unwrap_or(b.is_empty())
     }
 
-    let name = opt_as_slice(&doctype.name);
-    let public = opt_as_slice(&doctype.public_id);
-    let system = opt_as_slice(&doctype.system_id);
+    fn is_doctype_ok(doctype: &Doctype) -> bool {
+        let name   = &doctype.name;
+        let public = &doctype.public_id;
+        let system = &doctype.system_id;
 
-    let err = match (name, public, system) {
-          (Some("html"), None, None)
-        | (Some("html"), None, Some("about:legacy-compat"))
-        | (Some("html"), Some("-//W3C//DTD HTML 4.0//EN"), None)
-        | (Some("html"), Some("-//W3C//DTD HTML 4.0//EN"), Some("http://www.w3.org/TR/REC-html40/strict.dtd"))
-        | (Some("html"), Some("-//W3C//DTD HTML 4.01//EN"), None)
-        | (Some("html"), Some("-//W3C//DTD HTML 4.01//EN"), Some("http://www.w3.org/TR/html4/strict.dtd"))
-        | (Some("html"), Some("-//W3C//DTD XHTML 1.0 Strict//EN"), Some("http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"))
-        | (Some("html"), Some("-//W3C//DTD XHTML 1.1//EN"), Some("http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"))
-            => false,
+        let has_system_id = system.is_some();
 
-        _ => true,
-    };
+        if !atom_byte_equal(name, b"html") {
+            false
+        } else if !public.is_some() {
+            !has_system_id || byte_equal(system, b"about:legacy-compat")
+        } else if byte_equal(public, b"-//W3C//DTD HTML 4.0//EN") {
+            !has_system_id || byte_equal(system, b"http://www.w3.org/TR/REC-html40/strict.dtd")
+        } else if byte_equal(public, b"-//W3C//DTD HTML 4.01//EN") {
+            !has_system_id || byte_equal(system, b"http://www.w3.org/TR/html4/strict.dtd")
+        } else if byte_equal(public, b"-//W3C//DTD XHTML 1.0 Strict//EN") {
+            byte_equal(system, b"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd")
+        } else if byte_equal(public, b"-//W3C//DTD XHTML 1.1//EN") {
+            byte_equal(system, b"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd")
+        } else {
+            false
+        }
+    }
+
+    let err = !is_doctype_ok(doctype);
+
+    fn contains_span(haystack: &[&[u8]], needle: &Span) -> bool {
+        let needle_len = needle.count_bytes() as uint;
+        haystack.iter().any(|&x|
+            needle_len == x.len()
+            && needle.iter_bytes().zip(x.iter()).all(
+                // Quirks-mode matches are case-insensitive.
+                |(a, b)| match (a.to_ascii_opt(), b.to_ascii_opt()) {
+                    (Some(a), Some(b)) => a.eq_ignore_case(b),
+                    (None, None) => true,
+                    _ => false,
+                    }))
+    }
 
     // FIXME: We could do something asymptotically faster here.
     // But there aren't many strings, and this happens at most once per parse.
-    fn contains_pfx(haystack: &[&str], needle: &str) -> bool {
-        haystack.iter().any(|&x| needle.starts_with(x))
+    fn contains_span_prefix(haystack: &[&[u8]], needle: &Span) -> bool {
+        let needle_len = needle.count_bytes() as uint;
+        haystack.iter().any(|&x|
+            needle_len >= x.len()
+            && needle.iter_bytes().zip(x.iter()).all(
+                // Quirks-mode matches are case-insensitive.
+                |(a, b)| match (a.to_ascii_opt(), b.to_ascii_opt()) {
+                    (Some(a), Some(b)) => a.eq_ignore_case(b),
+                    (None, None) => true,
+                    _ => false,
+                    }))
     }
 
-    // Quirks-mode matches are case-insensitive.
-    let public = opt_to_ascii_lower(public);
-    let system = opt_to_ascii_lower(system);
-
-    let quirk = match (opt_as_slice(&public), opt_as_slice(&system)) {
+    let quirk = match (doctype.public_id.as_ref(), doctype.system_id.as_ref()) {
         _ if doctype.force_quirks => Quirks,
-        _ if name != Some("html") => Quirks,
+        _ if !atom_byte_equal(&doctype.name, b"html") => Quirks,
 
         _ if iframe_srcdoc => NoQuirks,
 
-        (Some(ref p), _) if QUIRKY_PUBLIC_MATCHES.contains(p) => Quirks,
-        (_, Some(ref s)) if QUIRKY_SYSTEM_MATCHES.contains(s) => Quirks,
+        (Some(p), _) if contains_span(QUIRKY_PUBLIC_MATCHES, p) => Quirks,
+        (_, Some(s)) if contains_span(QUIRKY_SYSTEM_MATCHES, s) => Quirks,
 
-        (Some(p), _) if contains_pfx(QUIRKY_PUBLIC_PREFIXES, p) => Quirks,
-        (Some(p), _) if contains_pfx(LIMITED_QUIRKY_PUBLIC_PREFIXES, p) => LimitedQuirks,
+        (Some(p), _) if contains_span_prefix(QUIRKY_PUBLIC_PREFIXES, p) => Quirks,
+        (Some(p), _) if contains_span_prefix(LIMITED_QUIRKY_PUBLIC_PREFIXES, p) => LimitedQuirks,
 
-        (Some(p), s) if contains_pfx(HTML4_PUBLIC_PREFIXES, p) => match s {
+        (Some(p), s) if contains_span_prefix(HTML4_PUBLIC_PREFIXES, p) => match s {
             None => Quirks,
             Some(_) => LimitedQuirks,
         },

--- a/src/tree_builder/interface.rs
+++ b/src/tree_builder/interface.rs
@@ -15,10 +15,11 @@ use core::prelude::*;
 use tokenizer::Attribute;
 
 use collections::vec::Vec;
-use collections::string::String;
 use collections::str::MaybeOwned;
 
-use string_cache::QualName;
+use string_cache::{QualName, Atom};
+
+use util::span::Span;
 
 pub use self::QuirksMode::{Quirks, LimitedQuirks, NoQuirks};
 pub use self::NodeOrText::{AppendNode, AppendText};
@@ -37,7 +38,7 @@ pub enum QuirksMode {
 /// the sink may not want to allocate a `Handle` for each.
 pub enum NodeOrText<Handle> {
     AppendNode(Handle),
-    AppendText(String),
+    AppendText(Span),
 }
 
 /// Types which can process tree modifications from the tree builder.
@@ -68,7 +69,7 @@ pub trait TreeSink<Handle> {
     fn create_element(&mut self, name: QualName, attrs: Vec<Attribute>) -> Handle;
 
     /// Create a comment node.
-    fn create_comment(&mut self, text: String) -> Handle;
+    fn create_comment(&mut self, text: Span) -> Handle;
 
     /// Append a node as the last child of the given node.  If this would
     /// produce adjacent sibling text nodes, it should concatenate the text
@@ -91,7 +92,7 @@ pub trait TreeSink<Handle> {
         new_node: NodeOrText<Handle>) -> Result<(), NodeOrText<Handle>>;
 
     /// Append a `DOCTYPE` element to the `Document` node.
-    fn append_doctype_to_document(&mut self, name: String, public_id: String, system_id: String);
+    fn append_doctype_to_document(&mut self, name: Atom, public_id: Span, system_id: Span);
 
     /// Add each attribute to the given element, if no attribute
     /// with that name already exists.

--- a/src/tree_builder/types.rs
+++ b/src/tree_builder/types.rs
@@ -13,7 +13,7 @@ use core::prelude::*;
 
 use tokenizer::Tag;
 
-use collections::string::String;
+use util::span::Span;
 
 pub use self::InsertionMode::*;
 pub use self::SplitStatus::*;
@@ -60,8 +60,8 @@ pub enum SplitStatus {
 #[deriving(PartialEq, Eq, Clone, Show)]
 pub enum Token {
     TagToken(Tag),
-    CommentToken(String),
-    CharacterTokens(SplitStatus, String),
+    CommentToken(Span),
+    CharacterTokens(SplitStatus, Span),
     NullCharacterToken,
     EOFToken,
 }
@@ -69,7 +69,7 @@ pub enum Token {
 pub enum ProcessResult {
     Done,
     DoneAckSelfClosing,
-    SplitWhitespace(String),
+    SplitWhitespace(Span),
     Reprocess(InsertionMode, Token),
 }
 

--- a/src/util/fast_option.rs
+++ b/src/util/fast_option.rs
@@ -1,0 +1,137 @@
+//! Options of big things (like `Option<SingleChar>`) make rustc generate really
+//! bad code with lots of moves. When rustc gets non-lexical borrows and NRVO,
+//! this module will be unnecessary. In the mean time, this is an unsafe option
+//! representation.
+use core::mem;
+use core::ops::Drop;
+use core::ptr;
+use core::intrinsics::move_val_init;
+
+pub use self::OptValue::{Uninit, Full};
+
+#[deriving(PartialEq, Eq, Show)]
+pub enum OptValue {
+    Uninit,
+    Full,
+}
+
+/// An optional value, but without the option header. Functions using `FastOption`s
+/// return `bool`, which is `true` if the option is valid, and `false` if it's not.
+///
+/// Every `FastOption` must be filled exactly once, with either a `None` or a `Some`,
+/// and `take`n only once.
+#[unsafe_no_drop_flag]
+pub struct FastOption<T> {
+    is_valid: bool,
+    t: T,
+}
+
+#[inline(never)]
+fn bad_usage() -> ! {
+    panic!("Invalid use of `FastOption`.");
+}
+
+impl<T> FastOption<T> {
+    #[inline(always)]
+    pub fn new() -> FastOption<T> {
+        unsafe {
+            FastOption {
+                is_valid: false,
+                t:        mem::uninitialized(),
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_filled(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline(always)]
+    fn set_valid(&mut self, new_val: bool) {
+        self.is_valid = new_val;
+    }
+
+    #[inline(always)]
+    fn check_valid(&self) {
+        if !self.is_valid { bad_usage() }
+    }
+
+    // This does a memcpy an da drop. Do it out of line.
+    #[inline(never)]
+    unsafe fn replace(&mut self, t: T) {
+        debug_assert!(self.is_valid);
+        self.t = t;
+    }
+
+    /// Only use this the first time a `FastOption` is filled. Otherwise, use
+    /// `replace`.
+    #[inline(always)]
+    pub fn fill(&mut self, t: T) -> OptValue {
+        unsafe {
+            if self.is_valid {
+                self.replace(t);
+            } else {
+                move_val_init(&mut self.t, t);
+                self.set_valid(true);
+            }
+        }
+        Full
+    }
+
+    #[inline(always)]
+    pub fn as_ref(&self) -> &T {
+        self.check_valid();
+        &self.t
+    }
+
+    #[inline(always)]
+    pub fn as_mut(&mut self) -> &mut T {
+        self.check_valid();
+        &mut self.t
+    }
+
+    #[inline(always)]
+    pub fn take(&mut self) -> T {
+        unsafe {
+            self.check_valid();
+            self.set_valid(false);
+            ptr::read(&self.t)
+        }
+    }
+}
+
+#[unsafe_destructor]
+impl<T> Drop for FastOption<T> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            if !self.is_valid {
+                move_val_init(&mut self.t, mem::zeroed());
+            }
+        }
+    }
+}
+
+#[test]
+fn proper_usage() {
+    use core::iter;
+
+    let mut opt = FastOption::new();
+    assert_eq!(opt.fill(vec!(42u)), Full);
+    assert_eq!(*opt.as_ref(), vec!(42));
+    assert_eq!(opt.take(), vec!(42));
+
+    let mut opt = FastOption::new();
+
+    // This will hopefully trash jemalloc if we mishandle memory.
+    for i in iter::range(0u, 100000) {
+        assert_eq!(opt.fill(vec!(i)), Full);
+        assert_eq!(opt.as_ref(), &vec!(i));
+        assert_eq!(opt.as_ref(), &vec!(i));
+        if i % 2 == 0 {
+            assert_eq!(opt.take(), vec!(i));
+        } else {
+        }
+    }
+}

--- a/src/util/fast_option.rs
+++ b/src/util/fast_option.rs
@@ -1,3 +1,12 @@
+// Copyright 2014 The html5ever Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 //! Options of big things (like `Option<SingleChar>`) make rustc generate really
 //! bad code with lots of moves. When rustc gets non-lexical borrows and NRVO,
 //! this module will be unnecessary. In the mean time, this is an unsafe option

--- a/src/util/single_char.rs
+++ b/src/util/single_char.rs
@@ -1,0 +1,83 @@
+use core::prelude::*;
+use core::mem;
+
+use iobuf::{BufSpan, Iobuf, ROIobuf};
+
+use util::span::Span;
+
+/// Represents a single character in an Iobuf. It contains the decoded character
+/// for convenient comparison, and the Iobuf it came from.
+#[deriving(Clone, Show)]
+pub struct SingleChar {
+    buf: ROIobuf<'static>,
+}
+
+impl SingleChar {
+    #[inline(always)]
+    pub fn new(buf: ROIobuf<'static>) -> SingleChar {
+        SingleChar { buf: buf }
+    }
+
+    pub fn unicode_replacement() -> SingleChar {
+        SingleChar {
+            buf: ROIobuf::from_str("\ufffd"),
+        }
+    }
+
+    pub fn null() -> SingleChar {
+        SingleChar {
+            buf: ROIobuf::from_str("\0"),
+        }
+    }
+
+    #[inline(always)]
+    pub fn into_buf(self) -> ROIobuf<'static> {
+        self.buf
+    }
+
+    #[inline(always)]
+    pub fn into_span(self) -> Span {
+        BufSpan::from_buf(self.into_buf())
+    }
+
+    #[inline(alwyas)]
+    /// Peeks at the first byte in the char. This might not be valid utf-8!
+    pub fn as_u8(&self) -> u8 {
+        unsafe { self.buf.unsafe_peek_be(0) }
+    }
+
+    /// This is SLOW. Don't use it. Prefer `as_u8`.
+    pub fn decode_as_char(&self) -> char {
+        unsafe {
+            let s: &str = mem::transmute(self.buf.as_window_slice());
+            s.char_at(0)
+        }
+    }
+
+    #[inline(always)]
+    pub fn as_mut(&mut self) -> &mut ROIobuf<'static> {
+        &mut self.buf
+    }
+}
+
+impl PartialEq for SingleChar {
+    #[inline]
+    fn eq(&self, other: &SingleChar) -> bool {
+        unsafe { self.buf.as_window_slice() == other.buf.as_window_slice() }
+    }
+}
+
+impl Eq for SingleChar {}
+
+pub trait MayAppendSingleChar {
+    /// Appends a "single char" to a container. Depending on implementation,
+    /// it might make sense to keep either the `char` or the buffer itself.
+    fn push_sc(&mut self, c: SingleChar);
+}
+
+impl MayAppendSingleChar for Span {
+    #[inline(always)]
+    fn push_sc(&mut self, c: SingleChar) {
+        self.push(c.buf)
+    }
+}

--- a/src/util/smallcharset.rs
+++ b/src/util/smallcharset.rs
@@ -26,7 +26,7 @@ impl SmallCharSet {
     /// Count the number of bytes of characters at the beginning
     /// of `buf` which are not in the set.
     /// See `tokenizer::buffer_queue::pop_except_from`.
-    #[inline(never)]
+    #[inline]
     pub fn nonmember_prefix_len(&self, buf: &[u8]) -> u32 {
         let mut n = 0;
         for &b in buf.iter() {

--- a/src/util/smallcharset.rs
+++ b/src/util/smallcharset.rs
@@ -26,9 +26,10 @@ impl SmallCharSet {
     /// Count the number of bytes of characters at the beginning
     /// of `buf` which are not in the set.
     /// See `tokenizer::buffer_queue::pop_except_from`.
-    pub fn nonmember_prefix_len(&self, buf: &str) -> uint {
+    #[inline(never)]
+    pub fn nonmember_prefix_len(&self, buf: &[u8]) -> u32 {
         let mut n = 0;
-        for b in buf.bytes() {
+        for &b in buf.iter() {
             if b >= 64 || !self.contains(b) {
                 n += 1;
             } else {
@@ -53,14 +54,14 @@ mod test {
     #[test]
     fn nonmember_prefix() {
         for &c in ['&', '\0'].iter() {
-            for x in range(0, 48u) {
-                for y in range(0, 48u) {
-                    let mut s = String::from_char(x, 'x');
+            for x in range(0, 48) {
+                for y in range(0, 48) {
+                    let mut s = String::from_char(x as uint, 'x');
                     s.push(c);
                     s.grow(y, 'x');
                     let set = small_char_set!('&' '\0');
 
-                    assert_eq!(x, set.nonmember_prefix_len(s.as_slice()));
+                    assert_eq!(x, set.nonmember_prefix_len(s.as_slice().as_bytes()));
                 }
             }
         }

--- a/src/util/span.rs
+++ b/src/util/span.rs
@@ -1,0 +1,161 @@
+use core::prelude::*;
+use core::iter;
+use core::mem;
+use core::str;
+
+use collections::ring_buf::RingBuf;
+use collections::string::String;
+
+use iobuf::{BufSpan, SpanIter, Iobuf, ROIobuf};
+
+use util::str::{Ascii, lower_ascii};
+
+pub use self::MaybeOwnedBytes::*;
+
+pub enum MaybeOwnedBytes<'a> {
+    Slice(&'a mut [u8]),
+    Owned(String),
+}
+
+pub type Span = BufSpan<ROIobuf<'static>>;
+
+/// Functions that are safe because all Spans in html5ever are valid utf-8.
+pub trait ValidatedSpanUtils {
+    fn iter_chars<'a>(&'a self) -> CharIterator<'a>;
+    fn iter_strs<'a>(&'a self) -> StrIterator<'a>;
+    fn slice_from(self, from: u32) -> Self;
+
+    /// Writes out an ascii-lowercased version of the span into a buffer.
+    /// If the buffer isn't big enough, a correctly-sized one will be allocated
+    /// instead.
+    fn write_into_lower<'a>(&self, buf: &'a mut [u8]) -> MaybeOwnedBytes<'a>;
+
+    /// Runs a closure with the span as an ascii-lowercased `str` version of
+    /// itself. We work very hard to prevent any heap allocations when this
+    /// happens, but it might still trigger one. Helpfully, a warning will be
+    /// output when that does happen.
+    fn with_lower_str_copy<'a, T>(&self, f: |&str| -> T) -> T;
+
+    fn byte_equal_slice_lower(&self, s: &[u8]) -> bool;
+}
+
+impl ValidatedSpanUtils for Span {
+    fn iter_chars<'a>(&'a self) -> CharIterator<'a> {
+        self.iter().flat_map(|buf| unsafe {
+            let buf: &'a str = mem::transmute(buf.as_window_slice());
+            buf.chars()
+        })
+    }
+
+    fn iter_strs<'a>(&'a self) -> StrIterator<'a> {
+        self.iter().map(|buf| unsafe {
+            let buf: &'a str = mem::transmute(buf.as_window_slice());
+            buf
+        })
+    }
+
+    fn slice_from(self, mut from: u32) -> Span {
+        let mut bufs: RingBuf<ROIobuf<'static>> = self.into_iter().collect();
+        while from > 0 {
+            let needs_pop =
+                match bufs.front_mut() {
+                    None => break,
+                    Some(ref mut buf) => {
+                        match buf.advance(from) {
+                            Ok(()) => {
+                                from = 0;
+                                buf.is_empty()
+                            }
+                            Err(()) => {
+                                from -= buf.len();
+                                true
+                            }
+                        }
+                    }
+                };
+
+            if needs_pop {
+                bufs.pop_front();
+            }
+        }
+
+        // This clone makes me :(, but `RingBuf` doesn't currently support `.into_iter()`.
+        bufs.iter().map(|buf| (*buf).clone()).collect()
+    }
+
+    fn write_into_lower<'a>(&self, buf: &'a mut [u8]) -> MaybeOwnedBytes<'a> {
+        let len = self.count_bytes();
+        if len <= buf.len() as u32 {
+            for (src, dst) in self.iter_bytes().zip(buf.iter_mut()) {
+                match Ascii::new(src) {
+                    None    => *dst = src,
+                    Some(a) => *dst = a.to_lowercase().to_u8(),
+                }
+            }
+            Slice(buf.slice_to_mut(len as uint))
+        } else {
+            let mut s = String::with_capacity(len as uint);
+            for c in self.iter_chars() {
+                s.push(lower_ascii(c));
+            }
+            Owned(s)
+        }
+    }
+
+    fn with_lower_str_copy<'a, T>(&self, f: |&str| -> T) -> T {
+        let mut buf = [0u8, ..64];
+
+        match self.write_into_lower(&mut buf) {
+            Slice(buf) => {
+                unsafe {
+                    let buf_as_str: &str = mem::transmute(buf);
+                    f(buf_as_str)
+                }
+            }
+            Owned(s) => {
+                h5e_warn!("Tag `{}` len={} forced us to allocate.", s, s.as_bytes().len());
+                f(s.as_slice())
+            }
+        }
+    }
+
+    fn byte_equal_slice_lower(&self, s: &[u8]) -> bool {
+        self.count_bytes_cmp(s.len()) == Ordering::Equal
+        && self.iter_bytes().zip(s.iter()).all(
+            |(x, &y)| lower_ascii(x as char) == lower_ascii(y as char))
+    }
+}
+
+type CharIterator<'a> =
+    iter::FlatMap<'static,
+                  &'a ROIobuf<'static>,
+                  SpanIter<'a, ROIobuf<'static>>,
+                  str::Chars<'a>>;
+
+type StrIterator<'a> =
+    iter::Map<'static,
+              &'a ROIobuf<'static>,
+              &'a str,
+              SpanIter<'a, ROIobuf<'static>>>;
+
+#[test]
+fn test_little_slice_from() {
+    let span = BufSpan::from_buf(ROIobuf::from_str("hello"));
+
+    assert_eq!(span.clone().slice_from(1), BufSpan::from_buf(ROIobuf::from_str("ello")));
+    assert_eq!(span.clone().slice_from(3), BufSpan::from_buf(ROIobuf::from_str("lo")));
+    assert_eq!(span.clone().slice_from(1000), BufSpan::from_buf(ROIobuf::from_str("")));
+}
+
+#[test]
+fn test_big_slice_from() {
+    let mut span = BufSpan::new();
+    span.push(ROIobuf::from_str("hello"));
+    span.push(ROIobuf::from_str(" "));
+    span.push(ROIobuf::from_str("world"));
+    assert_eq!(span.clone().slice_from(0), BufSpan::from_buf(ROIobuf::from_str("hello world")));
+    assert_eq!(span.clone().slice_from(1), BufSpan::from_buf(ROIobuf::from_str("ello world")));
+    assert_eq!(span.clone().slice_from(5), BufSpan::from_buf(ROIobuf::from_str(" world")));
+    assert_eq!(span.clone().slice_from(7), BufSpan::from_buf(ROIobuf::from_str("orld")));
+    assert_eq!(span.clone().slice_from(1000), BufSpan::from_buf(ROIobuf::from_str("")));
+}

--- a/src/util/span.rs
+++ b/src/util/span.rs
@@ -1,3 +1,11 @@
+// Copyright 2014 The html5ever Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 use core::prelude::*;
 use core::iter;
 use core::mem;


### PR DESCRIPTION
Instead of using strings, html5ever now uses Iobufs and Spans over
Iobufs to represent the raw html data. This allows us to do all of
the parsing without copying the HTML into a tree of strings: it can
be Spans and Iobufs all the way down.

There were several performance hacks done to get this faster. Most
of them were to work around rustc failures as chronicled in:

http://discuss.rust-lang.org/t/the-sad-state-of-zero-on-drop/944

Here's a little list of transformations done for performance reasons:

  - State machine states are now functions. Rustc isn't smart enough
    to properly handle large-ish things on the stack in different
    match arms. This does mean that it's sane to inline the jump
    table into `feed`, which had a nice impact on performance. Jump
    tables inside loops are especially efficient because it's just
    a bigger jump table!
  - Things which get atomized anyhow (except for doctypes, which
    weren't hot enough for me to bother changing) use the old String
    parsing method, since it ends up being a lot faster for small
    strings and doesn't cause O(tags) allocations, thanks to truncation.
  - A custom Option called `FastOption` which doesn't zero on `take`
    and can't be matched on, but still maintains safety.
  - No utf-8 decoding of the chars is avoided unless absolutely
    necessary. For most parsing, we just need the utf-8 length,
    which is much easier to calculate (a branch, and a LUT on the
    first byte in the "slow" path).
  - Chars and Runs are parsed into a "shared" location every time,
    because rustc is really bad at generating code for types which
    Drop a lot in a loop. See the discuss post at the top.
  - A new temp_buf has been introduced, because it is no longer
    performant to just append random characters to spans. Consider
    a partially-consumed comment start: `<-`. If the next character
    is an `a`, the <- needs to be emitted. The second temporary
    buffer is used to handle cases like that.
  - Similar to above, but when parsing char refs: the '&' and '#'
    are saved in case of backout.
  - Dashes at the end of a comment `----->` need to be saved and
    shuffled as we keep reading more dashes, so that we always
    emit the "right" ones to keep the span continuous. This
    required a little 2-element "queue": `first_comment_end_dash`
    and `second_comment_end_dash`.
  - Some of the tokenizer fields were reordered for cache
    efficiency.
  - Some inliner guidance was done in `get_char` and
    `get_preprocessed_char`, to keep fast paths fast.
  - `clone_from` to get data out of the input buffers is used
    where it makes sense, preventing a bunch of bad rustc codegen.

As a result of these optimizations (and zero-copy parsing in general):

===

zero-copy

test tokenize uncommitted/html5.html       ... bench: 124076195 ns/iter (+/- 9519897)
test tokenize uncommitted/lipsum-1M.html   ... bench:   1989708 ns/iter (+/- 405327)
test tokenize uncommitted/sina.com.cn.html ... bench:   7210262 ns/iter (+/- 1391972)
test tokenize uncommitted/strong.html      ... bench:  30002001 ns/iter (+/- 3375152)
test tokenize uncommitted/webapps.html     ... bench:  99264377 ns/iter (+/- 8138989)
test tokenize uncommitted/wikipedia.html   ... bench:   3841740 ns/iter (+/- 612645)

original

test tokenize uncommitted/html5.html       ... bench: 153991836 ns/iter (+/- 7196531)
test tokenize uncommitted/lipsum-1M.html   ... bench:   2393385 ns/iter (+/- 450953)
test tokenize uncommitted/sina.com.cn.html ... bench:   8837605 ns/iter (+/- 1238217)
test tokenize uncommitted/strong.html      ... bench:  44153393 ns/iter (+/- 5076161)
test tokenize uncommitted/webapps.html     ... bench: 136860951 ns/iter (+/- 8137049)
test tokenize uncommitted/wikipedia.html   ... bench:   4868854 ns/iter (+/- 797178)

SUMMARY

html5.html:       19%
sina.com.cn.html: 14%
strong.html:      47%
webapps.html:     27%
wikipedia.html:   21%
lipsum-1M.html:   17%

====

r? @kmcallister