### PR TITLE
Add xml5 parser to html5ever

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "html5lib-tests"]
 	path = html5lib-tests
 	url = https://github.com/html5lib/html5lib-tests
+[submodule "xml5lib-tests"]
+	path = xml5lib-tests
+	url = https://github.com/Ygg01/xml5lib-tests

--- a/dom_sink/src/common.rs
+++ b/dom_sink/src/common.rs
@@ -11,7 +11,7 @@ use html5ever::tokenizer::Attribute;
 
 use string_cache::QualName;
 
-pub use self::NodeEnum::{Document, Doctype, Text, Comment, Element};
+pub use self::NodeEnum::{Document, Doctype, Text, Comment, Element, PI};
 
 /// The different kinds of nodes in the DOM.
 #[derive(Debug)]
@@ -30,4 +30,7 @@ pub enum NodeEnum {
 
     /// An element with attributes.
     Element(QualName, Vec<Attribute>),
+
+    /// A Processing instruction.
+    PI(String, String),
 }

--- a/dom_sink/src/owned_dom.rs
+++ b/dom_sink/src/owned_dom.rs
@@ -18,7 +18,7 @@
 //! been thoroughly audited, and the performance gains vs. RcDom
 //! have not been demonstrated.
 
-use common::{NodeEnum, Document, Doctype, Text, Comment, Element};
+use common::{NodeEnum, Document, Doctype, Text, Comment, Element, PI};
 
 use html5ever::tokenizer::Attribute;
 use html5ever::tree_builder::{TreeSink, QuirksMode, NodeOrText, AppendNode, AppendText};
@@ -212,6 +212,10 @@ impl TreeSink for Sink {
         self.new_node(Comment(text))
     }
 
+    fn create_pi(&mut self, target: String, data: String) -> Handle  {
+        self.new_node(PI(target, data))
+    }
+
     fn append(&mut self, parent: Handle, child: NodeOrText<Handle>) {
         // Append to an existing Text node if we have one.
         match child {
@@ -381,6 +385,9 @@ impl Serializable for Node {
             (IncludeNode, &Doctype(ref name, _, _)) => serializer.write_doctype(&name),
             (IncludeNode, &Text(ref text)) => serializer.write_text(&text),
             (IncludeNode, &Comment(ref text)) => serializer.write_comment(&text),
+
+            (IncludeNode, &PI(ref target, ref data))
+                => serializer.write_processing_instruction(&target, &data),
 
             (IncludeNode, &Document) => panic!("Can't serialize Document node itself"),
         }

--- a/dom_sink/src/owned_dom.rs
+++ b/dom_sink/src/owned_dom.rs
@@ -197,7 +197,7 @@ impl TreeSink for Sink {
         x == y
     }
 
-    fn elem_name(&self, target: Handle) -> QualName {
+    fn elem_name(&self, target: &Handle) -> QualName {
         match target.node {
             Element(ref name, _) => name.clone(),
             _ => panic!("not an element!"),

--- a/dom_sink/src/rcdom.rs
+++ b/dom_sink/src/rcdom.rs
@@ -147,7 +147,7 @@ impl TreeSink for RcDom {
         same_node(&x, &y)
     }
 
-    fn elem_name(&self, target: Handle) -> QualName {
+    fn elem_name(&self, target: &Handle) -> QualName {
         // FIXME: rust-lang/rust#22252
         return match target.borrow().node {
             Element(ref name, _) => name.clone(),

--- a/dom_sink/src/rcdom.rs
+++ b/dom_sink/src/rcdom.rs
@@ -12,7 +12,7 @@
 //! This is sufficient as a static parse tree, but don't build a
 //! web browser using it. :)
 
-use common::{NodeEnum, Document, Doctype, Text, Comment, Element};
+use common::{NodeEnum, Document, Doctype, Text, Comment, Element,PI};
 
 use html5ever::tokenizer::Attribute;
 use html5ever::tree_builder::{TreeSink, QuirksMode, NodeOrText, AppendNode, AppendText};
@@ -163,6 +163,10 @@ impl TreeSink for RcDom {
         new_node(Comment(text))
     }
 
+    fn create_pi(&mut self, target: String, data: String) -> Handle {
+        new_node(PI(target, data))
+    }
+
     fn append(&mut self, parent: Handle, child: NodeOrText<Handle>) {
         // Append to an existing Text node if we have one.
         match child {
@@ -304,6 +308,9 @@ impl Serializable for Handle {
             (IncludeNode, &Doctype(ref name, _, _)) => serializer.write_doctype(&name),
             (IncludeNode, &Text(ref text)) => serializer.write_text(&text),
             (IncludeNode, &Comment(ref text)) => serializer.write_comment(&text),
+
+            (IncludeNode, &PI(ref target, ref data))
+                => serializer.write_processing_instruction(&target, &data),
 
             (IncludeNode, &Document) => panic!("Can't serialize Document node itself"),
         }

--- a/examples/noop-tree-builder.rs
+++ b/examples/noop-tree-builder.rs
@@ -46,8 +46,8 @@ impl TreeSink for Sink {
         x == y
     }
 
-    fn elem_name(&self, target: usize) -> QualName {
-        self.names.get(&target).expect("not an element").clone()
+    fn elem_name(&self, target: &usize) -> QualName {
+        self.names.get(target).expect("not an element").clone()
     }
 
     fn create_element(&mut self, name: QualName, _attrs: Vec<Attribute>) -> usize {

--- a/examples/noop-tree-builder.rs
+++ b/examples/noop-tree-builder.rs
@@ -60,6 +60,10 @@ impl TreeSink for Sink {
         self.get_id()
     }
 
+    fn create_pi(&mut self, _target: String, _data: String) -> usize {
+        self.get_id()
+    }
+
     fn append_before_sibling(&mut self,
             _sibling: usize,
             _new_node: NodeOrText<usize>) -> Result<(), NodeOrText<usize>> {

--- a/examples/print-rcdom.rs
+++ b/examples/print-rcdom.rs
@@ -66,7 +66,9 @@ fn walk(indent: usize, handle: Handle) {
 fn main() {
     let mut input = String::new();
     io::stdin().read_to_string(&mut input).unwrap();
-    let dom: RcDom = parse_xml(one_input(input), Default::default());
+    // For parsing xml uncomment following line
+    // let dom: RcDom = parse_xml(one_input(input), Default::default());
+    let dom: RcDom = parse(one_input(input), Default::default());
     walk(0, dom.document);
 
     if !dom.errors.is_empty() {

--- a/examples/print-rcdom.rs
+++ b/examples/print-rcdom.rs
@@ -22,7 +22,7 @@ use std::default::Default;
 use std::string::String;
 
 use html5ever::{parse, one_input};
-use html5ever_dom_sink::common::{Document, Doctype, Text, Comment, Element};
+use html5ever_dom_sink::common::{Document, Doctype, Text, Comment, Element, PI};
 use html5ever_dom_sink::rcdom::{RcDom, Handle};
 
 // This is not proper HTML serialization, of course.
@@ -44,6 +44,9 @@ fn walk(indent: usize, handle: Handle) {
         Comment(ref text)
             => println!("<!-- {} -->", text.escape_default()),
 
+        PI(ref target, ref data)
+            => println!("<?{} {}?>", target, data),
+
         Element(ref name, ref attrs) => {
             assert!(name.ns == ns!(html));
             print!("<{}", name.local);
@@ -63,7 +66,7 @@ fn walk(indent: usize, handle: Handle) {
 fn main() {
     let mut input = String::new();
     io::stdin().read_to_string(&mut input).unwrap();
-    let dom: RcDom = parse(one_input(input), Default::default());
+    let dom: RcDom = parse_xml(one_input(input), Default::default());
     walk(0, dom.document);
 
     if !dom.errors.is_empty() {

--- a/examples/print-tree-actions.rs
+++ b/examples/print-tree-actions.rs
@@ -56,8 +56,8 @@ impl TreeSink for Sink {
         x == y
     }
 
-    fn elem_name(&self, target: usize) -> QualName {
-        self.names.get(&target).expect("not an element").clone()
+    fn elem_name(&self, target: &usize) -> QualName {
+        self.names.get(target).expect("not an element").clone()
     }
 
     fn create_element(&mut self, name: QualName, _attrs: Vec<Attribute>) -> usize {

--- a/examples/print-tree-actions.rs
+++ b/examples/print-tree-actions.rs
@@ -73,6 +73,12 @@ impl TreeSink for Sink {
         id
     }
 
+    fn create_pi(&mut self, target: String, data: String) -> usize {
+        let id = self.get_id();
+        println!("Created Processing Instruction: {} {}", target, data);
+        id
+    }
+
     fn append(&mut self, parent: usize, child: NodeOrText<usize>) {
         match child {
             AppendNode(n)

--- a/examples/xml_tokenizer.rs
+++ b/examples/xml_tokenizer.rs
@@ -1,0 +1,99 @@
+// Copyright 2014 The html5ever Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(collections)]
+
+extern crate html5ever;
+
+use std::io::{self, Read};
+use std::default::Default;
+
+use html5ever::tokenizer::{XTokenSink, XToken, XmlTokenizerOpts, XParseError};
+use html5ever::tokenizer::{CharacterXTokens, NullCharacterXToken, XTagToken};
+use html5ever::tokenizer::{StartXTag, EndXTag, ShortXTag, EmptyXTag};
+use html5ever::tokenizer::{PIToken, XPi};
+use html5ever::driver::{tokenize_xml_to, one_input};
+
+#[derive(Copy, Clone)]
+struct XTokenPrinter {
+    in_char_run: bool,
+}
+
+impl XTokenPrinter {
+    fn is_char(&mut self, is_char: bool) {
+        match (self.in_char_run, is_char) {
+            (false, true ) => print!("CHAR : \""),
+            (true,  false) => println!("\""),
+            _ => (),
+        }
+        self.in_char_run = is_char;
+    }
+
+    fn do_char(&mut self, c: char) {
+        self.is_char(true);
+        print!("{}", c.to_string().escape_default());
+    }
+}
+
+impl XTokenSink for XTokenPrinter {
+    fn process_token(&mut self, token: XToken) {
+        match token {
+            CharacterXTokens(b) => {
+                for c in b.chars() {
+                    self.do_char(c);
+                }
+            }
+            NullCharacterXToken => self.do_char('\0'),
+            XTagToken(tag) => {
+                self.is_char(false);
+                // This is not proper HTML serialization, of course.
+                match tag.kind {
+                    StartXTag => print!("TAG  : <\x1b[32m{}\x1b[0m", tag.name.as_slice()),
+                    EndXTag   => print!("END TAG  : <\x1b[31m/{}\x1b[0m", tag.name.as_slice()),
+                    ShortXTag => print!("Short TAG  : <\x1b[31m/{}\x1b[0m", tag.name.as_slice()),
+                    EmptyXTag => print!("Empty TAG  : <\x1b[31m{}\x1b[0m", tag.name.as_slice()),
+                }
+                for attr in tag.attrs.iter() {
+                    print!(" \x1b[36m{}\x1b[0m='\x1b[34m{}\x1b[0m'",
+                        attr.name.local.as_slice(), attr.value);
+                }
+                if tag.kind == EmptyXTag {
+                    print!("/");
+                }
+                println!(">");
+            }
+            XParseError(err) => {
+                self.is_char(false);
+                println!("ERROR: {}", err);
+            }
+            PIToken(XPi{target, data}) => {
+                self.is_char(false);
+                println!("PI : <?{:?} {:?}?>", target, data);
+            }
+            _ => {
+                self.is_char(false);
+                println!("OTHER: {:?}", token);
+            }
+        }
+    }
+}
+
+fn main() {
+    let mut sink = XTokenPrinter {
+        in_char_run: false,
+    };
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input).unwrap();
+    tokenize_xml_to(sink, one_input(input), XmlTokenizerOpts {
+        profile: true,
+        exact_errors: true,
+        .. Default::default()
+    });
+    sink.is_char(false);
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -18,8 +18,6 @@ use std::default::Default;
 use tokenizer::{XmlTokenizerOpts, XmlTokenizer, XTokenSink};
 use tree_builder::{ XmlTreeBuilder};
 
-use collections::string::String;
-
 use string_cache::{Atom, QualName};
 
 /// Convenience function to turn a single `String` into an iterator.

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -15,6 +15,11 @@ use tree_builder::{TreeBuilderOpts, TreeBuilder, TreeSink};
 use std::option;
 use std::default::Default;
 
+use tokenizer::{XmlTokenizerOpts, XmlTokenizer, XTokenSink};
+use tree_builder::{ XmlTreeBuilder};
+
+use collections::string::String;
+
 use string_cache::{Atom, QualName};
 
 /// Convenience function to turn a single `String` into an iterator.
@@ -39,6 +44,30 @@ pub fn tokenize_to<
         opts: TokenizerOpts) -> Sink {
 
     let mut tok = Tokenizer::new(sink, opts);
+    for s in input {
+        tok.feed(s);
+    }
+    tok.end();
+    tok.unwrap()
+}
+
+/// Tokenize and send results to a `XTokenSink`.
+///
+/// ## Example
+///
+/// ```ignore
+/// let mut sink = MySink;
+/// tokenize_xml_to(&mut sink, one_input(my_str), Default::default());
+/// ```
+pub fn tokenize_xml_to<
+        Sink: XTokenSink,
+        It: Iterator<Item=String>
+    >(
+        sink: Sink,
+        input: It,
+        opts: XmlTokenizerOpts) -> Sink {
+
+    let mut tok = XmlTokenizer::new(sink, opts);
     for s in input {
         tok.feed(s);
     }
@@ -74,6 +103,31 @@ pub fn parse_to<
 
     let tb = TreeBuilder::new(sink, opts.tree_builder);
     let mut tok = Tokenizer::new(tb, opts.tokenizer);
+    for s in input {
+        tok.feed(s);
+    }
+    tok.end();
+    tok.unwrap().unwrap()
+}
+
+/// Parse and send results to a `TreeSink`.
+///
+/// ## Example
+///
+/// ```ignore
+/// let mut sink = MySink;
+/// parse_xml_to(&mut sink, one_input(my_str), Default::default());
+/// ```
+pub fn parse_xml_to<
+        Sink:TreeSink,
+        It: Iterator<Item=String>
+    >(
+        sink: Sink,
+        input: It,
+        opts: XmlTokenizerOpts) -> Sink {
+
+    let tb = XmlTreeBuilder::new(sink);
+    let mut tok = XmlTokenizer::new(tb, opts);
     for s in input {
         tok.feed(s);
     }
@@ -136,6 +190,22 @@ pub fn parse<Output, It>(input: It, opts: ParseOpts) -> Output
     let sink = parse_to(Default::default(), input, opts);
     ParseResult::get_result(sink)
 }
+
+/// Parse into a type which implements `ParseResult`.
+///
+/// ## Example
+///
+/// ```ignore
+/// let dom: RcDom = parse_xml(one_input(my_str), Default::default());
+/// ```
+pub fn parse_xml<Output, It>(input: It, opts: XmlTokenizerOpts) -> Output
+    where Output: ParseResult,
+          It: Iterator<Item=String>,
+{
+    let sink = parse_xml_to(Default::default(), input, opts);
+    ParseResult::get_result(sink)
+}
+
 
 /// Parse an HTML fragment into a type which implements `ParseResult`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ extern crate time;
 
 pub use tokenizer::Attribute;
 pub use driver::{one_input, ParseOpts, parse_to, parse_fragment_to, parse, parse_fragment};
+pub use driver::{parse_xml, parse_xml_to, tokenize_xml_to};
 
 pub use serialize::serialize;
 

--- a/src/tokenizer/char_ref/mod.rs
+++ b/src/tokenizer/char_ref/mod.rs
@@ -22,8 +22,6 @@ use super::{XTokenSink, XmlTokenizer};
 pub use self::XRef::*;
 use self::XState::*;
 
-use collections::string::ToString;
-
 mod data;
 
 //§ tokenizing-character-references
@@ -476,7 +474,7 @@ impl XCharRefTokenizer {
             return Done;
         }
 
-        h5e_debug!("Xml char ref tokenizer stepping in state {:?}", self.state);
+        debug!("Xml char ref tokenizer stepping in state {:?}", self.state);
         match self.state {
             XBegin => self.do_begin(tokenizer),
             XNumeric(base) => self.do_numeric(tokenizer, base),
@@ -618,7 +616,7 @@ impl XCharRefTokenizer {
     fn finish_reference<Sink: XTokenSink>(&mut self,
         tokenizer: &mut XmlTokenizer<Sink>) -> Status {
 
-        use core::mem::replace;
+        use std::mem::replace;
 
         match self.name_buf_opt {
             Some(ref mut c) if c.len() > 0 => {

--- a/src/tokenizer/char_ref/mod.rs
+++ b/src/tokenizer/char_ref/mod.rs
@@ -10,12 +10,19 @@
 use super::{Tokenizer, TokenSink};
 
 use util::str::{is_ascii_alnum, empty_str};
+use util::str::{is_xml_namechar};
 
 use std::char::from_u32;
 use std::borrow::Cow::Borrowed;
 
 pub use self::Status::*;
 use self::State::*;
+
+use super::{XTokenSink, XmlTokenizer};
+pub use self::XRef::*;
+use self::XState::*;
+
+use collections::string::ToString;
 
 mod data;
 
@@ -395,5 +402,265 @@ impl CharRefTokenizer {
                 }
             }
         }
+    }
+}
+#[derive(Debug)]
+enum XState {
+    XBegin,
+    XNumeric(u32),
+    XNumericSemicolon,
+    XReference,
+    XOctothorpe,
+}
+
+pub enum XRef {
+    NamedXRef(String),
+    CharXData(String),
+    NoReturn,
+}
+
+pub struct XCharRefTokenizer {
+    state: XState,
+    result: Option<XRef>,
+    hex_marker: Option<char>,
+
+    num: u32,
+    num_too_big: bool,
+
+    seen_digit: bool,
+    name_buf_opt: Option<String>,
+}
+impl XCharRefTokenizer {
+
+    // NB: We assume that we have an additional allowed character iff we're
+    // tokenizing in an attribute value.
+    pub fn new() -> XCharRefTokenizer {
+        XCharRefTokenizer {
+            state: XState::XBegin,
+            result: None,
+            hex_marker: None,
+            num: 0,
+            num_too_big: false,
+            seen_digit: false,
+            name_buf_opt: None,
+        }
+    }
+
+    // A CharRefTokenizer can only tokenize one character reference,
+    // so this method consumes the tokenizer.
+    pub fn get_result(self) -> XRef {
+        self.result.expect("get_result called before done")
+    }
+
+    fn name_buf_mut<'t>(&'t mut self) -> &'t mut String {
+        self.name_buf_opt.as_mut()
+            .expect("name_buf missing in named character reference")
+    }
+
+    fn name_buf<'t>(&'t self) -> &'t String {
+        self.name_buf_opt.as_ref()
+            .expect("name_buf missing in named character reference")
+    }
+}
+
+
+
+impl XCharRefTokenizer {
+
+    pub fn step<Sink: XTokenSink>(
+        &mut self,
+        tokenizer: &mut XmlTokenizer<Sink>
+        ) -> Status {
+
+        if self.result.is_some() {
+            return Done;
+        }
+
+        h5e_debug!("Xml char ref tokenizer stepping in state {:?}", self.state);
+        match self.state {
+            XBegin => self.do_begin(tokenizer),
+            XNumeric(base) => self.do_numeric(tokenizer, base),
+            XNumericSemicolon => self.do_numeric_semicolon(tokenizer),
+            XReference => self.do_reference(tokenizer),
+            XOctothorpe => self.do_octothorpe(tokenizer),
+        }
+    }
+
+    fn do_begin<Sink: XTokenSink>(&mut self,
+        tokenizer: &mut XmlTokenizer<Sink>) -> Status {
+        match unwrap_or_return!(tokenizer.peek(), Stuck) {
+            '\t' | '\n' | '\x0C' | ' ' | '<' | '&' | '%'
+                => self.finish_none(),
+
+            '#' => {
+                tokenizer.discard_char();
+                self.state = XState::XOctothorpe;
+                Progress
+            }
+
+            _ => {
+                self.state = XState::XReference;
+                self.name_buf_opt = Some(empty_str());
+                Progress
+            }
+        }
+    }
+
+    fn do_octothorpe<Sink: XTokenSink>(&mut self,
+        tokenizer: &mut XmlTokenizer<Sink>) -> Status {
+        let c = unwrap_or_return!(tokenizer.peek(), Stuck);
+        match c {
+            'x' | 'X' => {
+                tokenizer.discard_char();
+                self.hex_marker = Some(c);
+                self.state = XNumeric(16);
+            }
+
+            _ => {
+                self.hex_marker = None;
+                self.state = XNumeric(10);
+            }
+        }
+        Progress
+    }
+
+
+    fn do_numeric<Sink: XTokenSink>(&mut self,
+        tokenizer: &mut XmlTokenizer<Sink>, base: u32) -> Status {
+        let c = unwrap_or_return!(tokenizer.peek(), Stuck);
+        match c.to_digit(base as u32) {
+            Some(n) => {
+                tokenizer.discard_char();
+                self.num *= base;
+                if self.num > 0x10FFFF {
+                    // We might overflow, and the character is definitely invalid.
+                    // We still parse digits and semicolon, but don't use the result.
+                    self.num_too_big = true;
+                }
+                self.num += n as u32;
+                self.seen_digit = true;
+                Progress
+            }
+
+            None if !self.seen_digit => self.unconsume_numeric(tokenizer),
+
+            None => {
+                self.state = XNumericSemicolon;
+                Progress
+            }
+        }
+    }
+
+    fn do_numeric_semicolon<Sink: XTokenSink>(&mut self,
+        tokenizer: &mut XmlTokenizer<Sink>) -> Status {
+        match unwrap_or_return!(tokenizer.peek(), Stuck) {
+            ';' => tokenizer.discard_char(),
+            _   => tokenizer.emit_error(Borrowed("Semicolon missing after numeric character reference")),
+        };
+        self.finish_numeric(tokenizer)
+    }
+
+    fn do_reference<Sink: XTokenSink>(&mut self,
+        tokenizer: &mut XmlTokenizer<Sink>) -> Status {
+        let c = unwrap_or_return!(tokenizer.get_char(), Stuck);
+        if is_xml_namechar(&c) {
+            self.name_buf_mut().push(c);
+            Progress
+        } else if  c == ';' {
+            self.finish_reference(tokenizer)
+        } else {
+            tokenizer.unconsume(c.to_string());
+            let temp = self.name_buf().clone();
+            self.finish_text(temp)
+        }
+
+    }
+
+    pub fn end_of_file<Sink: XTokenSink>(&mut self,
+        tokenizer: &mut XmlTokenizer<Sink>) {
+
+
+        while self.result.is_none() {
+            match self.state {
+                XBegin => { self.finish_none(); },
+
+                XNumeric(_) if !self.seen_digit
+                    => { self.unconsume_numeric(tokenizer); },
+
+                XNumeric(_) | XState::XNumericSemicolon => {
+                    tokenizer.emit_error(Borrowed("EOF in numeric character reference"));
+                    self.finish_numeric(tokenizer);
+                },
+
+                XReference => {
+                    tokenizer.emit_error(Borrowed("EOF in reference"));
+                    self.finish_reference(tokenizer);
+                },
+
+                XOctothorpe => {
+                    tokenizer.emit_error(Borrowed("EOF after '#' in character reference"));
+                    self.finish_text("#".to_string());
+                },
+            }
+        }
+    }
+
+    fn finish_none(&mut self) -> Status {
+        self.result = Some(NoReturn);
+        Done
+    }
+
+    fn finish_text(&mut self, text: String) -> Status {
+        self.result = Some(CharXData(text));
+        Done
+    }
+
+    fn finish_reference<Sink: XTokenSink>(&mut self,
+        tokenizer: &mut XmlTokenizer<Sink>) -> Status {
+
+        use core::mem::replace;
+
+        match self.name_buf_opt {
+            Some(ref mut c) if c.len() > 0 => {
+                self.result = Some(NamedXRef(replace(c, String::new())));
+            },
+            _ => {
+                tokenizer.emit_error(Borrowed("empty reference"));
+                self.result = Some(NoReturn);
+            }
+        };
+        Done
+    }
+
+    fn finish_numeric<Sink: XTokenSink>(&mut self, tokenizer: &mut XmlTokenizer<Sink>) -> Status {
+        fn conv(n: u32) -> char {
+            from_u32(n).expect("invalid char missed by error handling cases")
+        }
+
+        let (c, error) = match self.num {
+            n if (n > 0x10FFFF) || self.num_too_big => ('\u{fffd}', true),
+            n => (conv(n), false),
+        };
+
+        if error {
+            let msg = format_if!(tokenizer.opts.exact_errors,
+                "Invalid numeric character reference",
+                "Invalid numeric character reference value 0x{:06X}", self.num);
+            tokenizer.emit_error(msg);
+        }
+        self.result = Some(CharXData(c.to_string()));
+        Done
+    }
+
+    fn unconsume_numeric<Sink: XTokenSink>(&mut self, tokenizer: &mut XmlTokenizer<Sink>) -> Status {
+        let mut unconsume = String::from_str("#");
+        match self.hex_marker {
+            Some(c) => unconsume.push(c),
+            None => (),
+        }
+
+
+        tokenizer.emit_error(Borrowed("Numeric character reference without digits"));
+        self.finish_text(unconsume)
     }
 }

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -729,7 +729,7 @@ impl <Sink:XTokenSink> XmlTokenizer<Sink> {
             c = '\u{FFFD}'
         }
 
-        h5e_debug!("got character {}", c);
+        debug!("got character {}", c);
         self.current_char = c;
         Some(c)
     }
@@ -752,7 +752,7 @@ impl <Sink:XTokenSink> XmlTokenizer<Sink> {
         }
 
         let d = self.input_buffers.pop_except_from(set);
-        h5e_debug!("got characters {:?}", d);
+        debug!("got characters {:?}", d);
         match d {
             Some(FromSet(c)) => self.get_preprocessed_char(c).map(|x| FromSet(x)),
 
@@ -2062,7 +2062,7 @@ impl<Sink: XTokenSink> XmlTokenizer<Sink> {
 
 
     fn eof_step(&mut self) -> bool {
-        h5e_debug!("processing EOF in state {:?}", self.state);
+        debug!("processing EOF in state {:?}", self.state);
         match self.state {
             XmlState::XData
                 => go!(self: eof),

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -22,7 +22,18 @@ use self::states::{Escaped, DoubleEscaped};
 use self::states::{Unquoted, SingleQuoted, DoubleQuoted};
 use self::states::{DoctypeIdKind, Public, System};
 
+pub use self::interface::{StartXTag, EndXTag, EmptyXTag, ShortXTag};
+pub use self::interface::{DoctypeXToken, XTagToken, PIToken, CommentXToken};
+pub use self::interface::{CharacterXTokens, EOFXToken, NullCharacterXToken};
+pub use self::interface::{XTokenSink, XParseError, XTagKind, XToken, XTag};
+
+pub use self::interface::XPi;
+
+use self::states::{XData, XTagState};
+use self::states::XmlState;
+
 use self::char_ref::{CharRef, CharRefTokenizer};
+use self::char_ref::{XCharRefTokenizer, XRef};
 
 use self::buffer_queue::{BufferQueue, SetResult, FromSet, NotFromSet};
 
@@ -523,6 +534,420 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 }
 //§ END
 
+/// Copy of Tokenizer options, with an impl for `Default`.
+/// FIXME: Unite this with TokenizerOpt
+#[derive(Copy, Clone)]
+pub struct XmlTokenizerOpts {
+    /// Report all parse errors described in the spec, at some
+    /// performance penalty?  Default: false
+    pub exact_errors: bool,
+
+    /// Discard a `U+FEFF BYTE ORDER MARK` if we see one at the beginning
+    /// of the stream?  Default: true
+    pub discard_bom: bool,
+
+    /// Keep a record of how long we spent in each state?  Printed
+    /// when `end()` is called.  Default: false
+    pub profile: bool,
+
+    /// Initial state override.  Only the test runner should use
+    /// a non-`None` value!
+    pub initial_state: Option<states::XmlState>,
+
+    /// Mod determining if the entity expansion is allowed
+    /// TODO: Upgrade to a struct with more options.
+    pub safe_mod: bool,
+
+}
+
+impl Default for XmlTokenizerOpts {
+    fn default() -> XmlTokenizerOpts {
+        XmlTokenizerOpts {
+            exact_errors: false,
+            discard_bom: true,
+            profile: false,
+            initial_state: None,
+            safe_mod: true,
+        }
+    }
+}
+
+/// The Xml tokenizer.
+pub struct XmlTokenizer<Sink> {
+    /// Options controlling the behavior of the tokenizer.
+    opts: XmlTokenizerOpts,
+
+    /// Destination for tokens we emit.
+    sink: Sink,
+
+    /// The abstract machine state as described in the spec.
+    state: states::XmlState,
+
+    /// Input ready to be tokenized.
+    input_buffers: BufferQueue,
+
+    /// Are we at the end of the file, once buffers have been processed
+    /// completely? This affects whether we will wait for lookahead or not.
+    at_eof: bool,
+
+    /// Tokenizer for character references, if we're tokenizing
+    /// one at the moment.
+    char_ref_tokenizer: Option<Box<XCharRefTokenizer>>,
+
+    /// Current input character.  Just consumed, may reconsume.
+    current_char: char,
+
+    /// Should we reconsume the current input character?
+    reconsume: bool,
+
+    /// Did we just consume \r, translating it to \n?  In that case we need
+    /// to ignore the next character if it's \n.
+    ignore_lf: bool,
+
+    /// Discard a U+FEFF BYTE ORDER MARK if we see one?  Only done at the
+    /// beginning of the stream.
+    discard_bom: bool,
+
+    /// Current tag kind.
+    current_tag_kind: XTagKind,
+
+    /// Current tag name.
+    current_tag_name: String,
+
+    /// Current tag attributes.
+    current_tag_attrs: Vec<Attribute>,
+
+    /// Current attribute name.
+    current_attr_name: String,
+
+    /// Current attribute value.
+    current_attr_value: String,
+
+    /// Current comment.
+    current_comment: String,
+
+    /// Current processing instruction target.
+    current_pi_target: String,
+
+    /// Current processing instruction value.
+    current_pi_data: String,
+
+    /// Record of how many ns we spent in each state, if profiling is enabled.
+    state_profile: BTreeMap<states::XmlState, u64>,
+
+    /// Record of how many ns we spent in the token sink.
+    time_in_sink: u64,
+}
+
+impl <Sink:XTokenSink> XmlTokenizer<Sink> {
+    /// Create a new tokenizer which feeds tokens to a particular `TokenSink`.
+    pub fn new(sink: Sink, opts: XmlTokenizerOpts) -> XmlTokenizer<Sink> {
+        if opts.profile && cfg!(for_c) {
+            panic!("Can't profile tokenizer when built as a C library");
+        }
+
+        let state = *opts.initial_state.as_ref().unwrap_or(&states::XData);
+        let discard_bom = opts.discard_bom;
+        XmlTokenizer {
+            opts: opts,
+            sink: sink,
+            state: state,
+            char_ref_tokenizer: None,
+            input_buffers: BufferQueue::new(),
+            at_eof: false,
+            current_char: '\0',
+            reconsume: false,
+            ignore_lf: false,
+            discard_bom: discard_bom,
+            current_tag_kind: StartXTag,
+            current_tag_name: empty_str(),
+            current_tag_attrs: vec!(),
+            current_attr_name: empty_str(),
+            current_attr_value: empty_str(),
+            current_comment: empty_str(),
+            current_pi_data: empty_str(),
+            current_pi_target: empty_str(),
+            state_profile: BTreeMap::new(),
+            time_in_sink: 0,
+        }
+    }
+    pub fn unwrap(self) -> Sink {
+        self.sink
+    }
+
+    pub fn sink<'a>(&'a self) -> &'a Sink {
+        &self.sink
+    }
+
+    pub fn sink_mut<'a>(&'a mut self) -> &'a mut Sink {
+        &mut self.sink
+    }
+
+    /// Feed an input string into the tokenizer.
+    pub fn feed(&mut self, input: String) {
+        if input.len() == 0 {
+            return;
+        }
+
+        let pos = if self.discard_bom && input.char_at(0) == '\u{FFEF}' {
+            self.discard_bom = false;
+            3  // length of BOM in UTF-8
+        } else {
+            0
+        };
+
+        self.input_buffers.push_back(input, pos);
+        self.run();
+    }
+
+    fn process_token(&mut self, token: XToken) {
+        if self.opts.profile {
+            let (_, dt) = time!(self.sink.process_token(token));
+            self.time_in_sink += dt;
+        } else {
+            self.sink.process_token(token);
+        }
+    }
+
+    // Get the next input character, which might be the character
+    // 'c' that we already consumed from the buffers.
+    fn get_preprocessed_char(&mut self, mut c: char) -> Option<char> {
+        if self.ignore_lf {
+            self.ignore_lf = false;
+            if c == '\n' {
+                c = unwrap_or_return!(self.input_buffers.next(), None);
+            }
+        }
+
+        if c == '\r' {
+            self.ignore_lf = true;
+            c = '\n';
+        }
+
+        // Normalize \x00 into \uFFFD
+        if c == '\x00' {
+            c = '\u{FFFD}'
+        }
+
+        h5e_debug!("got character {}", c);
+        self.current_char = c;
+        Some(c)
+    }
+
+    fn bad_eof_error(&mut self) {
+        let msg = format_if!(
+            self.opts.exact_errors,
+            "Unexpected EOF",
+            "Saw EOF in state {:?}", self.state);
+        self.emit_error(msg);
+    }
+
+    fn pop_except_from(&mut self, set: SmallCharSet) -> Option<SetResult> {
+        // Bail to the slow path for various corner cases.
+        // This means that `FromSet` can contain characters not in the set!
+        // It shouldn't matter because the fallback `FromSet` case should
+        // always do the same thing as the `NotFromSet` case.
+        if self.opts.exact_errors || self.reconsume || self.ignore_lf {
+            return self.get_char().map(|x| FromSet(x));
+        }
+
+        let d = self.input_buffers.pop_except_from(set);
+        h5e_debug!("got characters {:?}", d);
+        match d {
+            Some(FromSet(c)) => self.get_preprocessed_char(c).map(|x| FromSet(x)),
+
+            // NB: We don't set self.current_char for a run of characters not
+            // in the set.  It shouldn't matter for the codepaths that use
+            // this.
+            _ => d
+        }
+    }
+
+    // Check if the next characters are an ASCII case-insensitive match.  See
+    // BufferQueue::eat.
+    //
+    // NB: this doesn't do input stream preprocessing or set the current input
+    // character.
+    fn eat(&mut self, pat: &str) -> Option<bool> {
+        match self.input_buffers.eat(pat) {
+            None if self.at_eof => Some(false),
+            r => r,
+        }
+    }
+
+    // Run the state machine for as long as we can.
+    fn run(&mut self) {
+        if self.opts.profile {
+            loop {
+                let state = self.state;
+                let old_sink = self.time_in_sink;
+                let (run, mut dt) = time!(self.step());
+                dt -= (self.time_in_sink - old_sink);
+                let new = match self.state_profile.get_mut(&state) {
+                    Some(x) => {
+                        *x += dt;
+                        false
+                    }
+                    None => true,
+                };
+                if new {
+                    // do this here because of borrow shenanigans
+                    self.state_profile.insert(state, dt);
+                }
+                if !run { break; }
+            }
+        } else {
+            while self.step() {
+            }
+        }
+    }
+
+    //§ tokenization
+    // Get the next input character, if one is available.
+    fn get_char(&mut self) -> Option<char> {
+        if self.reconsume {
+            self.reconsume = false;
+            Some(self.current_char)
+        } else {
+            self.input_buffers.next()
+                .and_then(|c| self.get_preprocessed_char(c))
+        }
+    }
+
+    fn bad_char_error(&mut self) {
+        let msg = format_if!(
+            self.opts.exact_errors,
+            "Bad character",
+            "Saw {} in state {:?}", self.current_char, self.state);
+        self.emit_error(msg);
+    }
+
+    fn discard_tag(&mut self) {
+        self.current_tag_name = String::new();
+        self.current_tag_attrs = vec!();
+    }
+
+    fn create_tag(&mut self, kind: XTagKind, c: char) {
+        self.discard_tag();
+        self.current_tag_name.push(c);
+        self.current_tag_kind = kind;
+    }
+
+    // This method creates a PI token and
+    // sets its target to given char
+    fn create_pi(&mut self, c: char) {
+        self.current_pi_target = String::new();
+        self.current_pi_data  = String::new();
+        self.current_pi_target.push(c);
+    }
+
+    fn emit_char(&mut self, c: char) {
+        self.process_token(match c {
+            '\0' => CharacterXTokens('\u{FFFD}'.to_string()),
+            c => CharacterXTokens(c.to_string()),
+        });
+    }
+
+    fn emit_short_tag(&mut self) {
+        self.current_tag_kind = ShortXTag;
+        self.current_tag_name = String::new();
+        self.emit_current_tag();
+    }
+
+    fn emit_empty_tag(&mut self) {
+        self.current_tag_kind = EmptyXTag;
+        self.emit_current_tag();
+    }
+
+    fn set_empty_tag(&mut self) {
+        self.current_tag_kind = EmptyXTag;
+    }
+
+    fn emit_start_tag(&mut self) {
+        self.current_tag_kind = StartXTag;
+        self.emit_current_tag();
+    }
+
+    fn emit_current_tag(&mut self) {
+        self.finish_attribute();
+
+        let name = replace(&mut self.current_tag_name, String::new());
+        let name = Atom::from_slice(&name);
+
+        match self.current_tag_kind {
+            StartXTag | EmptyXTag => {},
+            EndXTag => {
+                if !self.current_tag_attrs.is_empty() {
+                    self.emit_error(Borrowed("Attributes on an end tag"));
+                }
+            },
+            ShortXTag => {
+                if !self.current_tag_attrs.is_empty() {
+                    self.emit_error(Borrowed("Attributes on a short tag"));
+                }
+            },
+        }
+
+        let token = XTagToken(XTag { kind: self.current_tag_kind,
+            name: name,
+            attrs: replace(&mut self.current_tag_attrs, vec!()),
+        });
+        self.process_token(token);
+
+
+        if self.current_tag_kind == StartXTag {
+            match self.sink.query_state_change() {
+                None => (),
+                Some(s) => self.state = s,
+            }
+        }
+    }
+
+    // The string must not contain '\0'!
+    fn emit_chars(&mut self, b: String) {
+        self.process_token(CharacterXTokens(b));
+    }
+
+    // Emits the current Processing Instruction
+    fn emit_pi(&mut self) {
+        let token = PIToken(XPi {
+            target: replace(&mut self.current_pi_target, String::new()),
+            data: replace(&mut self.current_pi_data, String::new()),
+        });
+        self.process_token(token);
+    }
+
+    fn consume_char_ref(&mut self) {
+        // NB: The char ref tokenizer assumes we have an additional allowed
+        // character iff we're tokenizing in an attribute value.
+        self.char_ref_tokenizer = Some(box XCharRefTokenizer::new());
+    }
+
+    fn emit_eof(&mut self) {
+        self.process_token(EOFXToken);
+    }
+
+    fn emit_error(&mut self, error: Cow<'static, str>) {
+        self.process_token(XParseError(error));
+    }
+
+    fn peek(&mut self) -> Option<char> {
+        if self.reconsume {
+            Some(self.current_char)
+        } else {
+            self.input_buffers.peek()
+        }
+    }
+
+    fn discard_char(&mut self) {
+        let c = self.get_char();
+        assert!(c.is_some());
+    }
+
+    fn unconsume(&mut self, buf: String) {
+        self.input_buffers.push_front(buf);
+    }
+}
 // Shorthand for common state machine behaviors.
 macro_rules! shorthand (
     ( $me:ident : emit $c:expr                     ) => ( $me.emit_char($c);                                   );
@@ -548,6 +973,10 @@ macro_rules! shorthand (
     ( $me:ident : emit_doctype                     ) => ( $me.emit_current_doctype();                          );
     ( $me:ident : error                            ) => ( $me.bad_char_error();                                );
     ( $me:ident : error_eof                        ) => ( $me.bad_eof_error();                                 );
+    ( $me:ident : create_pi $c:expr                ) => ( $me.create_pi($c);                                   );
+    ( $me:ident : push_pi_target $c:expr           ) => ( $me.current_pi_target.push($c);                      );
+    ( $me:ident : push_pi_data $c:expr             ) => ( $me.current_pi_data.push($c);                        );
+    ( $me:ident : set_empty_tag                    ) => ( $me.set_empty_tag();                                 );
 );
 
 // Tracing of tokenizer actions.  This adds significant bloat and compile time,
@@ -583,11 +1012,37 @@ macro_rules! go (
 
     ( $me:ident : consume_char_ref             ) => ({ $me.consume_char_ref(None); return true;         });
     ( $me:ident : consume_char_ref $addnl:expr ) => ({ $me.consume_char_ref(Some($addnl)); return true; });
+    ( $me:ident : consume_xchar_ref            ) => ({ $me.consume_char_ref(); return true;             });
 
     // We have a default next state after emitting a tag, but the sink can override.
     ( $me:ident : emit_tag $s:ident ) => ({
         $me.state = states::$s;
         $me.emit_current_tag();
+        return true;
+    });
+
+    // We have a special when dealing with empty and short tags in Xml
+    ( $me:ident : emit_short_tag $s:ident ) => ({
+        $me.state = states::$s;
+        $me.emit_short_tag();
+        return true;
+    });
+
+    ( $me:ident : emit_empty_tag $s:ident ) => ({
+        $me.state = states::$s;
+        $me.emit_empty_tag();
+        return true;
+    });
+
+    ( $me:ident : emit_start_tag $s:ident ) => ({
+        $me.state = states::$s;
+        $me.emit_start_tag();
+        return true;
+    });
+
+    ( $me:ident : emit_pi $s:ident ) => ({
+        $me.state = states::$s;
+        $me.emit_pi();
         return true;
     });
 
@@ -1316,6 +1771,424 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 => panic!("FIXME: state {:?} not implemented in EOF", self.state),
         }
     }
+}
+
+impl<Sink: XTokenSink> XmlTokenizer<Sink> {
+
+    // Run the state machine for a while.
+    // Return true if we should be immediately re-invoked
+    // (this just simplifies control flow vs. break / continue).
+    fn step(&mut self) -> bool {
+        if self.char_ref_tokenizer.is_some() {
+            return self.step_char_ref_tokenizer();
+        }
+
+        println!("processing in state {:?}", self.state);
+        match self.state {
+            //§ data-state
+            XmlState::XData => loop {
+                match pop_except_from!(self, small_char_set!('\r' '&' '<')) {
+                    FromSet('&')  => go!(self: consume_xchar_ref),
+                    FromSet('<')  => go!(self: to XTagState),
+                    FromSet(c)    => go!(self: emit c),
+                    NotFromSet(b) => self.emit_chars(b),
+                }
+            },
+            //§ tag-state
+            XmlState::XTagState => loop { match get_char!(self) {
+                '!' => go!(self: to MarkupDecl),
+                '/' => go!(self: to EndXTagState),
+                '?' => go!(self: to Pi),
+                '\t'| '\n' | ' '|
+                ':' | '<' | '>' => go!(self: error; emit '<'; reconsume XData),
+                cl => go!(self: create_tag StartXTag cl; to XTagName),
+                }
+            },
+            //§ end-tag-state
+            XmlState::EndXTagState => loop { match get_char!(self) {
+                '>' => go!(self:  emit_short_tag XData),
+                '\t' | '\n' | ' '|
+                '<' | ':'  => go!(self: error; emit '<'; emit '/'; reconsume XData),
+                cl => go!(self: create_tag EndXTag cl; to EndXTagName)
+                }
+            },
+            //§ end-tag-name-state
+            XmlState::EndXTagName => loop { match get_char!(self) {
+                '\t' | '\n'
+                | ' '   => go!(self: to EndXTagNameAfter),
+                '/'     => go!(self: error; to EndXTagNameAfter),
+                '>'     => go!(self: emit_tag XData),
+                cl      => go!(self: push_tag cl),
+                }
+            },
+            //§ end-tag-name-after-state
+            XmlState::EndXTagNameAfter => loop {match get_char!(self) {
+                '>'     => go!(self: emit_tag XData),
+                '\t' | '\n'
+                | ' '   => (),
+                _       => self.emit_error(Borrowed("Unexpected element in tag name")),
+                }
+            },
+            //§ pi-state
+            XmlState::Pi => loop { match get_char!(self) {
+                '\t' | '\n'
+                | ' '  => go!(self: error; reconsume BogusXComment),
+                cl     =>  go!(self: create_pi cl; to PiTarget),
+                }
+            },
+            //§ pi-target-state
+            XmlState::PiTarget => loop { match get_char!(self) {
+                '\t' | '\n'
+                | ' '  => go!(self: to PiTargetAfter),
+                '?'    => go!(self: to PiAfter),
+                cl     => go!(self: push_pi_target cl),
+                }
+            },
+            //§ pi-target-after-state
+            XmlState::PiTargetAfter => loop { match get_char!(self) {
+                '\t' | '\n' | ' '  => (),
+                _     => go!(self: reconsume PiData),
+                }
+            },
+            //§ pi-data-state
+            XmlState::PiData => loop { match get_char!(self) {
+                '?' => go!(self: to PiAfter),
+                cl  => go!(self: push_pi_data cl),
+                }
+            },
+            //§ pi-after-state
+            XmlState::PiAfter => loop { match get_char!(self) {
+                '>' => go!(self: emit_pi XData),
+                '?' => go!(self: to PiAfter),
+                cl  => go!(self: push_pi_data cl),
+                }
+            },
+            //§ markup-declaration-state
+            XmlState::MarkupDecl => loop {
+                if eat!(self, "--") {
+                    go!(self: clear_comment; to XComment);
+                } else if eat!(self, "[CDATA[") {
+                    go!(self: to Cdata);
+                } else if eat!(self, "DOCTYPE") {
+                    go!(self: error; to XDoctype);
+                } else {
+                    // FIXME: See with kmc for this!
+                    // FIXME: CDATA, requires "adjusted current node" from tree builder
+                    // FIXME: 'error' gives wrong message
+                    go!(self: error; to BogusXComment);
+                }
+            },
+            //§ comment-state
+            XmlState::XComment => loop { match get_char!(self) {
+                '-' => go!(self: to XCommentDash),
+                '>' => go!(self: error; emit_comment; to XData),
+                c   => go!(self: push_comment c; to XComment),
+                }
+            },
+            //§ comment-dash-state
+            XmlState::XCommentDash => loop { match get_char!(self) {
+                '-' => go!(self: to XCommentEnd),
+                c   => go!(self: push_comment c),
+                }
+            },
+            //§ comment-end-state
+            XmlState::XCommentEnd => loop { match get_char!(self) {
+                '>' => go!(self: emit_comment; to XData),
+                '-' => go!(self: push_comment '-'),
+                c   => go!(self: append_comment "--"; push_comment c; to XComment),
+                }
+            },
+            //§ cdata-state
+            XmlState::Cdata => loop { match get_char!(self) {
+                    ']' => go!(self: to CdataBracket),
+                    cl  => go!(self: emit cl),
+                }
+            },
+            //§ cdata-bracket-state
+            XmlState::CdataBracket => loop {  match get_char!(self) {
+                    ']' => go!(self: to CdataEnd),
+                    cl  => go!(self: emit ']'; emit cl),
+                }
+            },
+            //§ cdata-end-state
+            XmlState::CdataEnd => loop {  match get_char!(self) {
+                '>' => go!(self: to XData),
+                ']' => go!(self: emit ']'),
+                cl => go!(self: emit ']'; emit ']'; emit cl; to Cdata),
+                }
+            },
+            //§ tag-name-state
+            XmlState::XTagName => loop { match get_char!(self) {
+                '\t' | '\n'
+                | ' '   => go!(self: to TagAttrNameBefore),
+                '>'     => go!(self: emit_tag XData),
+                '/'     => go!(self: set_empty_tag; to XTagEmpty),
+                cl      => go!(self: push_tag cl),
+                }
+            },
+            //§ empty-tag-state
+            XmlState::XTagEmpty => loop { match get_char!(self) {
+                '>'     => go!(self: emit_empty_tag XData),
+                _       => go!(self: reconsume TagAttrValueBefore),
+                }
+            },
+            //§ tag-attribute-name-before-state
+            XmlState::TagAttrNameBefore => loop { match get_char!(self) {
+                '\t' | '\n'
+                | ' '   => (),
+                '>'     => go!(self: emit_tag XData),
+                '/'     => go!(self: set_empty_tag; to XTagEmpty),
+                ':'     => go!(self: error ),
+                cl      => go!(self: create_attr cl; to TagAttrName),
+                }
+            },
+            //§ tag-attribute-name-state
+            XmlState::TagAttrName => loop { match get_char!(self) {
+                '='     => go!(self: to TagAttrValueBefore),
+                '>'     => go!(self: emit_tag XData),
+                '\t' | '\n'
+                | ' '   => go!(self: to TagAttrNameAfter),
+                '/'     => go!(self: set_empty_tag; to XTagEmpty),
+                cl      => go!(self: push_name cl),
+                }
+            },
+            //§ tag-attribute-name-after-state
+            XmlState::TagAttrNameAfter => loop { match get_char!(self) {
+                '\t' | '\n'
+                | ' '   => (),
+                '='     => go!(self: to TagAttrValueBefore),
+                '>'     => go!(self: emit_tag XData),
+                '/'     => go!(self: set_empty_tag; to XTagEmpty),
+                cl      => go!(self: create_attr cl; to TagAttrName),
+                }
+            },
+            //§ tag-attribute-value-before-state
+            XmlState::TagAttrValueBefore => loop { match get_char!(self) {
+                '\t' | '\n'
+                | ' '   => (),
+                '"'     => go!(self: to TagAttrValue(DoubleQuoted)),
+                '\''    => go!(self: to TagAttrValue(SingleQuoted)),
+                '&'     => go!(self: reconsume TagAttrValue(Unquoted)),
+                '>'     => go!(self: emit_tag XData),
+                cl      => go!(self: push_value cl; to TagAttrValue(Unquoted)),
+                }
+            },
+            //§ tag-attribute-value-double-quoted-state
+            XmlState::TagAttrValue(DoubleQuoted) => loop {
+                match pop_except_from!(self, small_char_set!('\n' '"' '&')) {
+                    FromSet('"')  => go!(self: to TagAttrNameBefore),
+                    FromSet('&')  => go!(self: consume_xchar_ref ),
+                    FromSet(c)    => go!(self: push_value c),
+                    NotFromSet(b) => go!(self: append_value b),
+                }
+            },
+            //§ tag-attribute-value-single-quoted-state
+            XmlState::TagAttrValue(SingleQuoted) => loop {
+                match pop_except_from!(self, small_char_set!('\n' '\'' '&')) {
+                    FromSet('\'')  => go!(self: to TagAttrNameBefore),
+                    FromSet('&')  => go!(self: consume_xchar_ref ),
+                    FromSet(c)    => go!(self: push_value c),
+                    NotFromSet(b) => go!(self: append_value b),
+                }
+            },
+            //§ tag-attribute-value-double-quoted-state
+            XmlState::TagAttrValue(Unquoted) => loop {
+                match pop_except_from!(self, small_char_set!('\n' '\t' ' ' '&' '>')) {
+                    FromSet('\t') | FromSet('\n') | FromSet(' ')
+                     => go!(self: to TagAttrNameBefore),
+                    FromSet('&')  => go!(self: consume_xchar_ref ),
+                    FromSet('>')  => go!(self: emit_tag XData),
+                    FromSet(c)    => go!(self: push_value c),
+                    NotFromSet(b) => go!(self: append_value b),
+                }
+            },
+            //§ bogus-comment-state
+            XmlState::BogusXComment => loop { match get_char!(self) {
+                '>'  => go!(self: emit_comment; to XData),
+                c    => go!(self: push_comment c),
+                }
+            },
+            XmlState::XDoctype => {false},
+        }
+    }
+
+    /// Indicate that we have reached the end of the input.
+    // FIXME: Copy pasta review carefully
+    pub fn end(&mut self) {
+        // Handle EOF in the char ref sub-tokenizer, if there is one.
+        // Do this first because it might un-consume stuff.
+        match self.char_ref_tokenizer.take() {
+            None => (),
+            Some(mut tok) => {
+                tok.end_of_file(self);
+                self.process_char_ref(tok.get_result());
+            }
+        }
+
+        // Process all remaining buffered input.
+        // If we're waiting for lookahead, we're not gonna get it.
+        self.at_eof = true;
+        self.run();
+
+        while self.eof_step() {
+            // loop
+        }
+
+        if self.opts.profile {
+            self.dump_profile();
+        }
+    }
+    #[cfg(for_c)]
+    fn dump_profile(&self) {
+        unreachable!();
+    }
+
+    #[cfg(not(for_c))]
+    fn dump_profile(&self) {
+        let mut results: Vec<(states::XmlState, u64)>
+            = self.state_profile.iter().map(|(s, t)| (*s, *t)).collect();
+        results.sort_by(|&(_, x), &(_, y)| y.cmp(&x));
+
+        let total: u64 = results.iter().map(|&(_, t)| t).sum();
+        println!("\nTokenizer profile, in nanoseconds");
+        println!("\n{:12}         total in token sink", self.time_in_sink);
+        println!("\n{:12}         total in tokenizer", total);
+
+        for (k, v) in results.into_iter() {
+            let pct = 100.0 * (v as f64) / (total as f64);
+            println!("{:12}  {:4.1}%  {:?}", v, pct, k);
+        }
+    }
+
+
+    fn eof_step(&mut self) -> bool {
+        h5e_debug!("processing EOF in state {:?}", self.state);
+        match self.state {
+            XmlState::XData
+                => go!(self: eof),
+            XmlState::XTagState
+                => go!(self: error_eof; emit '<'; to XData),
+            XmlState::EndXTagState
+                => go!(self: error_eof; emit '<'; emit '/'; to XData),
+            XmlState::XTagEmpty
+                => go!(self: error_eof; to TagAttrNameBefore),
+            XmlState::Cdata
+            | XmlState::CdataBracket | XmlState::CdataEnd
+            | XmlState::XDoctype
+                => go!(self: error_eof; to XData),
+            XmlState::Pi
+                => go!(self: error_eof; to BogusXComment),
+            XmlState::PiTargetAfter | XmlState::PiAfter
+                => go!(self: reconsume PiData),
+            XmlState::MarkupDecl
+                => go!(self: error_eof; to BogusXComment),
+            XmlState::XComment | XmlState::XCommentDash
+            | XmlState::XCommentEnd
+                => go!(self: error_eof; emit_comment;to XData),
+            XmlState::XTagName | XmlState::TagAttrNameBefore
+            | XmlState::EndXTagName | XmlState::TagAttrNameAfter
+            | XmlState::EndXTagNameAfter | XmlState::TagAttrValueBefore
+            | XmlState::TagAttrValue(_)
+                => go!(self: error_eof; emit_tag XData),
+            XmlState::PiData | XmlState::PiTarget
+                => go!(self: error_eof; emit_pi XData),
+            XmlState::TagAttrName
+                => go!(self: error_eof; emit_start_tag XData),
+            XmlState::BogusXComment
+                => go!(self: emit_comment; to XData),
+        }
+    }
+
+
+    fn process_char_ref(&mut self, char_ref: XRef) {
+        match char_ref {
+            XRef::CharXData(cdata) => {
+                match self.state {
+                    states::XData
+                        => self.emit_chars(cdata),
+
+                    states::TagAttrValue(_)
+                        => go!(self: append_value cdata),
+
+                    _ => panic!("state {:?} should not be reachable in process_char_ref", self.state),
+                }
+
+            },
+            XRef::NamedXRef(xref) => {
+                if !self.opts.safe_mod {
+                    match self.state {
+                        states::XData
+                            => self.emit_chars(xref), // TODO entity replacement
+
+                        states::TagAttrValue(_)
+                            => go!(self: append_value xref), // TODO entity replacement
+
+                        _ => panic!("state {:?} should not be eligible for entity expansion",
+                                        self.state),
+                    }
+                }
+            },
+            XRef::NoReturn => {},
+        }
+    }
+
+    fn step_char_ref_tokenizer(&mut self) -> bool {
+        let mut tok = self.char_ref_tokenizer.take().unwrap();
+        let outcome = tok.step(self);
+
+        let progress = match outcome {
+            char_ref::Done => {
+                self.process_char_ref(tok.get_result());
+                return true;
+            }
+
+            char_ref::Stuck => false,
+            char_ref::Progress => true,
+        };
+
+        self.char_ref_tokenizer = Some(tok);
+        progress
+    }
+
+    fn emit_current_comment(&mut self) {
+        let comment = replace(&mut self.current_comment, empty_str());
+        self.process_token(CommentXToken(comment));
+    }
+
+    fn finish_attribute(&mut self) {
+        if self.current_attr_name.len() == 0 {
+            return;
+        }
+
+        // Check for a duplicate attribute.
+        // FIXME: the spec says we should error as soon as the name is finished.
+        // FIXME: linear time search, do we care?
+        let dup = {
+            let name = &self.current_attr_name[..];
+            self.current_tag_attrs.iter().any(|a| a.name.local.as_slice() == name)
+        };
+
+        if dup {
+            self.emit_error(Borrowed("Duplicate attribute"));
+            self.current_attr_name.truncate(0);
+            self.current_attr_value.truncate(0);
+        } else {
+            let name = replace(&mut self.current_attr_name, String::new());
+            self.current_tag_attrs.push(Attribute {
+                // The tree builder will adjust the namespace if necessary.
+                // This only happens in foreign elements.
+                name: QualName::new(ns!(""), Atom::from_slice(&name)),
+                value: replace(&mut self.current_attr_value, empty_str()),
+            });
+        }
+    }
+
+    fn create_attribute(&mut self, c: char) {
+        self.finish_attribute();
+
+        self.current_attr_name.push(c);
+    }
+
 }
 
 #[cfg(test)]

--- a/src/tokenizer/states.rs
+++ b/src/tokenizer/states.rs
@@ -17,6 +17,7 @@ pub use self::DoctypeIdKind::*;
 pub use self::RawKind::*;
 pub use self::AttrValueKind::*;
 pub use self::State::*;
+pub use self::XmlState::*;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
 pub enum ScriptEscapeKind {
@@ -89,4 +90,43 @@ pub enum State {
     BogusDoctype,
     CdataSection,
     Quiescent,
+}
+//FIXME remove these
+#[allow(missing_copy_implementations)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
+pub enum QuoteKind {
+    SingleQuotes,
+    DoubleQuotes,
+}
+
+//FIXME remove these
+#[allow(missing_copy_implementations)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
+pub enum XmlState {
+    XData,
+    XTagState,
+    EndXTagState,
+    EndXTagName,
+    EndXTagNameAfter,
+    Pi,
+    PiTarget,
+    PiTargetAfter,
+    PiData,
+    PiAfter,
+    MarkupDecl,
+    XComment,
+    XCommentDash,
+    XCommentEnd,
+    Cdata,
+    CdataBracket,
+    CdataEnd,
+    XDoctype,
+    XTagName,
+    XTagEmpty,
+    TagAttrNameBefore,
+    TagAttrName,
+    TagAttrNameAfter,
+    TagAttrValueBefore,
+    TagAttrValue(AttrValueKind),
+    BogusXComment,
 }

--- a/src/tree_builder/actions.rs
+++ b/src/tree_builder/actions.rs
@@ -202,7 +202,7 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
     fn current_node_in<TagSet>(&self, set: TagSet) -> bool 
         where TagSet: Fn(QualName) -> bool
     {
-        set(self.sink.elem_name(self.current_node()))
+        set(self.sink.elem_name(&self.current_node()))
     }
 
     // Insert at the "appropriate place for inserting a node".
@@ -522,7 +522,7 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
             thead tr body html);
 
         for elem in self.open_elems.iter() {
-            let name = self.sink.elem_name(elem.clone());
+            let name = self.sink.elem_name(&elem);
             if !body_end_ok(name.clone()) {
                 self.sink.parse_error(format_if!(self.opts.exact_errors,
                     "Unexpected open tag at end of body",
@@ -541,7 +541,7 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
             if pred(node.clone()) {
                 return true;
             }
-            if scope(self.sink.elem_name(node.clone())) {
+            if scope(self.sink.elem_name(&node)) {
                 return false;
             }
         }
@@ -554,11 +554,11 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
     fn elem_in<TagSet>(&self, elem: Handle, set: TagSet) -> bool 
         where TagSet: Fn(QualName) -> bool
     {
-        set(self.sink.elem_name(elem))
+        set(self.sink.elem_name(&elem))
     }
 
     fn html_elem_named(&self, elem: Handle, name: Atom) -> bool {
-        self.sink.elem_name(elem) == QualName::new(ns!(HTML), name)
+        self.sink.elem_name(&elem) == QualName::new(ns!(HTML), name)
     }
 
     fn current_node_named(&self, name: Atom) -> bool {
@@ -578,7 +578,7 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
     {
         loop {
             let elem = unwrap_or_return!(self.open_elems.last(), ()).clone();
-            let nsname = self.sink.elem_name(elem);
+            let nsname = self.sink.elem_name(&elem);
             if !set(nsname) { return; }
             self.pop();
         }
@@ -614,7 +614,7 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
             n += 1;
             match self.open_elems.pop() {
                 None => break,
-                Some(elem) => if pred(self.sink.elem_name(elem)) { break; },
+                Some(ref elem) => if pred(self.sink.elem_name(elem)) { break; },
             }
         }
         n
@@ -684,7 +684,7 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
             if let (true, Some(ctx)) = (last, self.context_elem.as_ref()) {
                 node = ctx;
             }
-            let name = match self.sink.elem_name(node.clone()) {
+            let name = match self.sink.elem_name(&node) {
                 QualName { ns: ns!(HTML), local } => local,
                 _ => continue,
             };
@@ -871,7 +871,7 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
             return false;
         }
 
-        let name = self.sink.elem_name(self.adjusted_current_node());
+        let name = self.sink.elem_name(&self.adjusted_current_node());
         if let ns!(HTML) = name.ns {
             return false;
         }
@@ -1064,7 +1064,7 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
     }
 
     fn foreign_start_tag(&mut self, mut tag: Tag) -> ProcessResult {
-        let cur = self.sink.elem_name(self.adjusted_current_node());
+        let cur = self.sink.elem_name(&self.adjusted_current_node());
         match cur.ns {
             ns!(MathML) => self.adjust_mathml_attributes(&mut tag),
             ns!(SVG) => {

--- a/src/tree_builder/actions.rs
+++ b/src/tree_builder/actions.rs
@@ -1242,7 +1242,7 @@ impl<Handle, Sink> XmlTreeBuilderActions<Handle>
     }
 
     fn stop_parsing(&mut self) -> XmlProcessResult {
-        h5e_warn!("stop_parsing for XML5 not implemented, full speed ahead!");
+        warn!("stop_parsing for XML5 not implemented, full speed ahead!");
         XDone
     }
 }

--- a/src/tree_builder/actions.rs
+++ b/src/tree_builder/actions.rs
@@ -20,6 +20,8 @@ use tree_builder::rules::TreeBuilderStep;
 use tokenizer::{Attribute, Tag, StartTag, EndTag};
 use tokenizer::states::{RawData, RawKind};
 
+use tokenizer::{XTag, XPi};
+
 use util::str::{AsciiExt, to_escaped_string};
 
 use std::{slice, fmt};
@@ -1082,5 +1084,165 @@ impl<Handle, Sink> TreeBuilderActions<Handle>
             self.insert_element(Push, cur.ns, tag.name, tag.attrs);
             Done
         }
+    }
+}
+
+pub trait XmlTreeBuilderActions<Handle> {
+    fn current_node(&self) -> Handle;
+    fn insert_appropriately(&mut self, child: NodeOrText<Handle>);
+    fn insert_tag(&mut self, tag: XTag) -> XmlProcessResult;
+    fn append_tag(&mut self, tag: XTag) -> XmlProcessResult;
+    fn append_tag_to_doc(&mut self, tag: XTag) -> Handle;
+    fn add_to_open_elems(&mut self, el: Handle) -> XmlProcessResult;
+    fn append_comment_to_doc(&mut self, comment: String) -> XmlProcessResult;
+    fn append_comment_to_tag(&mut self, text: String) -> XmlProcessResult;
+    fn append_pi_to_doc(&mut self, pi: XPi) -> XmlProcessResult;
+    fn append_pi_to_tag(&mut self, pi: XPi) -> XmlProcessResult;
+    fn append_text(&mut self, chars: String) -> XmlProcessResult;
+    fn tag_in_open_elems(&self, tag: &XTag) -> bool;
+    fn pop_until<TagSet>(&mut self, pred: TagSet) where TagSet: Fn(QualName) -> bool;
+    fn current_node_in<TagSet>(&self, set: TagSet) -> bool where TagSet: Fn(QualName) -> bool;
+    fn close_tag(&mut self, tag: XTag) -> XmlProcessResult;
+    fn no_open_elems(&self) -> bool;
+    fn pop(&mut self) -> Handle ;
+    fn stop_parsing(&mut self) -> XmlProcessResult;
+}
+
+#[doc(hidden)]
+impl<Handle, Sink> XmlTreeBuilderActions<Handle>
+    for super::XmlTreeBuilder<Handle, Sink>
+    where Handle: Clone,
+          Sink: TreeSink<Handle=Handle>,
+{
+
+    fn current_node(&self) -> Handle {
+        self.open_elems.last().expect("no current element").clone()
+    }
+
+    fn insert_appropriately(&mut self, child: NodeOrText<Handle>){
+        let target = self.current_node();
+        self.sink.append(target, child);
+    }
+
+    fn insert_tag(&mut self, tag: XTag) -> XmlProcessResult {
+        let child = self.sink.create_element(QualName::new(ns!(HTML),
+            tag.name), tag.attrs);
+        self.insert_appropriately(AppendNode(child.clone()));
+        self.add_to_open_elems(child)
+    }
+
+    fn append_tag(&mut self, tag: XTag) -> XmlProcessResult {
+        let child = self.sink.create_element(QualName::new(ns!(HTML),
+            tag.name), tag.attrs);
+        self.insert_appropriately(AppendNode(child));
+        XDone
+    }
+
+    fn append_tag_to_doc(&mut self, tag: XTag) -> Handle {
+        let root = self.doc_handle.clone();
+        let child = self.sink.create_element(QualName::new(ns!(HTML),
+            tag.name), tag.attrs);
+
+        self.sink.append(root, AppendNode(child.clone()));
+        child
+    }
+
+    fn add_to_open_elems(&mut self, el: Handle) -> XmlProcessResult {
+        self.open_elems.push(el);
+
+        //FIXME remove this on final commit
+        println!("After add to open elems there are {} open elems", self.open_elems.len());
+        XDone
+    }
+
+    fn append_comment_to_doc(&mut self, text: String) -> XmlProcessResult {
+        let target = self.doc_handle.clone();
+        let comment = self.sink.create_comment(text);
+        self.sink.append(target, AppendNode(comment));
+        XDone
+    }
+
+    fn append_comment_to_tag(&mut self, text: String) -> XmlProcessResult {
+        let target = self.current_node();
+        let comment = self.sink.create_comment(text);
+        self.sink.append(target, AppendNode(comment));
+        XDone
+    }
+
+    fn append_pi_to_doc(&mut self, pi: XPi) -> XmlProcessResult {
+        let target = self.doc_handle.clone();
+        let pi = self.sink.create_pi(pi.target, pi.data);
+        self.sink.append(target, AppendNode(pi));
+        XDone
+    }
+
+    fn append_pi_to_tag(&mut self, pi: XPi) -> XmlProcessResult {
+        let target = self.current_node();
+        let pi = self.sink.create_pi(pi.target, pi.data);
+        self.sink.append(target, AppendNode(pi));
+        XDone
+    }
+
+
+    fn append_text(&mut self, chars: String)
+        -> XmlProcessResult {
+        self.insert_appropriately(AppendText(chars));
+        XDone
+    }
+
+    fn tag_in_open_elems(&self, tag: &XTag) -> bool {
+        self.open_elems
+            .iter()
+            .any(|a| self.sink.elem_name(a) == QualName::new(ns!(HTML), tag.name.clone()))
+    }
+
+    // Pop elements until an element from the set has been popped.  Returns the
+    // number of elements popped.
+    fn pop_until<P>(&mut self, pred: P)
+        where P: Fn(QualName) -> bool
+    {
+        loop {
+            if self.current_node_in(|x| pred(x)) {
+                break;
+            }
+            self.open_elems.pop();
+        }
+    }
+
+    fn current_node_in<TagSet>(&self, set: TagSet) -> bool
+        where TagSet: Fn(QualName) -> bool
+    {
+        set(self.sink.elem_name(&self.current_node()))
+    }
+
+    fn close_tag(&mut self, tag: XTag) -> XmlProcessResult {
+        println!("Close tag: current_node.name {:?} \n Current tag {:?}",
+                 self.sink.elem_name(&self.current_node()), &tag.name);
+        if &self.sink.elem_name(&self.current_node()).local != &tag.name {
+            self.sink.parse_error(Borrowed("Current node doesn't match tag"));
+        }
+        // FIXME remove this part after debug
+        let is_closed = self.tag_in_open_elems(&tag);
+        println!("Close tag {:?}", is_closed);
+
+        if(is_closed) {
+            // FIXME: Real namespace resolution
+            self.pop_until(|p| p == QualName::new(ns!(HTML), tag.name.clone()));
+            self.pop();
+        }
+        XDone
+    }
+
+    fn no_open_elems(&self) -> bool {
+        self.open_elems.is_empty()
+    }
+
+    fn pop(&mut self) -> Handle {
+        self.open_elems.pop().expect("no current element")
+    }
+
+    fn stop_parsing(&mut self) -> XmlProcessResult {
+        h5e_warn!("stop_parsing for XML5 not implemented, full speed ahead!");
+        XDone
     }
 }

--- a/src/tree_builder/interface.rs
+++ b/src/tree_builder/interface.rs
@@ -76,6 +76,9 @@ pub trait TreeSink {
     /// Create a comment node.
     fn create_comment(&mut self, text: String) -> Self::Handle;
 
+    /// Create a Processing Instruction node.
+    fn create_pi(&mut self, target: String, data: String) -> Self::Handle;
+
     /// Append a node as the last child of the given node.  If this would
     /// produce adjacent sibling text nodes, it should concatenate the text
     /// instead.

--- a/src/tree_builder/interface.rs
+++ b/src/tree_builder/interface.rs
@@ -65,7 +65,7 @@ pub trait TreeSink {
     ///
     /// Should never be called on a non-element node;
     /// feel free to `panic!`.
-    fn elem_name(&self, target: Self::Handle) -> QualName;
+    fn elem_name(&self, target: &Self::Handle) -> QualName;
 
     /// Set the document's quirks mode.
     fn set_quirks_mode(&mut self, mode: QuirksMode);

--- a/src/tree_builder/mod.rs
+++ b/src/tree_builder/mod.rs
@@ -16,6 +16,7 @@ pub use self::interface::{TreeSink, Tracer, NextParserState};
 use self::types::*;
 use self::actions::TreeBuilderActions;
 use self::rules::TreeBuilderStep;
+use self::rules::XmlTreeBuilderStep;
 
 use string_cache::QualName;
 
@@ -23,6 +24,7 @@ use tokenizer;
 use tokenizer::{Doctype, Tag};
 use tokenizer::TokenSink;
 use tokenizer::states as tok_state;
+use tokenizer::XTokenSink;
 
 use util::str::{is_ascii_whitespace, char_run};
 
@@ -429,6 +431,150 @@ impl<Handle, Sink> TokenSink
     }
 
     fn query_state_change(&mut self) -> Option<tokenizer::states::State> {
+        self.next_tokenizer_state.take()
+    }
+}
+
+// The XML tree builder.
+pub struct XmlTreeBuilder<Handle, Sink> {
+    /// Consumer of tree modifications.
+    sink: Sink,
+
+    /// The document node, which is created by the sink.
+    doc_handle: Handle,
+
+    /// Next state change for the tokenizer, if any.
+    next_tokenizer_state: Option<tokenizer::states::XmlState>,
+
+    /// Stack of open elements, most recently added at end.
+    open_elems: Vec<Handle>,
+
+    /// Current element pointer.
+    curr_elem: Option<Handle>,
+
+    /// Current tree builder phase.
+    phase: XmlPhase,
+}
+impl<Handle, Sink> XmlTreeBuilder<Handle, Sink>
+    where Handle: Clone,
+          Sink: TreeSink<Handle=Handle>,
+{
+    /// Create a new tree builder which sends tree modifications to a particular `TreeSink`.
+    ///
+    /// The tree builder is also a `TokenSink`.
+    pub fn new(mut sink: Sink) -> XmlTreeBuilder<Handle, Sink> {
+        let doc_handle = sink.get_document();
+        XmlTreeBuilder {
+            sink: sink,
+            doc_handle: doc_handle,
+            next_tokenizer_state: None,
+            open_elems: vec!(),
+            curr_elem: None,
+            phase: StartPhase,
+        }
+    }
+
+    pub fn unwrap(self) -> Sink {
+        self.sink
+    }
+
+    pub fn sink<'a>(&'a self) -> &'a Sink {
+        &self.sink
+    }
+
+    pub fn sink_mut<'a>(&'a mut self) -> &'a mut Sink {
+        &mut self.sink
+    }
+
+    /// Call the `Tracer`'s `trace_handle` method on every `Handle` in the tree builder's
+    /// internal state.  This is intended to support garbage-collected DOMs.
+    pub fn trace_handles(&self, tracer: &Tracer<Handle=Handle>) {
+        tracer.trace_handle(self.doc_handle.clone());
+        for e in self.open_elems.iter() {
+            tracer.trace_handle(e.clone());
+        }
+        self.curr_elem.as_ref().map(|h| tracer.trace_handle(h.clone()));
+    }
+
+    // Debug helper
+    #[cfg(not(for_c))]
+    #[allow(dead_code)]
+    fn dump_state(&self, label: String) {
+        use string_cache::QualName;
+
+        println!("dump_state on {}", label);
+        print!("    open_elems:");
+        for node in self.open_elems.iter() {
+            let QualName { ns, local } = self.sink.elem_name(node);
+            print!(" {:?}:{:?}", ns,local);
+
+        }
+        println!("");
+    }
+
+    #[cfg(for_c)]
+    fn debug_step(&self, _mode: XmlPhase, _token: &XToken) {
+    }
+
+    #[cfg(not(for_c))]
+    fn debug_step(&self, mode: XmlPhase, token: &XToken) {
+        use util::str::to_escaped_string;
+        h5e_debug!("processing {} in insertion mode {:?}", to_escaped_string(token), mode);
+    }
+
+    fn process_to_completion(&mut self, mut token: XToken) {
+        // Queue of additional tokens yet to be processed.
+        // This stays empty in the common case where we don't split whitespace.
+        let mut more_tokens = VecDeque::new();
+
+        loop {
+            let phase = self.phase;
+            match self.step(phase, token) {
+                XDone => {
+                    token = unwrap_or_return!(more_tokens.pop_front(), ());
+                }
+                XReprocess(m, t) => {
+                    self.phase = m;
+                    token = t;
+                }
+
+            }
+        }
+    }
+}
+
+impl<Handle, Sink> XTokenSink
+    for XmlTreeBuilder<Handle, Sink>
+    where Handle: Clone,
+          Sink: TreeSink<Handle=Handle>,
+{
+    fn process_token(&mut self, token: tokenizer::XToken) {
+        //let ignore_lf = replace(&mut self.ignore_lf, false);
+
+        // Handle `ParseError` and `DoctypeToken`; convert everything else to the local `Token` type.
+        let token = match token {
+            tokenizer::XParseError(e) => {
+                self.sink.parse_error(e);
+                return;
+            }
+
+            tokenizer::DoctypeXToken(_) => {
+                panic!("Doctype not implemented!!");
+            }
+
+            tokenizer::PIToken(x)   => PIToken(x),
+            tokenizer::XTagToken(x) => XTagToken(x),
+            tokenizer::CommentXToken(x) => CommentXToken(x),
+            tokenizer::NullCharacterXToken => NullCharacterXToken,
+            tokenizer::EOFXToken => EOFXToken,
+            tokenizer::CharacterXTokens(x) => CharacterXTokens(x),
+
+        };
+
+        self.process_to_completion(token);
+    }
+
+    fn query_state_change(&mut self) -> Option<tokenizer::states::XmlState> {
         self.next_tokenizer_state.take()
     }
 }

--- a/src/tree_builder/mod.rs
+++ b/src/tree_builder/mod.rs
@@ -185,7 +185,7 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
                             opts: TreeBuilderOpts) -> TreeBuilder<Handle, Sink> {
         let doc_handle = sink.get_document();
         let context_is_template =
-            sink.elem_name(context_elem.clone()) == qualname!(HTML, template);
+            sink.elem_name(&context_elem) == qualname!(HTML, template);
         let mut tb = TreeBuilder {
             opts: opts,
             sink: sink,
@@ -221,7 +221,7 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
     // Step 4. Set the state of the HTML parser's tokenization stage as follows:
     pub fn tokenizer_state_for_context_elem(&self) -> tok_state::State {
         let elem = self.context_elem.clone().expect("no context element");
-        let name = match self.sink.elem_name(elem) {
+        let name = match self.sink.elem_name(&elem) {
             QualName { ns: ns!(HTML), local } => local,
             _ => return tok_state::Data
         };
@@ -282,7 +282,7 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
         println!("dump_state on {}", label);
         print!("    open_elems:");
         for node in self.open_elems.iter() {
-            let QualName { ns, local } = self.sink.elem_name(node.clone());
+            let QualName { ns, local } = self.sink.elem_name(&node);
             match ns {
                 ns!(HTML) => print!(" {}", &local[..]),
                 _ => panic!(),
@@ -294,7 +294,7 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
             match entry {
                 &Marker => print!(" Marker"),
                 &Element(ref h, _) => {
-                    let QualName { ns, local } = self.sink.elem_name(h.clone());
+                    let QualName { ns, local } = self.sink.elem_name(&h);
                     match ns {
                         ns!(HTML) => print!(" {}", &local[..]),
                         _ => panic!(),

--- a/src/tree_builder/mod.rs
+++ b/src/tree_builder/mod.rs
@@ -519,7 +519,7 @@ impl<Handle, Sink> XmlTreeBuilder<Handle, Sink>
     #[cfg(not(for_c))]
     fn debug_step(&self, mode: XmlPhase, token: &XToken) {
         use util::str::to_escaped_string;
-        h5e_debug!("processing {} in insertion mode {:?}", to_escaped_string(token), mode);
+        debug!("processing {} in insertion mode {:?}", to_escaped_string(token), mode);
     }
 
     fn process_to_completion(&mut self, mut token: XToken) {

--- a/src/tree_builder/rules.rs
+++ b/src/tree_builder/rules.rs
@@ -11,13 +11,14 @@
 
 use tree_builder::types::*;
 use tree_builder::tag_sets::*;
-use tree_builder::actions::TreeBuilderActions;
+use tree_builder::actions::{TreeBuilderActions, XmlTreeBuilderActions};
 use tree_builder::interface::{TreeSink, Quirks, AppendNode, NextParserState};
 
 use tokenizer::{Tag, StartTag, EndTag};
 use tokenizer::states::{Rcdata, Rawtext, ScriptData, Plaintext, Quiescent};
 
 use util::str::{AsciiExt, is_ascii_whitespace};
+use tokenizer::{XTag, StartXTag, EndXTag, ShortXTag, EmptyXTag};
 
 use std::mem::replace;
 use std::borrow::Cow::Borrowed;
@@ -33,7 +34,6 @@ pub trait TreeBuilderStep {
     fn step(&mut self, mode: InsertionMode, token: Token) -> ProcessResult;
     fn step_foreign(&mut self, token: Token) -> ProcessResult;
 }
-
 #[doc(hidden)]
 impl<Handle, Sink> TreeBuilderStep
     for super::TreeBuilder<Handle, Sink>
@@ -1383,5 +1383,138 @@ impl<Handle, Sink> TreeBuilderStep
             // catch-all case.
             _ => panic!("impossible case in foreign content"),
         })
+    }
+}
+
+// FIXME: Merge with TreeBuilderStep
+pub trait XmlTreeBuilderStep {
+    fn step(&mut self, mode: XmlPhase, token: XToken) -> XmlProcessResult;
+}
+
+#[doc(hidden)]
+impl<Handle, Sink> XmlTreeBuilderStep
+    for super::XmlTreeBuilder<Handle, Sink>
+    where Handle: Clone,
+          Sink: TreeSink<Handle=Handle>,
+{
+
+    fn step(&mut self, mode: XmlPhase, token: XToken) -> XmlProcessResult {
+        self.debug_step(mode, &token);
+
+        match mode {
+            StartPhase => match token {
+                XTagToken(XTag{kind: StartXTag, name, attrs}) => {
+                    let tag = XTag {
+                        kind: StartXTag,
+                        name: name,
+                        attrs: attrs
+                    };
+                    self.phase = MainPhase;
+                    let handle = self.append_tag_to_doc(tag);
+                    self.add_to_open_elems(handle)
+
+                },
+                XTagToken(XTag{kind: EmptyXTag, name, attrs}) => {
+                    let tag = XTag {
+                        kind: StartXTag,
+                        name: name,
+                        attrs: attrs
+                    };
+                    self.phase = EndPhase;
+                    self.append_tag_to_doc(tag);
+                    XDone
+                },
+                CommentXToken(comment) => {
+                    self.append_comment_to_doc(comment)
+                },
+                PIToken(pi) => {
+                    self.append_pi_to_doc(pi)
+                },
+                CharacterXTokens(ref chars)
+                    if !any_not_whitespace(chars) => {
+                        XDone
+                },
+                EOFXToken => {
+                    self.sink.parse_error(Borrowed("Unexpected EOF in start phase"));
+                    XReprocess(EndPhase, EOFXToken)
+                },
+                _ => {
+                    self.sink.parse_error(Borrowed("Unexpected element in start phase"));
+                    XDone
+                },
+            },
+            MainPhase => match token {
+                CharacterXTokens(chs) => {
+                    self.append_text(chs)
+                },
+                XTagToken(XTag{kind: StartXTag, name, attrs}) => {
+                    let tag = XTag {
+                        kind: StartXTag,
+                        name: name,
+                        attrs: attrs
+                    };
+
+                    self.insert_tag(tag)
+                },
+                XTagToken(XTag{kind: EmptyXTag, name, attrs}) => {
+                    let tag = XTag {
+                        kind: StartXTag,
+                        name: name,
+                        attrs: attrs
+                    };
+                    self.append_tag(tag)
+                },
+                XTagToken(XTag{kind: EndXTag, name, attrs}) => {
+                    let tag = XTag {
+                        kind: StartXTag,
+                        name: name,
+                        attrs: attrs
+                    };
+                    println!("Enter EndXTag in MainPhase");
+                    let retval = self.close_tag(tag);
+                    if self.no_open_elems() {
+                        println!("No open elems, switch to EndPhase");
+                        self.phase = EndPhase;
+                    }
+                    retval
+                },
+                XTagToken(XTag{kind: ShortXTag, ..}) => {
+                    self.pop();
+                    if self.no_open_elems() {
+                        self.phase = EndPhase;
+                    }
+                    XDone
+                },
+                CommentXToken(comment) => {
+                    self.append_comment_to_tag(comment)
+                },
+                PIToken(pi) => {
+                    self.append_pi_to_tag(pi)
+                },
+                EOFXToken | NullCharacterXToken=> {
+                    XReprocess(EndPhase, EOFXToken)
+                }
+            },
+            EndPhase => match token {
+                CommentXToken(comment) => {
+                    self.append_comment_to_doc(comment)
+                },
+                PIToken(pi) => {
+                    self.append_pi_to_doc(pi)
+                },
+                CharacterXTokens(ref chars)
+                    if !any_not_whitespace(chars) => {
+                        XDone
+                },
+                EOFXToken => {
+                    self.stop_parsing()
+                }
+                _ => {
+                    self.sink.parse_error(Borrowed("Unexpected element in end phase"));
+                    XDone
+                }
+            },
+
+        }
     }
 }

--- a/src/tree_builder/rules.rs
+++ b/src/tree_builder/rules.rs
@@ -395,7 +395,7 @@ impl<Handle, Sink> TreeBuilderStep
 
                     let mut to_close = None;
                     for node in self.open_elems.iter().rev() {
-                        let name = self.sink.elem_name(node.clone());
+                        let name = self.sink.elem_name(&node);
                         if can_close(name.clone()) {
                             to_close = Some(name.local);
                             break;
@@ -1360,7 +1360,7 @@ impl<Handle, Sink> TreeBuilderStep
                     }
 
                     let node = self.open_elems[stack_idx].clone();
-                    let node_name = self.sink.elem_name(node);
+                    let node_name = self.sink.elem_name(&node);
                     if !first && node_name.ns == ns!(HTML) {
                         let mode = self.mode;
                         return self.step(mode, TagToken(tag));

--- a/src/tree_builder/types.rs
+++ b/src/tree_builder/types.rs
@@ -10,11 +10,15 @@
 //! Types used within the tree builder code.  Not exported to users.
 
 use tokenizer::Tag;
+use tokenizer::{XTag, XPi};
 
 pub use self::InsertionMode::*;
+pub use self::XmlPhase::*;
 pub use self::SplitStatus::*;
 pub use self::Token::*;
+pub use self::XToken::*;
 pub use self::ProcessResult::*;
+pub use self::XmlProcessResult::*;
 pub use self::FormatEntry::*;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
@@ -43,6 +47,12 @@ pub enum InsertionMode {
     AfterAfterBody,
     AfterAfterFrameset,
 }
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum XmlPhase {
+    StartPhase,
+    MainPhase,
+    EndPhase,
+}
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum SplitStatus {
@@ -60,6 +70,23 @@ pub enum Token {
     CharacterTokens(SplitStatus, String),
     NullCharacterToken,
     EOFToken,
+}
+
+/// A subset/refinement of `tokenizer::XToken`.  Everything else is handled
+/// specially at the beginning of `process_token`.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum XToken {
+    XTagToken(XTag),
+    CommentXToken(String),
+    CharacterXTokens(String),
+    PIToken(XPi),
+    NullCharacterXToken,
+    EOFXToken,
+}
+
+pub enum XmlProcessResult {
+    XDone,
+    XReprocess(XmlPhase, XToken),
 }
 
 pub enum ProcessResult {

--- a/src/util/str.rs
+++ b/src/util/str.rs
@@ -199,6 +199,23 @@ pub fn char_run<Pred>(mut pred: Pred, buf: &str) -> Option<(usize, bool)>
     Some((buf.len(), matches))
 }
 
+/// Determines if the character is a valid name character
+/// according to XML 1.1 spec
+pub fn is_xml_namechar(c: &char) -> bool {
+    match *c {
+        'A'...'Z' | 'a'...'z' |  '0'...'9'
+        | ':' | '_' | '-' | '.' | '\u{B7}' | '\u{C0}'...'\u{D6}'
+        | '\u{D8}'...'\u{F6}' | '\u{370}'...'\u{37D}'
+        | '\u{37F}'...'\u{1FFF}' | '\u{200C}'...'\u{200D}'
+        | '\u{0300}'...'\u{036F}' | '\u{203F}'...'\u{2040}'
+        | '\u{2070}'...'\u{218F}' | '\u{2C00}'...'\u{2FEF}'
+        | '\u{3001}'...'\u{D7FF}' | '\u{F900}'...'\u{FDCF}'
+        | '\u{FDF0}'...'\u{FFFD}' | '\u{10000}'...'\u{EFFFF}'
+        => true,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 #[allow(non_snake_case)]
 mod test {

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -32,3 +32,24 @@ pub fn foreach_html5lib_test<Mk>(
         }
     }
 }
+
+pub fn foreach_xml5lib_test<Mk>(
+        src_dir: &Path,
+        subdir: &'static str,
+        ext: &'static OsStr,
+        mut mk: Mk)
+    where Mk: FnMut(&Path, fs::File)
+{
+    let mut test_dir_path = src_dir.to_path_buf();
+    test_dir_path.push("xml5lib-tests");
+    test_dir_path.push(subdir);
+
+    let test_files = fs::read_dir(&test_dir_path).unwrap();
+    for entry in test_files {
+        let path = entry.unwrap().path();
+        if path.extension() == Some(ext) {
+            let file = fs::File::open(&path).unwrap();
+            mk(&path, file);
+        }
+    }
+}

--- a/tests/tree_builder.rs
+++ b/tests/tree_builder.rs
@@ -32,7 +32,7 @@ use test::{TestDesc, TestDescAndFn, DynTestName, DynTestFn};
 use test::ShouldPanic::No;
 
 use html5ever::{parse, parse_fragment, one_input};
-use html5ever_dom_sink::common::{Document, Doctype, Text, Comment, Element};
+use html5ever_dom_sink::common::{Document, Doctype, Text, Comment, Element, PI};
 use html5ever_dom_sink::rcdom::{RcDom, Handle};
 
 use string_cache::Atom;
@@ -102,6 +102,14 @@ fn serialize(buf: &mut String, indent: usize, handle: Handle) {
             buf.push_str("\"");
             buf.push_str(&text);
             buf.push_str("\"\n");
+        }
+
+        PI(ref target, ref data) => {
+            buf.push_str("<?");
+            buf.push_str(&target);
+            buf.push_str(" ");
+            buf.push_str(&data);
+            buf.push_str("?>\n");
         }
 
         Comment(ref text) => {

--- a/tests/tree_builder.rs
+++ b/tests/tree_builder.rs
@@ -18,7 +18,7 @@ extern crate html5ever;
 extern crate html5ever_dom_sink;
 extern crate test_util;
 
-use test_util::foreach_html5lib_test;
+use test_util::{foreach_html5lib_test, foreach_xml5lib_test};
 
 use std::{fs, io, env, rt};
 use std::io::BufRead;
@@ -31,7 +31,7 @@ use std::collections::{HashSet, HashMap};
 use test::{TestDesc, TestDescAndFn, DynTestName, DynTestFn};
 use test::ShouldPanic::No;
 
-use html5ever::{parse, parse_fragment, one_input};
+use html5ever::{parse, parse_fragment, one_input, parse_xml};
 use html5ever_dom_sink::common::{Document, Doctype, Text, Comment, Element, PI};
 use html5ever_dom_sink::rcdom::{RcDom, Handle};
 
@@ -215,6 +215,49 @@ fn make_test(
     });
 }
 
+fn make_xml_test(
+        tests: &mut Vec<TestDescAndFn>,
+        ignores: &HashSet<String>,
+        filename: &str,
+        idx: usize,
+        fields: HashMap<String, String>) {
+
+    let get_field = |key| {
+        let field = fields.get(key).expect("missing field");
+        field.trim_right_matches('\n').to_string()
+    };
+
+    let data = get_field("data");
+    let expected = get_field("document");
+    let name = format!("tb: {}-{}", filename, idx);
+    let ignore = ignores.contains(&name)
+        || IGNORE_SUBSTRS.iter().any(|&ig| data.contains(ig));
+
+    tests.push(TestDescAndFn {
+        desc: TestDesc {
+            name: DynTestName(name),
+            ignore: ignore,
+            should_panic: No,
+        },
+        testfn: DynTestFn(Box::new(move || {
+            let mut result = String::new();
+
+            let dom: RcDom = parse_xml(one_input(data.clone()), Default::default());
+            for child in dom.document.borrow().children.iter() {
+                serialize(&mut result, 1, child.clone());
+            }
+
+            let len = result.len();
+            result.truncate(len - 1);  // drop the trailing newline
+
+            if result != expected {
+                panic!("\ninput: {}\ngot:\n{}\nexpected:\n{}\n",
+                    data, result, expected);
+            }
+        })),
+    });
+}
+
 fn tests(src_dir: &Path, ignores: &HashSet<String>) -> Vec<TestDescAndFn> {
     let mut tests = vec!();
 
@@ -229,6 +272,20 @@ fn tests(src_dir: &Path, ignores: &HashSet<String>) -> Vec<TestDescAndFn> {
             make_test(&mut tests, ignores, path.file_name().unwrap().to_str().unwrap(),
                       i, test);
         }
+    });
+
+    foreach_xml5lib_test(src_dir, "tree-construction",
+                         OsStr::new("dat"), |path, file| {
+        let buf = io::BufReader::new(file);
+        let lines = buf.lines()
+            .map(|res| res.ok().expect("couldn't read"));
+        let data = parse_tests(lines);
+
+        for (i, test) in data.into_iter().enumerate() {
+            make_xml_test(&mut tests, ignores, path.file_name().unwrap().to_str().unwrap(),
+                          i, test);
+        }
+
     });
 
     tests

--- a/xml5lib-tests/AUTHORS.rst
+++ b/xml5lib-tests/AUTHORS.rst
@@ -1,0 +1,9 @@
+Credits
+=======
+
+The ``xml5lib`` test data is maintained by:
+
+- Daniel Fath
+
+Contributors
+------------

--- a/xml5lib-tests/LICENSE
+++ b/xml5lib-tests/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2006-2013 James Graham, Geoffrey Sneddon and
+other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/xml5lib-tests/tokenizer/README.md
+++ b/xml5lib-tests/tokenizer/README.md
@@ -1,0 +1,104 @@
+Tokenizer tests
+===============
+
+The test format is [JSON](http://www.json.org/). This has the advantage
+that the syntax allows backward-compatible extensions to the tests and
+the disadvantage that it is relatively verbose.
+
+Basic Structure
+---------------
+
+    {"tests": [
+        {"description": "Test description",
+        "input": "input_string",
+        "output": [expected_output_tokens],
+        "initialStates": [initial_states],
+        "lastStartTag": last_start_tag,
+        "ignoreErrorOrder": ignore_error_order
+        }
+    ]}
+
+Multiple tests per file are allowed simply by adding more objects to the
+"tests" list.
+
+`description`, `input` and `output` are always present. The other values
+are optional.
+
+### Test set-up
+
+`test.input` is a string containing the characters to pass to the
+tokenizer. Specifically, it represents the characters of the **input
+stream**, and so implementations are expected to perform the processing
+described in the spec's **Preprocessing the input stream** section
+before feeding the result to the tokenizer.
+
+If `test.doubleEscaped` is present and `true`, then `test.input` is not
+quite as described above. Instead, it must first be subjected to another
+round of unescaping (i.e., in addition to any unescaping involved in the
+JSON import), and the result of *that* represents the characters of the
+input stream. Currently, the only unescaping required by this option is
+to convert each sequence of the form \\uHHHH (where H is a hex digit)
+into the corresponding Unicode code point. (Note that this option also
+affects the interpretation of `test.output`.)
+
+`test.initialStates` is a list of strings, each being the name of a
+tokenizer state. The test should be run once for each string, using it
+to set the tokenizer's initial state for that run. If
+`test.initialStates` is omitted, it defaults to `["data state"]`.
+
+`test.lastStartTag` is a lowercase string that should be used as "the
+tag name of the last start tag to have been emitted from this
+tokenizer", referenced in the spec's definition of **appropriate end tag
+token**. If it is omitted, it is treated as if "no start tag has been
+emitted from this tokenizer".
+
+### Test results
+
+`test.output` is a list of tokens, ordered with the first produced by
+the tokenizer the first (leftmost) in the list. The list must mach the
+**complete** list of tokens that the tokenizer should produce. Valid
+tokens are:
+
+    ["DOCTYPE", name, public_id, system_id, correctness]
+    ["StartTag", name, {attributes}*, true*]
+    ["StartTag", name, {attributes}]
+    ["EndTag", name]
+    ["Comment", data]
+    ["Character", data]
+    "ParseError"
+
+`public_id` and `system_id` are either strings or `null`. `correctness`
+is either `true` or `false`; `true` corresponds to the force-quirks flag
+being false, and vice-versa.
+
+When the self-closing flag is set, the `StartTag` array has `true` as
+its fourth entry. When the flag is not set, the array has only three
+entries for backwards compatibility.
+
+All adjacent character tokens are coalesced into a single
+`["Character", data]` token.
+
+If `test.doubleEscaped` is present and `true`, then every string within
+`test.output` must be further unescaped (as described above) before
+comparing with the tokenizer's output.
+
+`test.ignoreErrorOrder` is a boolean value indicating that the order of
+`ParseError` tokens relative to other tokens in the output stream is
+unimportant, and implementations should ignore such differences between
+their output and `expected_output_tokens`. (This is used for errors
+emitted by the input stream preprocessing stage, since it is useful to
+test that code but it is undefined when the errors occur). If it is
+omitted, it defaults to `false`.
+
+xmlViolation tests
+------------------
+
+`tokenizer/xmlViolation.test` differs from the above in a couple of
+ways:
+
+-   The name of the single member of the top-level JSON object is
+    "xmlViolationTests" instead of "tests".
+-   Each test's expected output assumes that implementation is applying
+    the tweaks given in the spec's "Coercing an HTML DOM into an
+    infoset" section.
+

--- a/xml5lib-tests/tokenizer/eof.test
+++ b/xml5lib-tests/tokenizer/eof.test
@@ -1,0 +1,113 @@
+{"tests": [
+
+{"description":"Data state EOF",
+"input":"",
+"output":[]
+},
+
+{"description":"Tag state EOF",
+"input":"<",
+"output":["ParseError", ["Character", "<"]]
+},
+
+{"description":"End tag state premature EOF",
+"input":"</",
+"output":["ParseError", ["Character", "</"]]
+},
+
+{"description":"End tag name state premature EOF",
+"input":"</a",
+"output":["ParseError", ["EndTag", "a"]]
+},
+
+{"description":"Pi state EOF",
+"input":"<?",
+"output":["ParseError", ["Comment", ""]]
+},
+
+{"description":"PI state Target EOF",
+"input":"<?ab",
+"output":["ParseError", ["PI", "ab", ""]]
+},
+
+{"description":"PI state Target after EOF",
+"input":"<?ab  ",
+"output":["ParseError", ["PI", "ab", ""]]
+},
+
+{"description":"PI state Target after EOF with some text",
+"input":"<?ab az",
+"output":["ParseError", ["PI", "ab", "az"]]
+},
+
+{"description":"End tag with attributes premature EOF",
+"input":"<a x=test /",
+"output":["ParseError", "ParseError", ["EmptyTag", "a", {"x":"test"}]]
+},
+
+{"description":"Comment EOF",
+"input":"<!",
+"output":["ParseError", ["Comment", ""]]
+},
+
+{"description":"Comment dash state EOF",
+"input":"<!-",
+"output":["ParseError", ["Comment", "-"]]
+},
+
+{"description":"Comment dash state EOF",
+"input":"<!--",
+"output":["ParseError", ["Comment", ""]]
+},
+
+{"description":"CDATA state EOF",
+"input":"<![CDATA[",
+"output":["ParseError"]
+},
+
+{"description":"CDATA bracket state EOF",
+"input":"<![CDATA[]",
+"output":["ParseError"]
+},
+
+{"description":"CDATA bracket state EOF with chars",
+"input":"<![CDATA[ax]",
+"output":[["Character", "ax"], "ParseError"]
+},
+
+{"description":"Tag name state EOF",
+"input":"<ab",
+"output":["ParseError", ["StartTag", "ab", {}]]
+},
+
+{"description":"Tag name state EOF",
+"input":"<ab ",
+"output":["ParseError", ["StartTag", "ab", {}]]
+},
+
+{"description":"Tag attribute name state EOF",
+"input":"<ab xa",
+"output":["ParseError", ["StartTag", "ab", {"xa":""}]]
+},
+
+{"description":"Tag attribute name after state EOF",
+"input":"<ab xa=",
+"output":["ParseError", ["StartTag", "ab", {"xa":""}]]
+},
+
+{"description":"Tag attribute name state EOF single-quoted",
+"input":"<ab foo='bar'",
+"output":["ParseError", ["StartTag", "ab", {"foo":"bar"}]]
+},
+
+{"description":"Tag attribute name state EOF unquoted",
+"input":"<ab foo=bar",
+"output":["ParseError", ["StartTag", "ab", {"foo":"bar"}]]
+},
+
+{"description":"Tag attribute name state EOF double-quoted",
+"input":"<ab foo=\"bar\"",
+"output":["ParseError", ["StartTag", "ab", {"foo":"bar"}]]
+}
+
+]}

--- a/xml5lib-tests/tokenizer/test1.test
+++ b/xml5lib-tests/tokenizer/test1.test
@@ -1,0 +1,149 @@
+{"tests": [
+
+{"description":"Tags test",
+"input":"<z></z></><a/>",
+"output":[["StartTag", "z", {}], ["EndTag", "z"], ["ShortTag", ""], ["EmptyTag", "a", {}]]
+},
+
+{"description":"Test longer tags",
+"input":"<az></xyz>",
+"output":[["StartTag", "az",{}],["EndTag", "xyz"]]
+},
+
+{"description":"Attributes DoubleQuoted",
+"input":"<a ax=\"test\">",
+"output":[["StartTag", "a", {"ax":"test"}]]},
+
+{"description":"Attributes SingleQuoted",
+"input":"<b ay='test'>",
+"output":[["StartTag", "b", {"ay":"test"}]]},
+
+{"description":"Attributes UnQuoted",
+"input":"<c az=test>",
+"output":[["StartTag", "c", {"az":"test"}]]},
+
+{"description":"Start tag multiple attributes",
+"input":"<c a=test1 b='test2' c=\"test3\">",
+"output":[["StartTag", "c", {"a":"test1", "b":"test2", "c":"test3"}]]},
+
+{"description":"Empty Tag multiple attributes",
+"input":"<c a=test1 b='test2' c=\"test3\"/>",
+"output":[["EmptyTag", "c", {"a":"test1", "b":"test2", "c":"test3"}]]
+},
+
+{"description":"Tag state Error >",
+"input":"<>",
+"output":["ParseError", ["Character", "<>"]]
+},
+
+{"description":"Tag state Error :",
+"input":"<:",
+"output":["ParseError", ["Character", "<:"]
+]},
+
+{"description":"Tag state Error <",
+"input":"<<",
+"output":["ParseError", ["Character", "<"], "ParseError", ["Character", "<"]]
+},
+
+{"description":"Tag state Error ' '",
+"input":"< ",
+"output":["ParseError", ["Character", "< "]]
+},
+
+{"description":"Tag state Error '\\t'",
+"input":"<\t",
+"output":["ParseError", ["Character", "<\t"]]
+},
+
+{"description":"Tag state Error '\\n'",
+"input":"<\n",
+"output":["ParseError", ["Character", "<\n"]]
+},
+
+{"description":"End tag state Error '\\t'",
+"input":"</\t",
+"output":["ParseError", ["Character", "</\t"]]
+},
+
+{"description":"End tag state Error '\\n'",
+"input":"</\n",
+"output":["ParseError", ["Character", "</\n"]]
+},
+
+{"description":"End tag state Error '\\n'",
+"input":"</ ",
+"output":["ParseError", ["Character", "</ "]]
+},
+
+{"description":"End tag state Error '<'",
+"input":"</<",
+"output":["ParseError", ["Character", "</"], "ParseError", ["Character", "<"]]
+},
+
+{"description":"End tag name after state",
+"input":"</a >",
+"output":[["EndTag", "a"]]
+},
+
+{"description":"End tag name after state with attr",
+"input":"</a f='x'>",
+"output":["ParseError", "ParseError", "ParseError", "ParseError", "ParseError", ["EndTag", "a"]]
+},
+
+{"description":"PI tag",
+"input":"<?xslt ma?>",
+"output":[["PI", "xslt", "ma"]]
+},
+
+{"description":"PI tag",
+"input":"<?xslt \t\n m?>",
+"output":[["PI", "xslt", "m"]]
+},
+
+{"description":"PI tag with '?' in target",
+"input":"<??xml \t\n m?>",
+"output":[["PI", "?xml", "m"]]
+},
+
+{"description":"Comment",
+"input":"<!--comment-->",
+"output":[["Comment", "comment"]]
+},
+
+{"description":"Comment",
+"input":"<!----comment -->",
+"output":[["Comment", "--comment "]]
+},
+
+{"description":"Comment",
+"input":"<!----comment--->",
+"output":[["Comment", "--comment-"]]
+},
+
+{"description":"Tiny Bogus Comment",
+"input":"<!>",
+"output":["ParseError", ["Comment", ""]]
+},
+
+{"description":"Short Bogus Comment",
+"input":"<!-->",
+"output":["ParseError", ["Comment", ""]]
+},
+
+{"description":"CDATA state",
+"input":"<![CDATA[&amping]]>",
+"output":[["Character", "&amping"]]
+},
+
+{"description":"CDATA state",
+"input":"<![CDATA[&amping ]]]>",
+"output":[["Character", "&amping ]"]]
+},
+
+{"description":"CDATA state",
+"input":"<![CDATA[&amping]] ]]>",
+"output":[["Character", "&amping]] "]]
+}
+
+]}

--- a/xml5lib-tests/tokenizer/test2.test
+++ b/xml5lib-tests/tokenizer/test2.test
@@ -1,0 +1,64 @@
+{"tests": [
+
+{"description":"EOF",
+"input":"",
+"output":[]
+},
+
+{"description":"End tag state premature EOF",
+"input":"</",
+"output":["ParseError", ["Character", "</"]]
+},
+
+{"description":"End tag name state premature EOF",
+"input":"</a",
+"output":["ParseError", ["EndTag", "a"]]
+},
+
+{"description":"End tag with attributes premature EOF",
+"input":"<a x=test /",
+"output":["ParseError", "ParseError", ["EmptyTag", "a", {"x":"test"}]]
+},
+
+
+{"description":"PI tag with '\\t' in target",
+"input":"<?\txml m?>",
+"output":["ParseError", ["Comment", "\txml m?"]]
+},
+
+{"description":"PI tag with '\\n' in target",
+"input":"<?\nxml m?>",
+"output":["ParseError", ["Comment", "\nxml m?"]]
+},
+
+{"description":"PI tag with ' ' in target",
+"input":"<? xml m?>",
+"output":["ParseError", ["Comment", " xml m?"]]
+},
+
+{"description":"Double end element",
+"input":"</br/>",
+"output":["ParseError", ["EndTag", "br"]]
+},
+
+{"description":"Start tag double attributes, one unfinished",
+"input":"<b ay='test' ay>",
+"output":["ParseError", ["StartTag", "b", {"ay":"test"}]]
+},
+
+{"description":"Start tag double attributes",
+"input":"<b ay='test' ay='x'>",
+"output":["ParseError", ["StartTag", "b", {"ay":"test"}]]
+},
+
+{"description":"Empty tag double attributes, one unfinished",
+"input":"<b ay='test' ay/>",
+"output":["ParseError", ["EmptyTag", "b", {"ay":"test"}]]
+},
+
+{"description":"Empty tag double attributes",
+"input":"<b ay='test' ay='x'/>",
+"output":["ParseError", ["EmptyTag", "b", {"ay":"test"}]]
+}
+
+]}

--- a/xml5lib-tests/tree-construction/README.md
+++ b/xml5lib-tests/tree-construction/README.md
@@ -1,0 +1,104 @@
+Tree Construction Tests
+=======================
+
+Each file containing tree construction tests consists of any number of
+tests separated by two newlines (LF) and a single newline before the end
+of the file. For instance:
+
+    [TEST]LF
+    LF
+    [TEST]LF
+    LF
+    [TEST]LF
+
+Where [TEST] is the following format:
+
+Each test must begin with a string "\#data" followed by a newline (LF).
+All subsequent lines until a line that says "\#errors" are the test data
+and must be passed to the system being tested unchanged, except with the
+final newline (on the last line) removed.
+
+Then there must be a line that says "\#errors". It must be followed by
+one line per parse error that a conformant checker would return. It
+doesn't matter what those lines are, although they can't be
+"\#document-fragment", "\#document", "\#script-off", "\#script-on", or
+empty, the only thing that matters is that there be the right number
+of parse errors.
+
+Then there \*may\* be a line that says "\#document-fragment", which must
+be followed by a newline (LF), followed by a string of characters that
+indicates the context element, followed by a newline (LF). If the string 
+of characters starts with "svg ", the context element is in the SVG
+namespace and the substring after "svg " is the local name. If the
+string of characters starts with "math ", the context element is in the
+MathML namespace and the substring after "math " is the local name.
+Otherwise, the context element is in the HTML namespace and the string
+is the local name. If this line is present the "\#data" must be parsed
+using the HTML fragment parsing algorithm with the context element as
+context.
+
+Then there \*may\* be a line that says "\#script-off" or
+"\#script-in". If a line that says "\#script-off" is present, the
+parser must set the scripting flag to disabled. If a line that says
+"\#script-on" is present, it must set it to enabled. Otherwise, the
+test should be run in both modes.
+
+Then there must be a line that says "\#document", which must be followed
+by a dump of the tree of the parsed DOM. Each node must be represented
+by a single line. Each line must start with "| ", followed by two spaces
+per parent node that the node has before the root document node.
+
+-   Element nodes must be represented by a "`<`" then the *tag name
+    string* "`>`", and all the attributes must be given, sorted
+    lexicographically by UTF-16 code unit according to their *attribute
+    name string*, on subsequent lines, as if they were children of the
+    element node.
+-   Attribute nodes must have the *attribute name string*, then an "="
+    sign, then the attribute value in double quotes (").
+-   Text nodes must be the string, in double quotes. Newlines aren't
+    escaped.
+-   Comments must be "`<`" then "`!-- `" then the data then "` -->`".
+-   DOCTYPEs must be "`<!DOCTYPE `" then the name then if either of the
+    system id or public id is non-empty a space, public id in
+    double-quotes, another space an the system id in double-quotes, and
+    then in any case "`>`".
+-   Processing instructions must be "`<?`", then the target, then a
+    space, then the data and then "`>`". (The HTML parser cannot emit
+    processing instructions, but scripts can, and the WebVTT to DOM
+    rules can emit them.)
+-   Template contents are represented by the string "content" with the
+    children below it.
+
+The *tag name string* is the local name prefixed by a namespace
+designator. For the HTML namespace, the namespace designator is the
+empty string, i.e. there's no prefix. For the SVG namespace, the
+namespace designator is "svg ". For the MathML namespace, the namespace
+designator is "math ".
+
+The *attribute name string* is the local name prefixed by a namespace
+designator. For no namespace, the namespace designator is the empty
+string, i.e. there's no prefix. For the XLink namespace, the namespace
+designator is "xlink ". For the XML namespace, the namespace designator
+is "xml ". For the XMLNS namespace, the namespace designator is "xmlns
+". Note the difference between "xlink:href" which is an attribute in no
+namespace with the local name "xlink:href" and "xlink href" which is an
+attribute in the xlink namespace with the local name "href".
+
+If there is also a "\#document-fragment" the bit following "\#document"
+must be a representation of the HTML fragment serialization for the
+context element given by "\#document-fragment".
+
+For example:
+
+    #data
+    <p>One<p>Two
+    #errors
+    3: Missing document type declaration
+    #document
+    | <html>
+    |   <head>
+    |   <body>
+    |     <p>
+    |       "One"
+    |     <p>
+    |       "Two"

--- a/xml5lib-tests/tree-construction/test1.dat
+++ b/xml5lib-tests/tree-construction/test1.dat
@@ -1,0 +1,102 @@
+#data
+<a></a>
+#document
+| <a>
+
+#data
+<!--COMMENT?--><a>
+#document
+| <!-- COMMENT? -->
+| <a>
+
+#data
+<!COMMENT?><a>
+#document
+| <!-- COMMENT? -->
+| <a>
+
+#data
+<?pix xml?><a>
+#document
+| <?pix xml?>
+| <a>
+
+#data
+<a/>
+#document
+| <a>
+
+#data
+<a>Text
+#document
+| <a>
+|   "Text"
+
+
+#data
+<a><b>
+#document
+| <a>
+|   <b>
+
+#data
+<a><b></b></a>
+#document
+| <a>
+|   <b>
+
+#data
+<a><b/></a>
+#document
+| <a>
+|   <b>
+
+#data
+<a><b/>
+#document
+| <a>
+|   <b>
+
+#data
+<a><b>Text
+#document
+| <a>
+|   <b>
+|     "Text"
+
+#data
+<a><b>Text</b>
+#document
+| <a>
+|   <b>
+|     "Text"
+
+#data
+<a><!--COMMENT-->
+#document
+| <a>
+|   <!-- COMMENT -->
+
+#data
+<a><?xslt dummy?>
+#document
+| <a>
+|   <?xslt dummy?>
+
+#data
+<a></a><?xslt dummy?>
+#document
+| <a>
+| <?xslt dummy?>
+
+#data
+<a></a><!--COMMENT-->
+#document
+| <a>
+| <!-- COMMENT -->
+
+#data
+<a><x></x></a><b>
+#document
+| <a>
+|   <x>


### PR DESCRIPTION
This large commit concerns #43. It adds everything that is currently defined in spec.

Included inside:
 
- Basic machinery - Tokenizer/States/Tree builder/etc. that implements following spec: [Ygg01/xml5_draft](https://github.com/Ygg01/xml5_draft)
- Tests, which reference:  [Ygg01/xml5lib-test](https://github.com/Ygg01/xml5lib-test)
- Some basic examples

Missing:
 - Namespace resolution
 - Doctype handling as per Ygg01/xml5_draft#2
 - Entity replacement (this is mostly C'n'P from html5ever character tokenizer), so all html5 entities are valid (e.g. &dash; &Aacute; etc.)
 - Unification of xml5 and html5 syntax
 - C API