### PR TITLE
Fix the build on 2015-01-25 Rust nightly

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -78,11 +78,9 @@ check-internal: html5ever-test
 check-external: html5ever-external-test
 	HTML5EVER_SRC_DIR=$(VPATH) ./html5ever-external-test
 
-METRICS ?= metrics.json
-
 .PHONY: bench
 bench: html5ever-external-bench
-	./html5ever-external-bench --bench --save-metrics $(METRICS)
+	./html5ever-external-bench --bench
 
 .PHONY: clean
 clean:

--- a/macros/src/match_token.rs
+++ b/macros/src/match_token.rs
@@ -117,7 +117,7 @@ type Tokens = Vec<ast::TokenTree>;
 type TagName = ast::Ident;
 
 // FIXME: duplicated in src/tokenizer/interface.rs
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Show)]
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
 enum TagKind {
     StartTag,
     EndTag,

--- a/macros/src/named_entities.rs
+++ b/macros/src/named_entities.rs
@@ -53,7 +53,7 @@ fn build_map(js: Json) -> Option<HashMap<String, [u32; 2]>> {
 
         // Slice off the initial '&'
         assert!(k.as_slice().char_at(0) == '&');
-        map.insert(k.as_slice().slice_from(1).to_string(), codepoint_pair);
+        map.insert(k[1..].to_string(), codepoint_pair);
     }
 
     // Add every missing prefix of those keys, mapping to NULL characters.
@@ -61,7 +61,7 @@ fn build_map(js: Json) -> Option<HashMap<String, [u32; 2]>> {
     let keys: Vec<String> = map.keys().map(|k| k.to_string()).collect();
     for k in keys.into_iter() {
         for n in range(1, k.len()) {
-            let pfx = k.as_slice().slice_to(n).to_string();
+            let pfx = k[..n].to_string();
             if !map.contains_key(&pfx) {
                 map.insert(pfx, [0, 0]);
             }

--- a/src/sink/common.rs
+++ b/src/sink/common.rs
@@ -16,7 +16,7 @@ use string_cache::QualName;
 pub use self::NodeEnum::{Document, Doctype, Text, Comment, Element};
 
 /// The different kinds of nodes in the DOM.
-#[derive(Show)]
+#[derive(Debug)]
 pub enum NodeEnum {
     /// The `Document` itself.
     Document,

--- a/src/tokenizer/buffer_queue.rs
+++ b/src/tokenizer/buffer_queue.rs
@@ -26,7 +26,7 @@ struct Buffer {
 }
 
 /// Result from `pop_except_from`.
-#[derive(PartialEq, Eq, Show)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum SetResult {
     FromSet(char),
     NotFromSet(String),

--- a/src/tokenizer/buffer_queue.rs
+++ b/src/tokenizer/buffer_queue.rs
@@ -104,10 +104,10 @@ impl BufferQueue {
     pub fn pop_except_from(&mut self, set: SmallCharSet) -> Option<SetResult> {
         let (result, now_empty) = match self.buffers.front_mut() {
             Some(&mut Buffer { ref mut pos, ref buf }) => {
-                let n = set.nonmember_prefix_len(buf.as_slice().slice_from(*pos));
+                let n = set.nonmember_prefix_len(&buf[*pos..]);
                 if n > 0 {
                     let new_pos = *pos + n;
-                    let out = String::from_str(buf.as_slice().slice(*pos, new_pos));
+                    let out = String::from_str(&buf[*pos..new_pos]);
                     *pos = new_pos;
                     (Some(NotFromSet(out)), new_pos >= buf.len())
                 } else {

--- a/src/tokenizer/char_ref/mod.rs
+++ b/src/tokenizer/char_ref/mod.rs
@@ -349,8 +349,7 @@ impl<Sink: TokenSink> CharRefTokenizer {
                     self.unconsume_name(tokenizer);
                     self.finish_none()
                 } else {
-                    tokenizer.unconsume(String::from_str(
-                        self.name_buf().as_slice().slice_from(name_len)));
+                    tokenizer.unconsume(String::from_str(&self.name_buf()[name_len..]));
                     self.result = Some(CharRef {
                         chars: [from_u32(c1).unwrap(), from_u32(c2).unwrap()],
                         num_chars: if c2 == 0 { 1 } else { 2 },

--- a/src/tokenizer/char_ref/mod.rs
+++ b/src/tokenizer/char_ref/mod.rs
@@ -37,7 +37,7 @@ pub enum Status {
     Done,
 }
 
-#[derive(Show)]
+#[derive(Debug)]
 enum State {
     Begin,
     Octothorpe,

--- a/src/tokenizer/interface.rs
+++ b/src/tokenizer/interface.rs
@@ -25,7 +25,7 @@ pub use self::Token::{NullCharacterToken, EOFToken, ParseError};
 
 /// A `DOCTYPE` token.
 // FIXME: already exists in Servo DOM
-#[derive(PartialEq, Eq, Clone, Show)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Doctype {
     pub name: Option<String>,
     pub public_id: Option<String>,
@@ -50,20 +50,20 @@ impl Doctype {
 /// The tokenizer creates all attributes this way, but the tree
 /// builder will adjust certain attribute names inside foreign
 /// content (MathML, SVG).
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Show)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub struct Attribute {
     pub name: QualName,
     pub value: String,
 }
 
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Show)]
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
 pub enum TagKind {
     StartTag,
     EndTag,
 }
 
 /// A tag token.
-#[derive(PartialEq, Eq, Clone, Show)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Tag {
     pub kind: TagKind,
     pub name: Atom,
@@ -88,7 +88,7 @@ impl Tag {
     }
 }
 
-#[derive(PartialEq, Eq, Show)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Token {
     DoctypeToken(Doctype),
     TagToken(Tag),

--- a/src/tokenizer/states.rs
+++ b/src/tokenizer/states.rs
@@ -20,19 +20,19 @@ pub use self::RawKind::*;
 pub use self::AttrValueKind::*;
 pub use self::State::*;
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Show)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
 pub enum ScriptEscapeKind {
     Escaped,
     DoubleEscaped,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Show)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
 pub enum DoctypeIdKind {
     Public,
     System,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Show)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
 pub enum RawKind {
     Rcdata,
     Rawtext,
@@ -40,14 +40,14 @@ pub enum RawKind {
     ScriptDataEscaped(ScriptEscapeKind),
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Show)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
 pub enum AttrValueKind {
     Unquoted,
     SingleQuoted,
     DoubleQuoted,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Show)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
 pub enum State {
     Data,
     Plaintext,

--- a/src/tree_builder/actions.rs
+++ b/src/tree_builder/actions.rs
@@ -30,7 +30,7 @@ use util::str::to_escaped_string;
 use core::mem::replace;
 use core::iter::{Rev, Enumerate};
 use core::slice;
-use core::fmt::Show;
+use core::fmt::Debug;
 use collections::vec::Vec;
 use collections::string::String;
 use std::borrow::Cow::Borrowed;
@@ -60,7 +60,7 @@ pub enum PushFlag {
 
 // These go in a trait so that we can control visibility.
 pub trait TreeBuilderActions<Handle> {
-    fn unexpected<T: Show>(&mut self, thing: &T) -> ProcessResult;
+    fn unexpected<T: Debug>(&mut self, thing: &T) -> ProcessResult;
     fn assert_named(&mut self, node: Handle, name: Atom);
     fn clear_active_formatting_to_marker(&mut self);
     fn create_formatting_element_for(&mut self, tag: Tag) -> Handle;
@@ -115,7 +115,7 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
     where Handle: Clone,
           Sink: TreeSink<Handle=Handle>,
 {
-    fn unexpected<T: Show>(&mut self, _thing: &T) -> ProcessResult {
+    fn unexpected<T: Debug>(&mut self, _thing: &T) -> ProcessResult {
         self.sink.parse_error(format_if!(
             self.opts.exact_errors,
             "Unexpected token",

--- a/src/tree_builder/interface.rs
+++ b/src/tree_builder/interface.rs
@@ -24,7 +24,7 @@ pub use self::QuirksMode::{Quirks, LimitedQuirks, NoQuirks};
 pub use self::NodeOrText::{AppendNode, AppendText};
 
 /// A document's quirks mode.
-#[derive(PartialEq, Eq, Copy, Clone, Hash, Show)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash, Debug)]
 pub enum QuirksMode {
     Quirks,
     LimitedQuirks,

--- a/src/tree_builder/mod.rs
+++ b/src/tree_builder/mod.rs
@@ -261,11 +261,11 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
 
                     token = CharacterTokens(
                         if is_ws { Whitespace } else { NotWhitespace },
-                        String::from_str(buf.slice_to(len)));
+                        String::from_str(&buf[..len]));
 
                     if len < buf.len() {
                         more_tokens.push_back(
-                            CharacterTokens(NotSplit, String::from_str(buf.slice_from(len))));
+                            CharacterTokens(NotSplit, String::from_str(&buf[len..])));
                     }
                 }
             }

--- a/src/tree_builder/types.rs
+++ b/src/tree_builder/types.rs
@@ -21,7 +21,7 @@ pub use self::Token::*;
 pub use self::ProcessResult::*;
 pub use self::FormatEntry::*;
 
-#[derive(PartialEq, Eq, Copy, Clone, Show)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum InsertionMode {
     Initial,
     BeforeHtml,
@@ -48,7 +48,7 @@ pub enum InsertionMode {
     AfterAfterFrameset,
 }
 
-#[derive(PartialEq, Eq, Copy, Clone, Show)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum SplitStatus {
     NotSplit,
     Whitespace,
@@ -57,7 +57,7 @@ pub enum SplitStatus {
 
 /// A subset/refinement of `tokenizer::Token`.  Everything else is handled
 /// specially at the beginning of `process_token`.
-#[derive(PartialEq, Eq, Clone, Show)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum Token {
     TagToken(Tag),
     CommentToken(String),

--- a/src/util/str.rs
+++ b/src/util/str.rs
@@ -14,10 +14,10 @@ use collections::vec::Vec;
 use collections::string::String;
 
 #[cfg(not(for_c))]
-use core::fmt::Show;
+use core::fmt::Debug;
 
 #[cfg(not(for_c))]
-pub fn to_escaped_string<T: Show>(x: &T) -> String {
+pub fn to_escaped_string<T: Debug>(x: &T) -> String {
     use collections::str::StrExt;
     use core::fmt::Writer;
 

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -43,8 +43,8 @@ fn splits(s: &str, n: uint) -> Vec<Vec<String>> {
     // do this with iterators?
     let mut out = vec!();
     for p in points.into_iter() {
-        let y = s.slice_from(p);
-        for mut x in splits(s.slice_to(p), n-1).into_iter() {
+        let y = &s[p..];
+        for mut x in splits(&s[..p], n-1).into_iter() {
             x.push(y.to_string());
             out.push(x);
         }
@@ -189,7 +189,7 @@ impl JsonExt for Json {
 fn json_to_token(js: &Json) -> Token {
     let parts = js.get_list();
     // Collect refs here so we don't have to use "ref" in all the patterns below.
-    let args: Vec<&Json> = parts.slice_from(1).iter().collect();
+    let args: Vec<&Json> = parts[1..].iter().collect();
     match (parts[0].get_str().as_slice(), args.as_slice()) {
         ("DOCTYPE", [name, public_id, system_id, correct]) => DoctypeToken(Doctype {
             name: name.get_nullable_str(),

--- a/tests/tree_builder.rs
+++ b/tests/tree_builder.rs
@@ -52,8 +52,7 @@ fn parse_tests<It: Iterator<Item=String>>(mut lines: It) -> Vec<HashMap<String, 
                     if line.as_slice() == "#data\n" {
                         finish_test!();
                     }
-                    key = Some(line.as_slice().slice_from(1)
-                        .trim_right_matches('\n').to_string());
+                    key = Some(line[1..].trim_right_matches('\n').to_string());
                 } else {
                     val.push_str(line.as_slice());
                 }


### PR DESCRIPTION
This fixes all build errors I was seeing in the 2015-01-25 Rust nightly build. `make examples check bench` now runs without errors.