### PR TITLE
Add quirks_mode to TreeBuilderOpts

### DIFF
--- a/src/tree_builder/mod.rs
+++ b/src/tree_builder/mod.rs
@@ -68,6 +68,9 @@ pub struct TreeBuilderOpts {
     /// **Warning**: This may produce extremely incorrect results
     /// on some documents!
     pub ignore_missing_rules: bool,
+
+    /// Initial TreeBuilder quirks mode. Default: NoQuirks
+    pub quirks_mode: QuirksMode,
 }
 
 impl Default for TreeBuilderOpts {
@@ -78,6 +81,7 @@ impl Default for TreeBuilderOpts {
             iframe_srcdoc: false,
             drop_doctype: false,
             ignore_missing_rules: false,
+            quirks_mode: NoQuirks,
         }
     }
 }
@@ -161,7 +165,7 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
             orig_mode: None,
             template_modes: vec!(),
             pending_table_text: vec!(),
-            quirks_mode: NoQuirks,
+            quirks_mode: opts.quirks_mode,
             doc_handle: doc_handle,
             open_elems: vec!(),
             active_formatting: vec!(),
@@ -193,7 +197,7 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
             orig_mode: None,
             template_modes: if context_is_template { vec![InTemplate] } else { vec![] },
             pending_table_text: vec!(),
-            quirks_mode: NoQuirks, // FIXME(#96) set this to match the sink's document
+            quirks_mode: opts.quirks_mode,
             doc_handle: doc_handle,
             open_elems: vec!(),
             active_formatting: vec!(),


### PR DESCRIPTION
Fixes https://github.com/servo/html5ever/issues/96, although with quirks_mode being initialized from an option in TreeBuilderOpts, the responsibility lies with the client of the parser to specify a quirks_mode that matches the target document.