### PR TITLE
Make the `sink` module an optional feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ rustc-serialize = "0"
 [dev-dependencies.test_util]
 path = "test_util"
 
+[dev-dependencies.html5ever_dom_sink]
+path = "dom_sink"
+
 [profile.dev]
 debug = false
 

--- a/dom_sink/Cargo.toml
+++ b/dom_sink/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "html5ever_dom_sink"
+version = "0.0.0"
+authors = [ "The html5ever Project Developers" ]
+
+[lib]
+name = "html5ever_dom_sink"
+
+[dependencies.html5ever]
+path = "../"
+
+[dependencies.mac]
+git = "https://github.com/reem/rust-mac"
+
+[dependencies.string_cache]
+git = "https://github.com/servo/string-cache"

--- a/dom_sink/src/common.rs
+++ b/dom_sink/src/common.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use tokenizer::Attribute;
+use html5ever::tokenizer::Attribute;
 
 use string_cache::QualName;
 

--- a/dom_sink/src/lib.rs
+++ b/dom_sink/src/lib.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The html5ever Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name="html5ever_dom_sink"]
+#![crate_type="dylib"]
+
+#![feature(alloc, box_syntax, collections)]
+
+extern crate html5ever;
+
+#[macro_use]
+extern crate string_cache;
+
+#[macro_use]
+extern crate mac;
+
+pub mod common;
+pub mod rcdom;
+pub mod owned_dom;

--- a/dom_sink/src/owned_dom.rs
+++ b/dom_sink/src/owned_dom.rs
@@ -18,15 +18,15 @@
 //! been thoroughly audited, and the performance gains vs. RcDom
 //! have not been demonstrated.
 
-use sink::common::{NodeEnum, Document, Doctype, Text, Comment, Element};
+use common::{NodeEnum, Document, Doctype, Text, Comment, Element};
 
-use tokenizer::Attribute;
-use tree_builder::{TreeSink, QuirksMode, NodeOrText, AppendNode, AppendText};
-use tree_builder;
-use serialize::{Serializable, Serializer};
-use serialize::TraversalScope;
-use serialize::TraversalScope::{IncludeNode, ChildrenOnly};
-use driver::ParseResult;
+use html5ever::tokenizer::Attribute;
+use html5ever::tree_builder::{TreeSink, QuirksMode, NodeOrText, AppendNode, AppendText};
+use html5ever::tree_builder;
+use html5ever::serialize::{Serializable, Serializer};
+use html5ever::serialize::TraversalScope;
+use html5ever::serialize::TraversalScope::{IncludeNode, ChildrenOnly};
+use html5ever::driver::ParseResult;
 
 use std::{mem, ptr};
 use std::cell::UnsafeCell;

--- a/examples/html2html.rs
+++ b/examples/html2html.rs
@@ -16,12 +16,13 @@
 //! where htmlparser-1.4.jar comes from http://about.validator.nu/htmlparser/
 
 extern crate html5ever;
+extern crate html5ever_dom_sink;
 
 use std::io::{self, Read, Write};
 use std::default::Default;
 
-use html5ever::sink::rcdom::RcDom;
 use html5ever::driver::ParseOpts;
+use html5ever_dom_sink::rcdom::RcDom;
 use html5ever::tree_builder::TreeBuilderOpts;
 use html5ever::{parse, one_input, serialize};
 

--- a/examples/print-rcdom.rs
+++ b/examples/print-rcdom.rs
@@ -11,6 +11,7 @@
 #![plugin(string_cache_plugin)]
 
 extern crate html5ever;
+extern crate html5ever_dom_sink;
 
 #[macro_use]
 extern crate string_cache;
@@ -20,9 +21,9 @@ use std::iter::repeat;
 use std::default::Default;
 use std::string::String;
 
-use html5ever::sink::common::{Document, Doctype, Text, Comment, Element};
-use html5ever::sink::rcdom::{RcDom, Handle};
 use html5ever::{parse, one_input};
+use html5ever_dom_sink::common::{Document, Doctype, Text, Comment, Element};
+use html5ever_dom_sink::rcdom::{RcDom, Handle};
 
 // This is not proper HTML serialization, of course.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![crate_name="html5ever"]
 #![crate_type="dylib"]
 
-#![feature(plugin, box_syntax, core, collections, alloc, str_char, slice_patterns)]
+#![feature(plugin, box_syntax, core, collections, str_char, slice_patterns)]
 #![deny(warnings)]
 #![allow(unused_parens)]
 
@@ -49,12 +49,5 @@ pub mod tokenizer;
 pub mod tree_builder;
 
 pub mod serialize;
-
-/// Consumers of the parser API.
-pub mod sink {
-    pub mod common;
-    pub mod rcdom;
-    pub mod owned_dom;
-}
 
 pub mod driver;

--- a/tests/serializer.rs
+++ b/tests/serializer.rs
@@ -12,13 +12,14 @@
 
 extern crate string_cache;
 extern crate html5ever;
+extern crate html5ever_dom_sink;
 
 use std::default::Default;
 use std::borrow::ToOwned;
 
-use html5ever::sink::rcdom::RcDom;
 use html5ever::driver::ParseOpts;
 use html5ever::{parse_fragment, one_input, serialize};
+use html5ever_dom_sink::rcdom::RcDom;
 
 fn parse_and_serialize(input: String) -> String {
     let dom: RcDom = parse_fragment(one_input(input), atom!(body), ParseOpts::default());

--- a/tests/tree_builder.rs
+++ b/tests/tree_builder.rs
@@ -15,6 +15,7 @@ extern crate test;
 extern crate string_cache;
 
 extern crate html5ever;
+extern crate html5ever_dom_sink;
 extern crate test_util;
 
 use test_util::foreach_html5lib_test;
@@ -30,9 +31,9 @@ use std::collections::{HashSet, HashMap};
 use test::{TestDesc, TestDescAndFn, DynTestName, DynTestFn};
 use test::ShouldPanic::No;
 
-use html5ever::sink::common::{Document, Doctype, Text, Comment, Element};
-use html5ever::sink::rcdom::{RcDom, Handle};
 use html5ever::{parse, parse_fragment, one_input};
+use html5ever_dom_sink::common::{Document, Doctype, Text, Comment, Element};
+use html5ever_dom_sink::rcdom::{RcDom, Handle};
 
 use string_cache::Atom;
 


### PR DESCRIPTION
Consumers who provide their own sinks (like Servo) probably don't need this module.  Disabling it reduces compile time by about 20% (a couple of seconds on my laptop).  Probably reduces final link time and possibly binary size too, but I haven't measured those.

r? @kmcallister