### PR TITLE
Remove old orphan check

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,7 +10,7 @@
 #![crate_name="html5ever_macros"]
 #![crate_type="dylib"]
 
-#![feature(plugin_registrar, quote, old_orphan_check)]
+#![feature(plugin_registrar, quote)]
 #![feature(rustc_private, std_misc, core, hash, collections, path, io)]
 #![deny(warnings)]
 


### PR DESCRIPTION
With this PR we are able to run on current nightly (`rustc 1.0.0-nightly (1d00c545e 2015-01-30 19:56:34 +0000)`) with zero warnings