### PR TITLE
Implement zero-copy parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ phf = "0"
 phf_macros = "0"
 time = "0"
 log = "0"
+iobuf = "5"
 
 [dependencies.string_cache]
 git = "https://github.com/servo/string-cache"

--- a/Makefile.in
+++ b/Makefile.in
@@ -14,7 +14,6 @@ RUST_DIRS := -L $(VPATH)/target/debug -L $(VPATH)/target/debug/deps
 
 RUSTC_CMD := $(RUSTC) -D warnings -C rpath $(RUST_DIRS) \
     --extern time=`find $(VPATH)/target/debug/deps -name 'libtime-*.rlib'` \
-    --extern log=`find $(VPATH)/target/debug/deps -name 'liblog-*.rlib'` \
     $(RUSTFLAGS)
 
 # We build the library itself using Cargo.

--- a/benches/tokenizer.rs
+++ b/benches/tokenizer.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(box_syntax, core, std_misc, start, test, io, path)]
+#![feature(box_syntax, core, std_misc, start, test)]
 
 extern crate test;
 extern crate html5ever;
@@ -21,6 +21,7 @@ use test::{black_box, Bencher, TestDesc, TestDescAndFn};
 use test::{DynTestName, DynBenchFn, TDynBenchFn};
 use test::ShouldPanic::No;
 
+use html5ever::Tendril;
 use html5ever::tokenizer::{TokenSink, Token, Tokenizer, TokenizerOpts};
 
 struct Sink;

--- a/examples/noop-tokenize-zerocopy.rs
+++ b/examples/noop-tokenize-zerocopy.rs
@@ -7,21 +7,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Run a single benchmark once.  For use with profiling tools.
-
 #![feature(test)]
 
 extern crate test;
 extern crate html5ever;
 
 use std::io;
-use std::io::prelude::*;
 use std::default::Default;
 
 use test::black_box;
 
+use html5ever::TendrilReader;
 use html5ever::tokenizer::{TokenSink, Token, TokenizerOpts};
-use html5ever::driver::{tokenize_to, one_input};
+use html5ever::driver::tokenize_to;
 
 struct Sink;
 
@@ -34,10 +32,10 @@ impl TokenSink for Sink {
 }
 
 fn main() {
-    let mut input = String::new();
-    io::stdin().read_to_string(&mut input).unwrap();
+    let reader = TendrilReader::from_utf8(16384, io::stdin())
+        .map(|r| r.unwrap());
 
-    tokenize_to(Sink, one_input(input), TokenizerOpts {
+    tokenize_to(Sink, reader, TokenizerOpts {
         profile: true,
         .. Default::default()
     });

--- a/examples/noop-tokenize.rs
+++ b/examples/noop-tokenize.rs
@@ -9,12 +9,12 @@
 
 // Run a single benchmark once.  For use with profiling tools.
 
-#![feature(core, test)]
+#![feature(test)]
 
 extern crate test;
 extern crate html5ever;
 
-use std::{fs, env};
+use std::io;
 use std::io::prelude::*;
 use std::default::Default;
 
@@ -34,15 +34,10 @@ impl TokenSink for Sink {
 }
 
 fn main() {
-    let mut path = env::current_exe().unwrap();
-    path.push("../data/bench/");
-    path.push(env::args().nth(1).unwrap().as_slice());
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input).unwrap();
 
-    let mut file = fs::File::open(&path).unwrap();
-    let mut file_input = String::new();
-    file.read_to_string(&mut file_input).unwrap();
-
-    tokenize_to(Sink, one_input(file_input), TokenizerOpts {
+    tokenize_to(Sink, one_input(input), TokenizerOpts {
         profile: true,
         .. Default::default()
     });

--- a/examples/noop-tree-builder.rs
+++ b/examples/noop-tree-builder.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::borrow::Cow;
 use string_cache::QualName;
 
-use html5ever::{parse_to, one_input};
+use html5ever::{parse_to, one_input, Tendril};
 use html5ever::tokenizer::Attribute;
 use html5ever::tree_builder::{TreeSink, QuirksMode, NodeOrText};
 
@@ -56,7 +56,7 @@ impl TreeSink for Sink {
         id
     }
 
-    fn create_comment(&mut self, _text: String) -> usize {
+    fn create_comment(&mut self, _text: Tendril) -> usize {
         self.get_id()
     }
 
@@ -72,7 +72,7 @@ impl TreeSink for Sink {
     fn set_quirks_mode(&mut self, _mode: QuirksMode) { }
     fn append(&mut self, _parent: usize, _child: NodeOrText<usize>) { }
 
-    fn append_doctype_to_document(&mut self, _name: String, _public_id: String, _system_id: String) { }
+    fn append_doctype_to_document(&mut self, _name: Tendril, _public_id: Tendril, _system_id: Tendril) { }
     fn add_attrs_if_missing(&mut self, _target: usize, _attrs: Vec<Attribute>) { }
     fn remove_from_parent(&mut self, _target: usize) { }
     fn reparent_children(&mut self, _node: usize, _new_parent: usize) { }

--- a/examples/print-tree-actions.rs
+++ b/examples/print-tree-actions.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::borrow::Cow;
 use string_cache::QualName;
 
-use html5ever::{parse_to, one_input};
+use html5ever::{parse_to, one_input, Tendril};
 use html5ever::tokenizer::Attribute;
 use html5ever::tree_builder::{TreeSink, QuirksMode, NodeOrText, AppendNode, AppendText};
 
@@ -67,7 +67,7 @@ impl TreeSink for Sink {
         id
     }
 
-    fn create_comment(&mut self, text: String) -> usize {
+    fn create_comment(&mut self, text: Tendril) -> usize {
         let id = self.get_id();
         println!("Created comment \"{}\" as {}", text.escape_default(), id);
         id
@@ -97,7 +97,7 @@ impl TreeSink for Sink {
         Ok(())
     }
 
-    fn append_doctype_to_document(&mut self, name: String, public_id: String, system_id: String) {
+    fn append_doctype_to_document(&mut self, name: Tendril, public_id: Tendril, system_id: Tendril) {
         println!("Append doctype: {} {} {}", name, public_id, system_id);
     }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -11,7 +11,7 @@
 #![crate_type="dylib"]
 
 #![feature(plugin_registrar, quote)]
-#![feature(rustc_private, core, std_misc)]
+#![feature(rustc_private, core, std_misc, str_char)]
 #![deny(warnings)]
 
 extern crate syntax;

--- a/src/for_c/common.rs
+++ b/src/for_c/common.rs
@@ -20,6 +20,8 @@ use libc::{size_t, c_int, c_char, strlen};
 
 use string_cache::Atom;
 
+use util::tendril::Tendril;
+
 #[repr(C)]
 pub struct h5e_buf {
     data: *const u8,
@@ -77,6 +79,12 @@ pub trait AsLifetimeBuf {
 }
 
 impl AsLifetimeBuf for String {
+    fn as_lifetime_buf<'a>(&'a self) -> LifetimeBuf<'a> {
+        LifetimeBuf::from_str(self.as_slice())
+    }
+}
+
+impl AsLifetimeBuf for Tendril {
     fn as_lifetime_buf<'a>(&'a self) -> LifetimeBuf<'a> {
         LifetimeBuf::from_str(self.as_slice())
     }

--- a/src/for_c/tokenizer.rs
+++ b/src/for_c/tokenizer.rs
@@ -11,6 +11,7 @@
 
 use core::prelude::*;
 
+use util::tendril::Tendril;
 use for_c::common::{LifetimeBuf, AsLifetimeBuf, h5e_buf, c_bool};
 
 use tokenizer::{TokenSink, Token, Doctype, Tag, ParseError, DoctypeToken};
@@ -64,7 +65,7 @@ impl TokenSink for *mut h5e_token_sink {
             ($name:ident) => (call!($name,)); // bleh
         }
 
-        fn opt_str_to_buf<'a>(s: &'a Option<String>) -> LifetimeBuf<'a> {
+        fn opt_str_to_buf<'a>(s: &'a Option<Tendril>) -> LifetimeBuf<'a> {
             match *s {
                 None => LifetimeBuf::null(),
                 Some(ref s) => s.as_lifetime_buf(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![crate_name="html5ever"]
 #![crate_type="dylib"]
 
-#![feature(plugin, box_syntax, no_std, core, collections, alloc)]
+#![feature(plugin, box_syntax, no_std, core, collections, alloc, str_char)]
 #![deny(warnings)]
 #![allow(unused_parens)]
 
@@ -49,6 +49,9 @@ extern crate phf;
 
 extern crate time;
 
+extern crate iobuf;
+
+pub use util::tendril::{Tendril, TendrilReader, TendrilReaderError, IntoTendril};
 pub use tokenizer::Attribute;
 pub use driver::{one_input, ParseOpts, parse_to, parse_fragment_to, parse, parse_fragment};
 
@@ -61,6 +64,7 @@ mod macros;
 #[macro_use]
 mod util {
     pub mod str;
+    pub mod tendril;
     #[macro_use] pub mod smallcharset;
 }
 

--- a/src/sink/common.rs
+++ b/src/sink/common.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use util::tendril::Tendril;
 use tokenizer::Attribute;
 
 use collections::vec::Vec;
-use collections::string::String;
 use string_cache::QualName;
 
 pub use self::NodeEnum::{Document, Doctype, Text, Comment, Element};
@@ -22,13 +22,13 @@ pub enum NodeEnum {
     Document,
 
     /// A `DOCTYPE` with name, public id, and system id.
-    Doctype(String, String, String),
+    Doctype(Tendril, Tendril, Tendril),
 
     /// A text node.
-    Text(String),
+    Text(Tendril),
 
     /// A comment.
-    Comment(String),
+    Comment(Tendril),
 
     /// An element with attributes.
     Element(QualName, Vec<Attribute>),

--- a/src/sink/owned_dom.rs
+++ b/src/sink/owned_dom.rs
@@ -23,6 +23,7 @@ use core::prelude::*;
 
 use sink::common::{NodeEnum, Document, Doctype, Text, Comment, Element};
 
+use util::tendril::Tendril;
 use tokenizer::Attribute;
 use tree_builder::{TreeSink, QuirksMode, NodeOrText, AppendNode, AppendText};
 use tree_builder;
@@ -38,7 +39,6 @@ use core::mem;
 use core::ptr;
 use alloc::boxed::Box;
 use collections::vec::Vec;
-use collections::string::String;
 use std::borrow::Cow;
 use std::io::{self, Write};
 use std::collections::HashSet;
@@ -215,7 +215,7 @@ impl TreeSink for Sink {
         self.new_node(Element(name, attrs))
     }
 
-    fn create_comment(&mut self, text: String) -> Handle {
+    fn create_comment(&mut self, text: Tendril) -> Handle {
         self.new_node(Comment(text))
     }
 
@@ -269,7 +269,7 @@ impl TreeSink for Sink {
         Ok(())
     }
 
-    fn append_doctype_to_document(&mut self, name: String, public_id: String, system_id: String) {
+    fn append_doctype_to_document(&mut self, name: Tendril, public_id: Tendril, system_id: Tendril) {
         append(self.document, self.new_node(Doctype(name, public_id, system_id)));
     }
 

--- a/src/sink/rcdom.rs
+++ b/src/sink/rcdom.rs
@@ -16,6 +16,7 @@ use core::prelude::*;
 
 use sink::common::{NodeEnum, Document, Doctype, Text, Comment, Element};
 
+use util::tendril::Tendril;
 use tokenizer::Attribute;
 use tree_builder::{TreeSink, QuirksMode, NodeOrText, AppendNode, AppendText};
 use tree_builder;
@@ -28,7 +29,6 @@ use core::cell::RefCell;
 use core::default::Default;
 use alloc::rc::{Rc, Weak};
 use collections::vec::Vec;
-use collections::string::String;
 use std::borrow::Cow;
 use std::io::{self, Write};
 use std::ops::DerefMut;
@@ -156,7 +156,7 @@ impl TreeSink for RcDom {
         new_node(Element(name, attrs))
     }
 
-    fn create_comment(&mut self, text: String) -> Handle {
+    fn create_comment(&mut self, text: Tendril) -> Handle {
         new_node(Comment(text))
     }
 
@@ -211,7 +211,7 @@ impl TreeSink for RcDom {
         Ok(())
     }
 
-    fn append_doctype_to_document(&mut self, name: String, public_id: String, system_id: String) {
+    fn append_doctype_to_document(&mut self, name: Tendril, public_id: Tendril, system_id: Tendril) {
         append(&self.document, new_node(Doctype(name, public_id, system_id)));
     }
 

--- a/src/tokenizer/interface.rs
+++ b/src/tokenizer/interface.rs
@@ -19,6 +19,8 @@ use std::marker::Send;
 
 use string_cache::{Atom, QualName};
 
+use util::tendril::Tendril;
+
 pub use self::TagKind::{StartTag, EndTag};
 pub use self::Token::{DoctypeToken, TagToken, CommentToken, CharacterTokens};
 pub use self::Token::{NullCharacterToken, EOFToken, ParseError};
@@ -27,9 +29,9 @@ pub use self::Token::{NullCharacterToken, EOFToken, ParseError};
 // FIXME: already exists in Servo DOM
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Doctype {
-    pub name: Option<String>,
-    pub public_id: Option<String>,
-    pub system_id: Option<String>,
+    pub name: Option<Tendril>,
+    pub public_id: Option<Tendril>,
+    pub system_id: Option<Tendril>,
     pub force_quirks: bool,
 }
 
@@ -53,7 +55,7 @@ impl Doctype {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub struct Attribute {
     pub name: QualName,
-    pub value: String,
+    pub value: Tendril,
 }
 
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
@@ -92,8 +94,8 @@ impl Tag {
 pub enum Token {
     DoctypeToken(Doctype),
     TagToken(Tag),
-    CommentToken(String),
-    CharacterTokens(String),
+    CommentToken(Tendril),
+    CharacterTokens(Tendril),
     NullCharacterToken,
     EOFToken,
     ParseError(Cow<'static, str>),

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -546,6 +546,7 @@ macro_rules! shorthand (
     ( $me:ident : create_tag $kind:ident $c:expr   ) => ( $me.create_tag($kind, $c);                           );
     ( $me:ident : push_tag $c:expr                 ) => ( $me.current_tag_name.push($c);                       );
     ( $me:ident : discard_tag                      ) => ( $me.discard_tag();                                   );
+    ( $me:ident : discard_char                     ) => ( $me.discard_char();                                  );
     ( $me:ident : push_temp $c:expr                ) => ( $me.temp_buf.push($c);                               );
     ( $me:ident : emit_temp                        ) => ( $me.emit_temp_buf();                                 );
     ( $me:ident : clear_temp                       ) => ( $me.clear_temp_buf();                                );
@@ -628,6 +629,10 @@ macro_rules! go_match ( ( $me:ident : $x:expr, $($pats:pat),+ => $($cmds:tt)* ) 
 // from the function where it is used.
 macro_rules! get_char ( ($me:expr) => (
     unwrap_or_return!($me.get_char(), false)
+));
+
+macro_rules! peek ( ($me:expr) => (
+    unwrap_or_return!($me.peek(), false)
 ));
 
 macro_rules! pop_except_from ( ($me:expr, $set:expr) => (
@@ -922,18 +927,16 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             }},
 
             //§ before-attribute-value-state
-            states::BeforeAttributeValue => loop { match get_char!(self) {
-                '\t' | '\n' | '\x0C' | ' ' => (),
-                '"'  => go!(self: to AttributeValue DoubleQuoted),
-                '&'  => go!(self: reconsume AttributeValue Unquoted),
-                '\'' => go!(self: to AttributeValue SingleQuoted),
-                '\0' => go!(self: error; push_value '\u{fffd}'; to AttributeValue Unquoted),
-                '>'  => go!(self: error; emit_tag Data),
-                c => {
-                    go_match!(self: c,
-                        '<' , '=' , '`' => error);
-                    go!(self: push_value c; to AttributeValue Unquoted);
-                }
+            // Use peek so we can handle the first attr character along with the rest,
+            // hopefully in the same zero-copy buffer.
+            states::BeforeAttributeValue => loop { match peek!(self) {
+                '\t' | '\n' | '\r' | '\x0C' | ' ' => go!(self: discard_char),
+                '"'  => go!(self: discard_char; to AttributeValue DoubleQuoted),
+                '&'  => go!(self: to AttributeValue Unquoted),
+                '\'' => go!(self: discard_char; to AttributeValue SingleQuoted),
+                '\0' => go!(self: discard_char; error; push_value '\u{fffd}'; to AttributeValue Unquoted),
+                '>'  => go!(self: discard_char; error; emit_tag Data),
+                _    => go!(self: to AttributeValue Unquoted),
             }},
 
             //§ attribute-value-(double-quoted)-state

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -32,8 +32,9 @@ use self::char_ref::{CharRef, CharRefTokenizer};
 
 use self::buffer_queue::{BufferQueue, SetResult, FromSet, NotFromSet};
 
-use util::str::{lower_ascii, lower_ascii_letter, empty_str};
+use util::str::{lower_ascii, lower_ascii_letter};
 use util::smallcharset::SmallCharSet;
+use util::tendril::{Tendril, IntoTendril};
 
 use core::mem::replace;
 use core::default::Default;
@@ -50,19 +51,16 @@ mod interface;
 mod char_ref;
 mod buffer_queue;
 
-fn option_push(opt_str: &mut Option<String>, c: char) {
+fn option_push(opt_str: &mut Option<Tendril>, c: char) {
     match *opt_str {
         Some(ref mut s) => s.push(c),
-        None => *opt_str = Some(c.to_string()),
+        None => *opt_str = Some(Tendril::from_char(c)),
     }
 }
 
-fn append_strings(lhs: &mut String, rhs: String) {
-    if lhs.is_empty() {
-        *lhs = rhs;
-    } else {
-        lhs.push_str(rhs.as_slice());
-    }
+/// Pre-allocate a string which will hold a tag or attribute name.
+fn name_buffer() -> String {
+    String::with_capacity(12)
 }
 
 /// Tokenizer options, with an impl for `Default`.
@@ -153,10 +151,10 @@ pub struct Tokenizer<Sink> {
     current_attr_name: String,
 
     /// Current attribute value.
-    current_attr_value: String,
+    current_attr_value: Tendril,
 
     /// Current comment.
-    current_comment: String,
+    current_comment: Tendril,
 
     /// Current doctype token.
     current_doctype: Doctype,
@@ -165,7 +163,7 @@ pub struct Tokenizer<Sink> {
     last_start_tag_name: Option<Atom>,
 
     /// The "temporary buffer" mentioned in the spec.
-    temp_buf: String,
+    temp_buf: Tendril,
 
     /// Record of how many ns we spent in each state, if profiling is enabled.
     state_profile: BTreeMap<states::State, u64>,
@@ -197,15 +195,15 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             ignore_lf: false,
             discard_bom: discard_bom,
             current_tag_kind: StartTag,
-            current_tag_name: empty_str(),
+            current_tag_name: name_buffer(),
             current_tag_self_closing: false,
             current_tag_attrs: vec!(),
-            current_attr_name: empty_str(),
-            current_attr_value: empty_str(),
-            current_comment: empty_str(),
+            current_attr_name: name_buffer(),
+            current_attr_value: Tendril::new(),
+            current_comment: Tendril::new(),
             current_doctype: Doctype::new(),
             last_start_tag_name: start_tag_name,
-            temp_buf: empty_str(),
+            temp_buf: Tendril::new(),
             state_profile: BTreeMap::new(),
             time_in_sink: 0,
         }
@@ -224,12 +222,15 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
     }
 
     /// Feed an input string into the tokenizer.
-    pub fn feed(&mut self, input: String) {
-        if input.len() == 0 {
+    pub fn feed<T>(&mut self, input: T)
+        where T: IntoTendril,
+    {
+        let input = input.into_tendril();
+        if input.is_empty() {
             return;
         }
 
-        let pos = if self.discard_bom && input.as_slice().char_at(0) == '\u{feff}' {
+        let pos = if self.discard_bom && input.char_at(0) == '\u{feff}' {
             self.discard_bom = false;
             3  // length of BOM in UTF-8
         } else {
@@ -372,20 +373,20 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
     fn emit_char(&mut self, c: char) {
         self.process_token(match c {
             '\0' => NullCharacterToken,
-            _ => CharacterTokens(c.to_string()),
+            _ => CharacterTokens(Tendril::from_char(c)),
         });
     }
 
     // The string must not contain '\0'!
-    fn emit_chars(&mut self, b: String) {
+    fn emit_chars(&mut self, b: Tendril) {
         self.process_token(CharacterTokens(b));
     }
 
     fn emit_current_tag(&mut self) {
         self.finish_attribute();
 
-        let name = replace(&mut self.current_tag_name, String::new());
-        let name = Atom::from_slice(name.as_slice());
+        let name = Atom::from_slice(&self.current_tag_name);
+        self.current_tag_name.truncate(0);
 
         match self.current_tag_kind {
             StartTag => {
@@ -418,22 +419,22 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
     fn emit_temp_buf(&mut self) {
         // FIXME: Make sure that clearing on emit is spec-compatible.
-        let buf = replace(&mut self.temp_buf, empty_str());
+        let buf = replace(&mut self.temp_buf, Tendril::new());
         self.emit_chars(buf);
     }
 
     fn clear_temp_buf(&mut self) {
         // Do this without a new allocation.
-        self.temp_buf.truncate(0);
+        self.temp_buf.clear();
     }
 
     fn emit_current_comment(&mut self) {
-        let comment = replace(&mut self.current_comment, empty_str());
+        let comment = replace(&mut self.current_comment, Tendril::new());
         self.process_token(CommentToken(comment));
     }
 
     fn discard_tag(&mut self) {
-        self.current_tag_name = String::new();
+        self.current_tag_name.truncate(0);
         self.current_tag_self_closing = false;
         self.current_tag_attrs = vec!();
     }
@@ -468,21 +469,22 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         // FIXME: the spec says we should error as soon as the name is finished.
         // FIXME: linear time search, do we care?
         let dup = {
-            let name = self.current_attr_name.as_slice();
+            let name = &*self.current_attr_name;
             self.current_tag_attrs.iter().any(|a| a.name.local.as_slice() == name)
         };
 
         if dup {
             self.emit_error(Borrowed("Duplicate attribute"));
             self.current_attr_name.truncate(0);
-            self.current_attr_value.truncate(0);
+            self.current_attr_value.clear();
         } else {
-            let name = replace(&mut self.current_attr_name, String::new());
+            let name = Atom::from_slice(&self.current_attr_name);
+            self.current_attr_name.truncate(0);
             self.current_tag_attrs.push(Attribute {
                 // The tree builder will adjust the namespace if necessary.
                 // This only happens in foreign elements.
-                name: QualName::new(ns!(""), Atom::from_slice(name.as_slice())),
-                value: replace(&mut self.current_attr_value, empty_str()),
+                name: QualName::new(ns!(""), name),
+                value: replace(&mut self.current_attr_value, Tendril::new()),
             });
         }
     }
@@ -492,7 +494,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         self.process_token(DoctypeToken(doctype));
     }
 
-    fn doctype_id<'a>(&'a mut self, kind: DoctypeIdKind) -> &'a mut Option<String> {
+    fn doctype_id<'a>(&'a mut self, kind: DoctypeIdKind) -> &'a mut Option<Tendril> {
         match kind {
             Public => &mut self.current_doctype.public_id,
             System => &mut self.current_doctype.system_id,
@@ -502,8 +504,8 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
     fn clear_doctype_id(&mut self, kind: DoctypeIdKind) {
         let id = self.doctype_id(kind);
         match *id {
-            Some(ref mut s) => s.truncate(0),
-            None => *id = Some(empty_str()),
+            Some(ref mut s) => s.clear(),
+            None => *id = Some(Tendril::new()),
         }
     }
 
@@ -530,7 +532,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         assert!(c.is_some());
     }
 
-    fn unconsume(&mut self, buf: String) {
+    fn unconsume(&mut self, buf: Tendril) {
         self.input_buffers.push_front(buf);
     }
 
@@ -553,11 +555,11 @@ macro_rules! shorthand (
     ( $me:ident : create_attr $c:expr              ) => ( $me.create_attribute($c);                            );
     ( $me:ident : push_name $c:expr                ) => ( $me.current_attr_name.push($c);                      );
     ( $me:ident : push_value $c:expr               ) => ( $me.current_attr_value.push($c);                     );
-    ( $me:ident : append_value $c:expr             ) => ( append_strings(&mut $me.current_attr_value, $c);     );
+    ( $me:ident : append_value $c:expr             ) => ( $me.current_attr_value.push_tendril($c);             );
     ( $me:ident : push_comment $c:expr             ) => ( $me.current_comment.push($c);                        );
     ( $me:ident : append_comment $c:expr           ) => ( $me.current_comment.push_str($c);                    );
     ( $me:ident : emit_comment                     ) => ( $me.emit_current_comment();                          );
-    ( $me:ident : clear_comment                    ) => ( $me.current_comment.truncate(0);                     );
+    ( $me:ident : clear_comment                    ) => ( $me.current_comment.clear();                         );
     ( $me:ident : create_doctype                   ) => ( $me.current_doctype = Doctype::new();                );
     ( $me:ident : push_doctype_name $c:expr        ) => ( option_push(&mut $me.current_doctype.name, $c);      );
     ( $me:ident : push_doctype_id $k:ident $c:expr ) => ( option_push($me.doctype_id($k), $c);                 );
@@ -815,7 +817,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 let c = get_char!(self);
                 match c {
                     '\t' | '\n' | '\x0C' | ' ' | '/' | '>' => {
-                        let esc = if self.temp_buf.as_slice() == "script" { DoubleEscaped } else { Escaped };
+                        let esc = if &*self.temp_buf == "script" { DoubleEscaped } else { Escaped };
                         go!(self: emit c; to RawData ScriptDataEscaped esc);
                     }
                     _ => match lower_ascii_letter(c) {
@@ -865,7 +867,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 let c = get_char!(self);
                 match c {
                     '\t' | '\n' | '\x0C' | ' ' | '/' | '>' => {
-                        let esc = if self.temp_buf.as_slice() == "script" { Escaped } else { DoubleEscaped };
+                        let esc = if &*self.temp_buf == "script" { Escaped } else { DoubleEscaped };
                         go!(self: emit c; to RawData ScriptDataEscaped esc);
                     }
                     _ => match lower_ascii_letter(c) {
@@ -1344,47 +1346,27 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 mod test {
     use core::prelude::*;
     use collections::vec::Vec;
-    use collections::string::String;
-    use super::{option_push, append_strings}; // private items
+    use util::tendril::Tendril;
+    use super::{option_push}; // private items
 
     #[test]
     fn push_to_None_gives_singleton() {
-        let mut s: Option<String> = None;
+        let mut s: Option<Tendril> = None;
         option_push(&mut s, 'x');
-        assert_eq!(s, Some(String::from_str("x")));
+        assert_eq!(s, Some(Tendril::owned_copy("x")));
     }
 
     #[test]
     fn push_to_empty_appends() {
-        let mut s: Option<String> = Some(String::new());
+        let mut s: Option<Tendril> = Some(Tendril::new());
         option_push(&mut s, 'x');
-        assert_eq!(s, Some(String::from_str("x")));
+        assert_eq!(s, Some(Tendril::owned_copy("x")));
     }
 
     #[test]
     fn push_to_nonempty_appends() {
-        let mut s: Option<String> = Some(String::from_str("y"));
+        let mut s: Option<Tendril> = Some(Tendril::owned_copy("y"));
         option_push(&mut s, 'x');
-        assert_eq!(s, Some(String::from_str("yx")));
-    }
-
-    #[test]
-    fn append_appends() {
-        let mut s = String::from_str("foo");
-        append_strings(&mut s, String::from_str("bar"));
-        assert_eq!(s, String::from_str("foobar"));
-    }
-
-    #[test]
-    fn append_to_empty_does_not_copy() {
-        let mut lhs: String = String::from_str("");
-        let rhs: Vec<u8> = vec![b'f', b'o', b'o'];
-        let ptr_old = rhs[0] as *const u8;
-
-        append_strings(&mut lhs, String::from_utf8(rhs).unwrap());
-        assert_eq!(lhs, String::from_str("foo"));
-
-        let ptr_new = lhs.into_bytes()[0] as *const u8;
-        assert_eq!(ptr_old, ptr_new);
+        assert_eq!(s, Some(Tendril::owned_copy("yx")));
     }
 }

--- a/src/tree_builder/data.rs
+++ b/src/tree_builder/data.rs
@@ -12,6 +12,7 @@ use core::prelude::*;
 use tokenizer::Doctype;
 use tree_builder::interface::{QuirksMode, Quirks, LimitedQuirks, NoQuirks};
 use util::str::AsciiExt;
+use util::tendril::Tendril;
 
 use collections::string::String;
 
@@ -94,17 +95,24 @@ static HTML4_PUBLIC_PREFIXES: &'static [&'static str] = &[
 ];
 
 pub fn doctype_error_and_quirks(doctype: &Doctype, iframe_srcdoc: bool) -> (bool, QuirksMode) {
-    fn opt_as_slice<'t>(x: &'t Option<String>) -> Option<&'t str> {
+    fn opt_string_as_slice<'t>(x: &'t Option<String>) -> Option<&'t str> {
         x.as_ref().map(|y| y.as_slice())
+    }
+
+    fn opt_tendril_as_slice<'t>(x: &'t Option<Tendril>) -> Option<&'t str> {
+        match *x {
+            Some(ref t) => Some(t),
+            None => None,
+        }
     }
 
     fn opt_to_ascii_lower(x: Option<&str>) -> Option<String> {
         x.map(|y| y.to_ascii_lower())
     }
 
-    let name = opt_as_slice(&doctype.name);
-    let public = opt_as_slice(&doctype.public_id);
-    let system = opt_as_slice(&doctype.system_id);
+    let name = opt_tendril_as_slice(&doctype.name);
+    let public = opt_tendril_as_slice(&doctype.public_id);
+    let system = opt_tendril_as_slice(&doctype.system_id);
 
     let err = match (name, public, system) {
           (Some("html"), None, None)
@@ -130,7 +138,7 @@ pub fn doctype_error_and_quirks(doctype: &Doctype, iframe_srcdoc: bool) -> (bool
     let public = opt_to_ascii_lower(public);
     let system = opt_to_ascii_lower(system);
 
-    let quirk = match (opt_as_slice(&public), opt_as_slice(&system)) {
+    let quirk = match (opt_string_as_slice(&public), opt_string_as_slice(&system)) {
         _ if doctype.force_quirks => Quirks,
         _ if name != Some("html") => Quirks,
 

--- a/src/tree_builder/interface.rs
+++ b/src/tree_builder/interface.rs
@@ -15,10 +15,11 @@ use core::prelude::*;
 use tokenizer::Attribute;
 
 use collections::vec::Vec;
-use collections::string::String;
 use std::borrow::Cow;
 
 use string_cache::QualName;
+
+use util::tendril::Tendril;
 
 pub use self::QuirksMode::{Quirks, LimitedQuirks, NoQuirks};
 pub use self::NodeOrText::{AppendNode, AppendText};
@@ -37,7 +38,7 @@ pub enum QuirksMode {
 /// the sink may not want to allocate a `Handle` for each.
 pub enum NodeOrText<Handle> {
     AppendNode(Handle),
-    AppendText(String),
+    AppendText(Tendril),
 }
 
 /// Types which can process tree modifications from the tree builder.
@@ -69,7 +70,7 @@ pub trait TreeSink {
     fn create_element(&mut self, name: QualName, attrs: Vec<Attribute>) -> Self::Handle;
 
     /// Create a comment node.
-    fn create_comment(&mut self, text: String) -> Self::Handle;
+    fn create_comment(&mut self, text: Tendril) -> Self::Handle;
 
     /// Append a node as the last child of the given node.  If this would
     /// produce adjacent sibling text nodes, it should concatenate the text
@@ -92,7 +93,7 @@ pub trait TreeSink {
         new_node: NodeOrText<Self::Handle>) -> Result<(), NodeOrText<Self::Handle>>;
 
     /// Append a `DOCTYPE` element to the `Document` node.
-    fn append_doctype_to_document(&mut self, name: String, public_id: String, system_id: String);
+    fn append_doctype_to_document(&mut self, name: Tendril, public_id: Tendril, system_id: Tendril);
 
     /// Add each attribute to the given element, if no attribute
     /// with that name already exists.

--- a/src/tree_builder/rules.rs
+++ b/src/tree_builder/rules.rs
@@ -20,12 +20,12 @@ use tokenizer::{Tag, StartTag, EndTag};
 use tokenizer::states::{Rcdata, Rawtext, ScriptData, Plaintext};
 
 use util::str::is_ascii_whitespace;
+use util::tendril::Tendril;
 
 use core::mem::replace;
-use collections::string::String;
 use std::borrow::Cow::Borrowed;
 
-fn any_not_whitespace(x: &String) -> bool {
+fn any_not_whitespace(x: &Tendril) -> bool {
     // FIXME: this might be much faster as a byte scan
     x.as_slice().chars().any(|c| !is_ascii_whitespace(c))
 }

--- a/src/tree_builder/types.rs
+++ b/src/tree_builder/types.rs
@@ -11,9 +11,8 @@
 
 use core::prelude::*;
 
+use util::tendril::Tendril;
 use tokenizer::Tag;
-
-use collections::string::String;
 
 pub use self::InsertionMode::*;
 pub use self::SplitStatus::*;
@@ -60,8 +59,8 @@ pub enum SplitStatus {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum Token {
     TagToken(Tag),
-    CommentToken(String),
-    CharacterTokens(SplitStatus, String),
+    CommentToken(Tendril),
+    CharacterTokens(SplitStatus, Tendril),
     NullCharacterToken,
     EOFToken,
 }
@@ -69,7 +68,7 @@ pub enum Token {
 pub enum ProcessResult {
     Done,
     DoneAckSelfClosing,
-    SplitWhitespace(String),
+    SplitWhitespace(Tendril),
     Reprocess(InsertionMode, Token),
 }
 

--- a/src/util/smallcharset.rs
+++ b/src/util/smallcharset.rs
@@ -24,7 +24,7 @@ impl SmallCharSet {
     /// Count the number of bytes of characters at the beginning
     /// of `buf` which are not in the set.
     /// See `tokenizer::buffer_queue::pop_except_from`.
-    pub fn nonmember_prefix_len(&self, buf: &str) -> usize {
+    pub fn nonmember_prefix_len(&self, buf: &str) -> u32 {
         let mut n = 0;
         for b in buf.bytes() {
             if b >= 64 || !self.contains(b) {
@@ -52,11 +52,11 @@ mod test {
     #[test]
     fn nonmember_prefix() {
         for &c in ['&', '\0'].iter() {
-            for x in 0 .. 48usize {
-                for y in 0 .. 48usize {
-                    let mut s = repeat("x").take(x).collect::<String>();
+            for x in 0 .. 48u32 {
+                for y in 0 .. 48u32 {
+                    let mut s = repeat("x").take(x as usize).collect::<String>();
                     s.push(c);
-                    s.push_str(repeat("x").take(y).collect::<String>().as_slice());
+                    s.push_str(repeat("x").take(y as usize).collect::<String>().as_slice());
                     let set = small_char_set!('&' '\0');
 
                     assert_eq!(x, set.nonmember_prefix_len(s.as_slice()));

--- a/src/util/tendril.rs
+++ b/src/util/tendril.rs
@@ -1,0 +1,922 @@
+// Copyright 2015 The html5ever Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::prelude::v1::*;
+
+use std::{mem, fmt, io, str, slice};
+use std::raw::{self, Repr};
+use std::ops::Deref;
+use std::cmp::Ordering;
+use std::error::FromError;
+
+use iobuf::{Iobuf, ROIobuf, RWIobuf};
+
+use util::str::AsciiCast;
+
+use self::Tendril_::{Shared, Owned, Ascii};
+
+#[derive(Clone)]
+enum Tendril_ {
+    Shared(ROIobuf<'static>),
+    Ascii(u8),
+    Owned(String),
+}
+
+/// html5ever's abstraction of strings.
+///
+/// A tendril either owns its content, or is a slice of a shared buffer.
+/// These buffers are managed with non-atomic (thread-local) reference
+/// counting, which is very fast.
+///
+/// Like `String`, `Tendril` implements `Deref<Target = str>`. So you can
+/// call string slice methods on `Tendril`, or pass `&Tendril` to a function
+/// expecting `&str`.
+///
+/// Accordingly, the content of a tendril is guaranteed to be valid UTF-8.
+/// Take particular care of this when calling `unsafe` functions below!
+///
+/// The maximum size of a tendril is 1 GB. The safe methods below will
+/// `panic!` if a tendril grows beyond that size.
+#[derive(Clone)]
+pub struct Tendril(Tendril_);
+
+impl PartialEq for Tendril {
+    #[inline]
+    fn eq(&self, other: &Tendril) -> bool {
+        &**self == &**other
+    }
+
+    #[inline]
+    fn ne(&self, other: &Tendril) -> bool {
+        &**self != &**other
+    }
+}
+
+impl Eq for Tendril { }
+
+impl PartialOrd for Tendril {
+    #[inline]
+    fn partial_cmp(&self, other: &Tendril) -> Option<Ordering> {
+        (&**self).partial_cmp(other)
+    }
+}
+
+impl Ord for Tendril {
+    #[inline]
+    fn cmp(&self, other: &Tendril) -> Ordering {
+        (&**self).cmp(other)
+    }
+}
+
+impl fmt::Display for Tendril {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        <str as fmt::Display>::fmt(&*self, fmt)
+    }
+}
+
+impl fmt::Debug for Tendril {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(fmt, "Tendril[{}](", match self.0 {
+            Shared(_) => "shared",
+            Ascii(_) => "ascii",
+            Owned(_) => "owned",
+        }));
+        try!(<str as fmt::Debug>::fmt(&*self, fmt));
+        try!(write!(fmt, ")"));
+        Ok(())
+    }
+}
+
+impl Deref for Tendril {
+    type Target = str;
+
+    #[inline]
+    fn deref<'a>(&'a self) -> &'a str {
+        match self.0 {
+            Shared(ref s) => unsafe {
+                mem::transmute(s.as_window_slice())
+            },
+            Owned(ref s) => s,
+            Ascii(ref b) => unsafe {
+                str::from_utf8_unchecked(slice::ref_slice(b))
+            },
+        }
+    }
+}
+
+/// Interpret the slice as a single ASCII codepoint, if possible.
+#[inline(always)]
+fn as_single_ascii(x: &str) -> Option<u8> {
+    // &str is always valid UTF-8, so a one-byte &str must contain
+    // an ASCII character.
+    if x.len() == 1 {
+        Some(unsafe { *x.as_bytes().get_unchecked(0) })
+    } else {
+        None
+    }
+}
+
+/// The maximum size of a tendril is 1 GB.
+pub const TENDRIL_MAX_LEN: u32 = 1 << 30;
+
+impl Tendril {
+    /// Create a new, empty tendril.
+    #[inline]
+    pub fn new() -> Tendril {
+        Tendril(Owned(String::new()))
+    }
+
+    /// Create a tendril from any `IntoTendril` type.
+    #[inline]
+    pub fn from<T>(x: T) -> Tendril
+        where T: IntoTendril,
+    {
+        x.into_tendril()
+    }
+
+    /// Create a tendril from a character.
+    #[inline]
+    pub fn from_char(c: char) -> Tendril {
+        let n = c as usize;
+        if n < 0x80 {
+            Tendril(Ascii(n as u8))
+        } else {
+            Tendril(Owned(c.to_string()))
+        }
+    }
+
+    /// Create a tendril from a `String`, without copying.
+    #[inline]
+    pub fn owned(s: String) -> Tendril {
+        assert!(s.len() < (1 << 31));
+        Tendril(Owned(s))
+    }
+
+    /// Copy a string to create a tendril which owns its content.
+    #[inline]
+    pub fn owned_copy(s: &str) -> Tendril {
+        if let Some(n) = as_single_ascii(s) {
+            Tendril(Ascii(n))
+        } else {
+            Tendril(Owned(String::from_str(s)))
+        }
+    }
+
+    /// Copy a string to create a shared buffer which multiple
+    /// tendrils can point into.
+    ///
+    /// See also `subtendril`.
+    #[inline]
+    pub fn shared_copy(s: &str) -> Tendril {
+        Tendril(Shared(ROIobuf::from_str_copy(s)))
+    }
+
+    /// Does this tendril point into a shared buffer?
+    #[inline]
+    pub fn is_shared(&self) -> bool {
+        match self.0 {
+            Shared(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Get the length of the tendril.
+    #[inline]
+    pub fn len32(&self) -> u32 {
+        match self.0 {
+            Shared(ref b) => b.len(),
+            Owned(ref s) => s.len() as u32,
+            Ascii(_) => 1,
+        }
+    }
+
+    /// Count how many bytes at the beginning of the tendril
+    /// either all match or all don't match the predicate,
+    /// and also return whether they match.
+    ///
+    /// Returns `None` on an empty string.
+    pub fn char_run<Pred>(&self, mut pred: Pred) -> Option<(u32, bool)>
+        where Pred: FnMut(char) -> bool,
+    {
+        let (first, rest) = unwrap_or_return!(self.slice_shift_char(), None);
+        let matches = pred(first);
+
+        for (idx, ch) in rest.char_indices() {
+            if matches != pred(ch) {
+                return Some(((idx + first.len_utf8()) as u32, matches));
+            }
+        }
+        Some((self.len32(), matches))
+    }
+
+    /// Promotes the tendril to owning its content, and get a
+    /// mutable reference.
+    ///
+    /// This is unsafe because the user must not exceed the 1 GB
+    /// size limit!
+    #[inline]
+    unsafe fn to_mut<'a>(&'a mut self) -> &'a mut String {
+        match self.0 {
+            Owned(ref mut s) => return s,
+            _ => (),
+        }
+
+        self.0 = Owned(String::from_str(self));
+        match self.0 {
+            Owned(ref mut s) => s,
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    fn check_len(&self) {
+        if self.len() > TENDRIL_MAX_LEN as usize {
+            panic!("tendril exceeded 1 GB");
+        }
+    }
+
+    /// Push a character onto the end of the tendril.
+    #[inline]
+    pub fn push(&mut self, c: char) {
+        if self.is_empty() {
+            if let Some(a) = c.to_ascii_opt() {
+                self.0 = Ascii(a.to_u8());
+                return;
+            }
+        }
+        unsafe {
+            self.to_mut().push(c);
+        }
+        self.check_len();
+    }
+
+    /// Push a string onto the end of the tendril.
+    #[inline]
+    pub fn push_str(&mut self, rhs: &str) {
+        match rhs.len() {
+            0 => return,
+            1 if self.is_empty() => {
+                if let Some(n) = as_single_ascii(rhs) {
+                    self.0 = Ascii(n);
+                    return;
+                }
+            }
+            n if n > TENDRIL_MAX_LEN as usize => {
+                panic!("attempted to extend tendril by more than 1 GB");
+            }
+
+            // Otherwise, 2 * TENDRIL_MAX_LEN does not overflow u32.
+            _ => (),
+        }
+        unsafe {
+            self.to_mut().push_str(rhs);
+        }
+        self.check_len();
+    }
+
+    /// Push another tendril onto the end of the tendril.
+    #[inline]
+    pub fn push_tendril(&mut self, rhs: Tendril) {
+        if rhs.is_empty() {
+            return;
+        }
+
+        if self.is_empty() {
+            *self = rhs;
+            return;
+        }
+
+        // Try to merge adjacent Iobufs.
+        if let (&mut Tendril(Shared(ref mut a)), &Tendril(Shared(ref b)))
+            = (&mut *self, &rhs)
+        {
+            if a.extend_with(b).is_ok() {
+                return;
+            }
+        }
+
+        if rhs.len() > TENDRIL_MAX_LEN as usize{
+            panic!("attempted to extend tendril by more than 1 GB");
+        }
+
+        // Slow path: copy on write.
+        unsafe {
+            self.to_mut().push_str(&rhs);
+        }
+        self.check_len();
+    }
+
+    /// Truncate the tendril to an empty tendril, without discarding allocations.
+    #[inline]
+    pub fn clear(&mut self) {
+        if let Owned(ref mut s) = self.0 {
+            s.truncate(0);
+            return;
+        }
+        self.0 = Owned(String::new());
+    }
+
+    /// Remove the front character, if it's `\n`.
+    #[inline]
+    pub fn pop_front_lf(&mut self) {
+        match self.0 {
+            Ascii(b'\n') => *self = Tendril::new(),
+            Ascii(_) => (),
+            Owned(ref mut s) => {
+                if s.starts_with("\n") {
+                    s.remove(0);
+                }
+            }
+            Shared(ref mut b) => unsafe {
+                if b.unsafe_peek_le(0) == b'\n' {
+                    b.unsafe_sub_window_from(1);
+                }
+            }
+        }
+    }
+
+    /// Slice a tendril.
+    ///
+    /// The new tendril encompasses bytes in the index range `[from, to)`.
+    ///
+    /// If possible, the new and old tendrils point into the same shared
+    /// buffer.
+    ///
+    /// This method is `unsafe` because neither bounds checking nor UTF-8
+    /// validity checking is guaranteed. If you violate these properties
+    /// then all bets are off!
+    ///
+    /// html5ever uses `subtendril` in certain fast paths, just after
+    /// finding a character boundary with a byte-wise scan.
+    #[inline]
+    pub unsafe fn subtendril(&self, from: u32, to: u32) -> Tendril {
+        match *self {
+            Tendril(Shared(ref a)) => {
+                let mut b = a.clone();
+                b.unsafe_sub_window(from, to - from);
+                Tendril(Shared(b))
+            }
+            _ => {
+                let b = self.slice_unchecked(from as usize, to as usize);
+                Tendril::owned_copy(b)
+            }
+        }
+    }
+}
+
+/// Types which can be converted into a `Tendril`.
+///
+/// The `Tendril` and `String` instances avoid copying the string data.
+/// The other instances copy into a new owned buffer.
+pub trait IntoTendril {
+    fn into_tendril(self) -> Tendril;
+}
+
+impl IntoTendril for Tendril {
+    #[inline(always)]
+    fn into_tendril(self) -> Tendril {
+        self
+    }
+}
+
+impl IntoTendril for String {
+    #[inline(always)]
+    fn into_tendril(self) -> Tendril {
+        Tendril::owned(self)
+    }
+}
+
+impl<'a> IntoTendril for &'a str {
+    #[inline(always)]
+    fn into_tendril(self) -> Tendril {
+        Tendril::owned_copy(self)
+    }
+}
+
+impl IntoTendril for char {
+    #[inline(always)]
+    fn into_tendril(self) -> Tendril {
+        Tendril::from_char(self)
+    }
+}
+
+// Be very careful about overflow if you plan to use these functions in another context!
+#[inline(always)]
+unsafe fn unsafe_slice<'a>(buf: &'a [u8], from: u32, to: u32) -> &'a [u8] {
+    let raw::Slice { data, len } = buf.repr();
+    debug_assert!((from as usize) < len);
+    debug_assert!((to as usize) <= len);
+    slice::from_raw_parts(data.offset(from as isize), (to - from) as usize)
+}
+
+#[inline(always)]
+unsafe fn unsafe_slice_mut<'a>(buf: &'a mut [u8], from: u32, to: u32) -> &'a mut [u8] {
+    let raw::Slice { data, len } = buf.repr();
+    debug_assert!((from as usize) < len);
+    debug_assert!((to as usize) <= len);
+    slice::from_raw_parts_mut(data.offset(from as isize) as *mut u8, (to - from) as usize)
+}
+
+// Return the number of bytes at the end of the buffer that make up an incomplete
+// but possibly valid UTF-8 character.
+//
+// This does *not* check UTF-8 validity. Rather it's used to defer
+// validity checking for the last few bytes of a buffer, when appropriate.
+// However, it's safe to call on arbitrary byte buffers.
+#[inline(always)]
+fn incomplete_trailing_utf8(buf: &[u8]) -> u32 {
+    let n = buf.len();
+    if n < 1 { return 0; }
+
+    // There are four patterns of valid-but-incomplete UTF-8:
+    //
+    //                   ... 110xxxxx
+    //          ... 1110xxxx 10xxxxxx
+    //          ... 11110xxx 10xxxxxx
+    // ... 11110xxx 10xxxxxx 10xxxxxx
+
+    #[inline(always)] fn is_cont(v: u8) -> bool    { v & 0b11_000000 == 0b10_000000 }
+    #[inline(always)] fn is_start(v: u8) -> bool   { v & 0b11_000000 == 0b11_000000 }
+    #[inline(always)] fn is_start_3(v: u8) -> bool { v & 0b1111_0000 == 0b1110_0000 }
+    #[inline(always)] fn is_start_4(v: u8) -> bool { v & 0b11111_000 == 0b11110_000 }
+
+    unsafe {
+        let c = *buf.get_unchecked(n-1);
+        if is_start(c) { return 1; }
+
+        if is_cont(c) {
+            if n <= 1 { return 0; }
+            let b = *buf.get_unchecked(n-2);
+            if is_start_3(b) || is_start_4(b) { return 2; }
+
+            if is_cont(b) {
+                if n <= 2 { return 0; }
+                let a = *buf.get_unchecked(n-3);
+                if is_start_4(a) { return 3; }
+            }
+        }
+    }
+
+    0
+}
+
+/// Iterator which produces tendrils by reading an input stream.
+///
+/// The tendrils will be backed by shared buffers. They support
+/// slicing via `.subtendril()` without a copy.
+pub struct TendrilReader<R> {
+    dead: bool,
+    chunk_size: u32,
+    leftover: (u32, [u8; 3]),
+    reader: R,
+}
+
+impl<R> TendrilReader<R>
+    where R: io::Read,
+{
+    /// Read a UTF-8 input stream as a sequence of tendrils (or errors).
+    ///
+    /// Each read will attempt to fill a buffer of `chunk_size` bytes.
+    ///
+    /// # Panics
+    ///
+    /// If `chunk_size` is less than 4 bytes or greater than 1 GB.
+    #[inline]
+    pub fn from_utf8(chunk_size: u32, reader: R) -> TendrilReader<R> {
+        // A chunk must be big enough to hold any UTF-8 character.
+        // Also it must be small enough to fit in an Iobuf.
+        // 1GB is only halfway to the Iobuf limit, so we don't worry
+        // about going a few bytes over, e.g. when handling leftover
+        // UTF-8 bytes.
+        assert!(chunk_size >= 4);
+        assert!(chunk_size <= TENDRIL_MAX_LEN);
+        TendrilReader {
+            dead: false,
+            chunk_size: chunk_size,
+            reader: reader,
+            leftover: (0, [0; 3]),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum TendrilReaderError {
+    IoError(io::Error),
+    Utf8Error(str::Utf8Error),
+}
+
+impl FromError<io::Error> for TendrilReaderError {
+    #[inline]
+    fn from_error(err: io::Error) -> TendrilReaderError {
+        TendrilReaderError::IoError(err)
+    }
+}
+
+impl FromError<str::Utf8Error> for TendrilReaderError {
+    #[inline]
+    fn from_error(err: str::Utf8Error) -> TendrilReaderError {
+        TendrilReaderError::Utf8Error(err)
+    }
+}
+
+impl<R> Iterator for TendrilReader<R>
+    where R: io::Read,
+{
+    type Item = Result<Tendril, TendrilReaderError>;
+
+    fn next(&mut self) -> Option<Result<Tendril, TendrilReaderError>> {
+        if self.dead {
+            return None;
+        }
+
+        let mut buf = RWIobuf::new(self.chunk_size as usize);
+
+        // Copy some leftover bytes from a previous incomplete character,
+        // if any.
+        let mut size = match self.leftover {
+            (0, _) => 0,
+            (ref mut n, ref pfx) => {
+                debug_assert!(*n <= 3);
+                unsafe {
+                    // chunk_size >= 4, which is checked in the
+                    // TendrilReader constructor.
+                    buf.unsafe_poke(0, unsafe_slice(pfx, 0, *n));
+                }
+                mem::replace(n, 0)
+            }
+        };
+
+        unsafe {
+            if size < self.chunk_size {
+                let dest = unsafe_slice_mut(buf.as_mut_window_slice(), size, self.chunk_size);
+                match self.reader.read(dest) {
+                    Err(e) => return Some(Err(TendrilReaderError::from_error(e))),
+
+                    Ok(0) => {
+                        // EOF
+                        self.dead = true;
+                        return match size {
+                            0 => None,
+                            _ => Some(Err(TendrilReaderError::from_error(str::Utf8Error::TooShort))),
+                        };
+                    }
+
+                    Ok(n) => size += n as u32,
+                }
+            }
+
+            // Trim the window to exclude uninitialized bytes, and set the
+            // limit to forbid un-doing this.
+            buf.unsafe_sub_to(size);
+
+            // Defer validity checking for the bytes making up an incomplete
+            // UTF-8 character at the end, if any.
+            let tail_len = incomplete_trailing_utf8(buf.as_window_slice());
+            if tail_len > 0 {
+                let rest = size - tail_len;
+                self.leftover.0 = tail_len;
+                buf.unsafe_peek(rest, unsafe_slice_mut(&mut self.leftover.1, 0, tail_len));
+                buf.unsafe_sub_window_to(rest);
+            }
+
+            // Check UTF-8 validity for the remaining buffer.
+            match str::from_utf8(buf.as_window_slice()) {
+                Err(e) => Some(Err(TendrilReaderError::from_error(e))),
+                Ok(_) => Some(Ok(Tendril(Shared(buf.read_only())))),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::prelude::v1::*;
+    use std::{io, cmp};
+    use std::slice::bytes;
+
+    use util::str::is_ascii_whitespace;
+
+    use super::{Tendril, Tendril_, TendrilReader, incomplete_trailing_utf8};
+
+    #[test]
+    fn tendril_create() {
+        assert_eq!("", &*Tendril::new());
+
+        for s in &["", "foo", "zzzzzzzzzzzzzzzzz", "fooő", "ꙮ"] {
+            assert_eq!(*s, &*Tendril::owned(String::from_str(s)));
+            assert_eq!(*s, &*Tendril::owned_copy(s));
+            assert_eq!(*s, &*Tendril::shared_copy(s));
+        }
+    }
+
+    #[test]
+    fn tendril_from() {
+        assert_eq!("x", &*Tendril::from('x'));
+        assert_eq!("xyz", &*Tendril::from("xyz"));
+        assert_eq!("xyz", &*Tendril::from(String::from_str("xyz")));
+        assert_eq!("xyz", &*Tendril::from(Tendril::from("xyz")));
+    }
+
+    #[test]
+    fn tendril_eq() {
+        assert_eq!(Tendril::owned_copy("foo"), Tendril::owned_copy("foo"));
+        assert_eq!(Tendril::owned_copy("foo"), Tendril::shared_copy("foo"));
+        assert_eq!(Tendril::shared_copy("foo"), Tendril::shared_copy("foo"));
+        assert!(Tendril::owned_copy("foo") != Tendril::owned_copy("bar"));
+        assert!(Tendril::owned_copy("foo") != Tendril::shared_copy("bar"));
+        assert!(Tendril::shared_copy("foo") != Tendril::shared_copy("bar"));
+    }
+
+    #[test]
+    fn tendril_partial_ord() {
+        assert!(Tendril::owned_copy("foo") > Tendril::owned_copy("bar"));
+        assert!(Tendril::owned_copy("foo") > Tendril::shared_copy("bar"));
+        assert!(Tendril::shared_copy("foo") > Tendril::shared_copy("bar"));
+        assert!(Tendril::owned_copy("bar") < Tendril::owned_copy("foo"));
+        assert!(Tendril::owned_copy("bar") < Tendril::shared_copy("foo"));
+        assert!(Tendril::shared_copy("bar") < Tendril::shared_copy("foo"));
+    }
+
+    macro_rules! test_char_run ( ($name:ident, $input:expr, $expect:expr) => (
+        test_eq!($name, Tendril::owned_copy($input).char_run(is_ascii_whitespace), $expect);
+    ));
+
+    test_char_run!(run_empty, "", None);
+    test_char_run!(run_one_t, " ", Some((1, true)));
+    test_char_run!(run_one_f, "x", Some((1, false)));
+    test_char_run!(run_t, "  \t  \n", Some((6, true)));
+    test_char_run!(run_f, "xyzzy", Some((5, false)));
+    test_char_run!(run_tf, "   xyzzy", Some((3, true)));
+    test_char_run!(run_ft, "xyzzy   ", Some((5, false)));
+    test_char_run!(run_tft, "   xyzzy  ", Some((3, true)));
+    test_char_run!(run_ftf, "xyzzy   hi", Some((5, false)));
+    test_char_run!(run_multibyte_0, "中 ", Some((3, false)));
+    test_char_run!(run_multibyte_1, " 中 ", Some((1, true)));
+    test_char_run!(run_multibyte_2, "  中 ", Some((2, true)));
+    test_char_run!(run_multibyte_3, "   中 ", Some((3, true)));
+
+    #[test]
+    fn push() {
+        let mut t = Tendril::owned_copy("foo");
+        t.push('x');
+        assert_eq!("foox", &*t);
+        t.push('y');
+        assert_eq!("fooxy", &*t);
+
+        let mut t = Tendril::shared_copy("foo");
+        t.push('x');
+        assert_eq!("foox", &*t);
+        t.push('y');
+        assert_eq!("fooxy", &*t);
+    }
+
+    #[test]
+    fn push_str() {
+        let mut t = Tendril::owned_copy("foo");
+        t.push_str("xy");
+        assert_eq!("fooxy", &*t);
+        t.push_str("ab");
+        assert_eq!("fooxyab", &*t);
+
+        let mut t = Tendril::shared_copy("foo");
+        t.push_str("xy");
+        assert_eq!("fooxy", &*t);
+        t.push_str("ab");
+        assert_eq!("fooxyab", &*t);
+    }
+
+    #[test]
+    fn push_tendril_simple() {
+        let mut t = Tendril::owned_copy("foo");
+        t.push_tendril(Tendril::owned_copy("xy"));
+        assert_eq!("fooxy", &*t);
+        t.push_tendril(Tendril::owned_copy("ab"));
+        assert_eq!("fooxyab", &*t);
+
+        let mut t = Tendril::owned_copy("foo");
+        t.push_tendril(Tendril::shared_copy("xy"));
+        assert_eq!("fooxy", &*t);
+        t.push_tendril(Tendril::owned_copy("ab"));
+        assert_eq!("fooxyab", &*t);
+
+        let mut t = Tendril::shared_copy("foo");
+        t.push_tendril(Tendril::owned_copy("xy"));
+        assert_eq!("fooxy", &*t);
+        t.push_tendril(Tendril::shared_copy("ab"));
+        assert_eq!("fooxyab", &*t);
+
+        let mut t = Tendril::shared_copy("foo");
+        t.push_tendril(Tendril::shared_copy("xy"));
+        assert_eq!("fooxy", &*t);
+        t.push_tendril(Tendril::shared_copy("ab"));
+        assert_eq!("fooxyab", &*t);
+    }
+
+    #[test]
+    fn push_tendril_share() {
+        let mut x = Tendril::new();
+        x.push_tendril(Tendril::shared_copy("foo"));
+        assert!(x.is_shared());
+
+        let mut x = Tendril::owned_copy("");
+        x.push_tendril(Tendril::shared_copy("foo"));
+        assert!(x.is_shared());
+
+        let mut x = Tendril::shared_copy("foo");
+        x.push_str("");
+        assert!(x.is_shared());
+
+        let mut x = Tendril::shared_copy("foo");
+        x.push_tendril(Tendril::owned_copy(""));
+        assert!(x.is_shared());
+
+        let mut x = Tendril::shared_copy("foo");
+        x.push_tendril(Tendril::shared_copy(""));
+        assert!(x.is_shared());
+    }
+
+    #[test]
+    fn pop_front_lf() {
+        let mut t = Tendril::new();
+        t.pop_front_lf();
+        assert_eq!("", &*t);
+
+        let mut t = Tendril(Tendril_::Ascii(b'\n'));
+        t.pop_front_lf();
+        assert_eq!("", &*t);
+
+        let mut t = Tendril(Tendril_::Ascii(b'x'));
+        t.pop_front_lf();
+        assert_eq!("x", &*t);
+
+        let mut t = Tendril::owned_copy("\n");
+        t.pop_front_lf();
+        assert_eq!("", &*t);
+
+        let mut t = Tendril::owned_copy("\nfoo");
+        t.pop_front_lf();
+        assert_eq!("foo", &*t);
+
+        let mut t = Tendril::owned_copy("foo");
+        t.pop_front_lf();
+        assert_eq!("foo", &*t);
+
+        let mut t = Tendril::shared_copy("\n");
+        t.pop_front_lf();
+        assert_eq!("", &*t);
+
+        let mut t = Tendril::shared_copy("\nfoo");
+        t.pop_front_lf();
+        assert_eq!("foo", &*t);
+
+        let mut t = Tendril::shared_copy("foo");
+        t.pop_front_lf();
+        assert_eq!("foo", &*t);
+    }
+
+    // FIXME: Test the coalescing of adjacent shared tendrils.
+
+    #[test]
+    fn clear() {
+        let mut x = Tendril::owned_copy("foo");
+        x.clear();
+        assert!(x.is_empty());
+
+        let mut x = Tendril::shared_copy("foo");
+        x.clear();
+        assert!(x.is_empty());
+    }
+
+    #[test]
+    fn subtendril() {
+        let x = Tendril::owned_copy("foo");
+        let s = unsafe { x.subtendril(0, 1) };
+        assert_eq!("f", &*s);
+
+        let x = Tendril::shared_copy("foo");
+        let s = unsafe { x.subtendril(0, 1) };
+        assert_eq!("f", &*s);
+        assert!(s.is_shared());
+
+        let x = Tendril::shared_copy("\u{a66e}of");
+        let s = unsafe { x.subtendril(0, 4) };
+        assert_eq!("\u{a66e}o", &*s);
+        assert!(s.is_shared());
+    }
+
+    // FIXME: Test scenarios where a tendril grows past the size limit.
+
+    #[test]
+    fn test_complete_trailing_utf8() {
+        fn test(x: &str) {
+            assert_eq!(0, incomplete_trailing_utf8(x.as_bytes()));
+        }
+
+        test("foobar");
+        test("fooő");
+        test("foo\u{a66e}");
+        test("foo\u{1f4a9}");
+    }
+
+    #[test]
+    fn test_incomplete_trailing_utf8() {
+        assert_eq!(1, incomplete_trailing_utf8(b"foo\xC5"));
+        assert_eq!(1, incomplete_trailing_utf8(b"foo\xEA"));
+        assert_eq!(2, incomplete_trailing_utf8(b"foo\xEA\x99"));
+        assert_eq!(1, incomplete_trailing_utf8(b"foo\xF0"));
+        assert_eq!(2, incomplete_trailing_utf8(b"foo\xF0\x9F"));
+        assert_eq!(3, incomplete_trailing_utf8(b"foo\xF0\x9F\x92"));
+    }
+
+    struct SliceChunks<'a> {
+        slice: &'a [u8],
+        idx: usize,
+        chunk_size: usize,
+    }
+
+    impl<'a> io::Read for SliceChunks<'a> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let len = cmp::min(cmp::min(self.chunk_size, buf.len()),
+                               self.slice.len() - self.idx);
+            if len == 0 { return Ok(0); }
+            let src = &self.slice[self.idx..][..len];
+            bytes::copy_memory(buf, src);
+            self.idx += len;
+            Ok(src.len())
+        }
+    }
+
+    fn test_tendril_reader(input: &str) {
+        let mut chunk_sizes = vec![1, 2, 3, 4, 5, 6, 8, 15, 16, 17, 63, 64, 65, 255, 256, 257];
+        if input.len() >= 5 {
+            chunk_sizes.push(input.len() - 1);
+            chunk_sizes.push(input.len());
+            chunk_sizes.push(input.len() + 1);
+        }
+
+        for &source_chunk_size in &chunk_sizes {
+            for &tendril_buf_size in &chunk_sizes {
+                if tendril_buf_size < 4 { continue; }
+
+                let reader = SliceChunks {
+                    slice: input.as_bytes(),
+                    idx: 0,
+                    chunk_size: source_chunk_size,
+                };
+
+                let mut result = String::new();
+                for tendril in TendrilReader::from_utf8(tendril_buf_size as u32, reader) {
+                    let tendril = tendril.unwrap();
+                    result.push_str(&tendril);
+                }
+
+                assert_eq!(input, &*result);
+            }
+        }
+    }
+
+    macro_rules! test_tendril_reader {
+        ($( $n:ident => $e:expr, )*) => {$(
+            #[test]
+            fn $n() {
+                test_tendril_reader($e);
+            }
+        )*}
+    }
+
+    test_tendril_reader! {
+        reader_smoke_test => "Hello, world!",
+
+        udhr_en => "All human beings are born free and equal in dignity and rights.
+                    They are endowed with reason and conscience and should act
+                    towards one another in a spirit of brotherhood.",
+
+        udhr_hu => "Minden emberi lény szabadon születik és egyenlő méltósága és
+                    joga van. Az emberek, ésszel és lelkiismerettel bírván,
+                    egymással szemben testvéri szellemben kell hogy viseltessenek.",
+
+        udhr_th => "เราทุกคนเกิดมาอย่างอิสระ เราทุกคนมีความคิดและความเข้าใจเป็นของเราเอง
+                    เราทุกคนควรได้รับการปฏิบัติในทางเดียวกัน.",
+
+        udhr_kr => "모든 인간은 태어날 때부터 자유로우며 그 존엄과 권리에 있어
+                    동등하다. 인간은 천부적으로 이성과 양심을 부여받았으며 서로
+                    형제애의 정신으로 행동하여야 한다.",
+
+        udhr_jbo => "ro remna cu se jinzi co zifre je simdu'i be le ry. nilselsi'a
+                     .e lei ry. selcru .i ry. se menli gi'e se sezmarde .i .ei
+                     jeseki'ubo ry. simyzu'e ta'i le tunba",
+
+        udhr_chr => "ᏂᎦᏓ ᎠᏂᏴᏫ ᏂᎨᎫᏓᎸᎾ ᎠᎴ ᎤᏂᏠᏱ ᎤᎾᏕᎿ ᏚᏳᎧᏛ ᎨᏒᎢ. ᎨᏥᏁᎳ ᎤᎾᏓᏅᏖᏗ ᎠᎴ ᎤᏃᏟᏍᏗ
+                     ᎠᎴ ᏌᏊ ᎨᏒ ᏧᏂᎸᏫᏍᏓᏁᏗ ᎠᎾᏟᏅᏢ ᎠᏓᏅᏙ ᎬᏗ.",
+    }
+
+    // FIXME: test TendrilReader error handling
+}


### PR DESCRIPTION
This is based on #60 but with substantial changes. The biggest difference is that we only use shared buffers for the character runs found by `pop_except_from`. The majority of the remaining spans are single ASCII characters, which have their own fast path. Everything else is a `String` as before.

This branch also drops many of the micro-optimizations from #60. Unlike that PR, we leave the parser rules alone for the most part.

r? @Manishearth or @SimonSapin (general review)

r? @cgaebel (iobuf usage in `tendril.rs`)

Depending on the specific content and the I/O chunk size, this branch speeds up tokenization by up to a few percent. I did not see any significant performance regressions with sensible chunk sizes.

I have plans for further optimizations, including following up on the rustc bugs @cgaebel identified in #60.

The branch already achieves a significant drop in allocations and memory consumption:

(preliminary numbers)

### Webapp spec, single page:

pre-zerocopy

```
846,520 allocs, 37,567,992 bytes allocated
maximum resident: 11,248 kB
```

zerocopy

```
95,690 allocs, 25,698,480 bytes allocated
maximum resident: 3,648 kB
```

### Wikipedia (GotG from servo-static-suite)

pre-zerocopy

```
62,705 allocs, 2,299,424 bytes allocated
maximum resident: 3,948 kB
```

zerocopy

```
11,549 allocs, 2,355,984 bytes allocated
maximum resident: 3,596 kB
```