### PR TITLE
Remove deprecated `unstable` attribute.

### DIFF
--- a/src/sink/owned_dom.rs
+++ b/src/sink/owned_dom.rs
@@ -7,17 +7,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![unstable(feature="string_cache_namespace",
-    reason="This module uses unsafe code, has not been thoroughly \
-            audited, and the performance gains vs. RcDom have not \
-            been demonstrated")]
-
 //! A simple DOM where every node is owned by its parent.
 //!
 //! Since ownership is more complicated during parsing, we actually
 //! build a different type and then transmute to the public `Node`.
 //! This is believed to be memory safe, but if you want to be extra
 //! careful you can use `RcDom` instead.
+//!
+//! **Warning: Unstable.** This module uses unsafe code, has not
+//! been thoroughly audited, and the performance gains vs. RcDom
+//! have not been demonstrated.
 
 use sink::common::{NodeEnum, Document, Doctype, Text, Comment, Element};
 


### PR DESCRIPTION
Fixes a build warning in rustc nightly.  Move the warning to a doc comment instead. r? @kmcallister