### PR TITLE
Use enum rather than bool for controlling serialize

### DIFF
--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -16,15 +16,22 @@ use collections::vec::Vec;
 use string_cache::{Atom, QualName};
 
 //§ serializing-html-fragments
+#[derive(Copy, PartialEq)]
+pub enum TraversalScope {
+    IncludeNode,
+    ChildrenOnly
+}
+
 pub trait Serializable {
-    fn serialize<'wr, Wr: Writer>(&self, serializer: &mut Serializer<'wr, Wr>, incl_self: bool) -> IoResult<()>;
+    fn serialize<'wr, Wr: Writer>(&self, serializer: &mut Serializer<'wr, Wr>,
+                                  traversal_scope: TraversalScope) -> IoResult<()>;
 }
 
 pub fn serialize<Wr: Writer, T: Serializable>
     (writer: &mut Wr, node: &T, opts: SerializeOpts) -> IoResult<()> {
 
     let mut ser = Serializer::new(writer, opts);
-    node.serialize(&mut ser, opts.include_root)
+    node.serialize(&mut ser, opts.traversal_scope)
 }
 
 #[derive(Copy)]
@@ -32,15 +39,15 @@ pub struct SerializeOpts {
     /// Is scripting enabled?
     pub scripting_enabled: bool,
 
-    /// Serialize the root node? Default: false
-    pub include_root: bool,
+    /// Serialize the root node? Default: ChildrenOnly
+    pub traversal_scope: TraversalScope,
 }
 
 impl Default for SerializeOpts {
     fn default() -> SerializeOpts {
         SerializeOpts {
             scripting_enabled: true,
-            include_root: false,
+            traversal_scope: TraversalScope::ChildrenOnly,
         }
     }
 }

--- a/src/sink/owned_dom.rs
+++ b/src/sink/owned_dom.rs
@@ -27,6 +27,8 @@ use tokenizer::Attribute;
 use tree_builder::{TreeSink, QuirksMode, NodeOrText, AppendNode, AppendText};
 use tree_builder;
 use serialize::{Serializable, Serializer};
+use serialize::TraversalScope;
+use serialize::TraversalScope::{IncludeNode, ChildrenOnly};
 use driver::ParseResult;
 
 use core::cell::UnsafeCell;
@@ -355,39 +357,39 @@ impl ParseResult for OwnedDom {
 impl Serializable for Node {
     fn serialize<'wr, Wr: Writer>(&self,
             serializer: &mut Serializer<'wr, Wr>,
-            incl_self: bool) -> IoResult<()> {
+            traversal_scope: TraversalScope) -> IoResult<()> {
 
-        match (incl_self, &self.node) {
+        match (traversal_scope, &self.node) {
             (_, &Element(ref name, ref attrs)) => {
-                if incl_self {
+                if traversal_scope == IncludeNode {
                     try!(serializer.start_elem(name.clone(),
                         attrs.iter().map(|at| (&at.name, at.value.as_slice()))));
                 }
 
                 for child in self.children.iter() {
-                    try!(child.serialize(serializer, true));
+                    try!(child.serialize(serializer, IncludeNode));
                 }
 
-                if incl_self {
+                if traversal_scope == IncludeNode {
                     try!(serializer.end_elem(name.clone()));
                 }
                 Ok(())
             }
 
-            (false, &Document) => {
+            (ChildrenOnly, &Document) => {
                 for child in self.children.iter() {
-                    try!(child.serialize(serializer, true));
+                    try!(child.serialize(serializer, IncludeNode));
                 }
                 Ok(())
             }
 
-            (false, _) => Ok(()),
+            (ChildrenOnly, _) => Ok(()),
 
-            (true, &Doctype(ref name, _, _)) => serializer.write_doctype(name.as_slice()),
-            (true, &Text(ref text)) => serializer.write_text(text.as_slice()),
-            (true, &Comment(ref text)) => serializer.write_comment(text.as_slice()),
+            (IncludeNode, &Doctype(ref name, _, _)) => serializer.write_doctype(name.as_slice()),
+            (IncludeNode, &Text(ref text)) => serializer.write_text(text.as_slice()),
+            (IncludeNode, &Comment(ref text)) => serializer.write_comment(text.as_slice()),
 
-            (true, &Document) => panic!("Can't serialize Document node itself"),
+            (IncludeNode, &Document) => panic!("Can't serialize Document node itself"),
         }
     }
 }


### PR DESCRIPTION
In https://github.com/servo/servo/pull/5029, @jdm [requested](https://critic.hoppipolla.co.uk/showcomment?chain=10737) an enum rather than bool for indicating whether to serialize a whole node, or only its children. For consistency, I pushed that suggestion all the way down through html5ever, and it looks like this.