### PR TITLE
Shrink test output in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   - mkdir build
   - cd build
   - ../configure
-  - make check docs for_c
+  - make check docs for_c | ../scripts/shrink-test-output.py
 after_script:
   - cd /home/travis/build/servo/html5ever/target
   - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ env:
   global:
       - secure: uytPp0Fs+LT3QDEhDM3LJWiLvT2AHbdWnXrPEs+bYshQwt9wST+KQnYLyRfBuGg2ux3pkZwsRUFexvN8pQ3ab4aU2P21Xo98TzdXRwXurNYePgk/3tykEH+JrL52DfjCWB1VsjzzFrP02XU0XtB30qWC/n+fxeMWT7JT2GVh/OE=
 language: rust
-script:
-  - mkdir build
-  - cd build
-  - ../configure
-  - make check docs for_c | ../scripts/shrink-test-output.py
+script: scripts/travis-build.sh
 after_script:
   - cd /home/travis/build/servo/html5ever/target
   - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/scripts/shrink-test-output.py
+++ b/scripts/shrink-test-output.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# Copyright 2015 The html5ever Project Developers. See the
+# COPYRIGHT file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import re
+import sys
+
+
+REPLACEMENTS = {
+    'ok': '.',
+    'FAILED': 'F',
+    'ignored': 'I',
+}
+TEST_RESULT_RE = re.compile(
+    r'^test .* \.\.\. ({0})$'.format('|'.join(REPLACEMENTS.keys())))
+
+
+def main():
+    while True:
+        line = sys.stdin.readline()
+        if len(line) is 0:
+            break
+        match = TEST_RESULT_RE.match(line)
+        if match:
+            sys.stdout.write(REPLACEMENTS[match.group(1)])
+        else:
+            sys.stdout.write(line)
+        sys.stdout.flush()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2015 The html5ever Project Developers. See the
+# COPYRIGHT file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+mkdir build
+cd build
+../configure
+make check docs for_c | ../scripts/shrink-test-output.py

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -14,3 +14,4 @@ mkdir build
 cd build
 ../configure
 make check docs for_c | ../scripts/shrink-test-output.py
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Travis CI won't display build logs longer than 10,000 lines. Since we have so many tests, our CI logs get truncated and you can't see the test failures down at the end of the log.

Instead of printing each test on its own line, we now just print out a single character for each test indiciating success (`.`), failure (`F`), or that the test was ignored (`I`). Failing tests are still printed in full at the end of the test run.