### PR TITLE
Opt in to container-based Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 branches:
   except:
       - servo


### PR DESCRIPTION
This should provide faster build startup times, and will also allow caching between builds if that seems useful. See http://docs.travis-ci.com/user/workers/container-based-infrastructure/ for details.