### PR TITLE
Fix <noscript> tests

### DIFF
--- a/data/test/ignore
+++ b/data/test/ignore
@@ -13,13 +13,7 @@ tb: ruby.dat-20
 tb: ruby.dat-3
 tb: ruby.dat-5
 tb: ruby.dat-7
-tb: tests16.dat-181
-tb: tests16.dat-183
-tb: tests16.dat-185
 tb: tests16.dat-194
-tb: tests16.dat-84
-tb: tests16.dat-86
-tb: tests16.dat-88
 tb: tests19.dat-10
 tb: tests19.dat-11
 tb: tests19.dat-18
@@ -29,8 +23,6 @@ tb: tests19.dat-8
 tb: tests19.dat-9
 tb: tests2.dat-44
 tb: tests26.dat-9
-tb: tests5.dat-16
-tb: webkit02.dat-2
 tb: foreign-fragment.dat-0
 tb: foreign-fragment.dat-1
 tb: foreign-fragment.dat-18


### PR DESCRIPTION
Use the expectations' fields script-on and script-off to run the tests with their scripting flag set appropriately.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/158)
<!-- Reviewable:end -->
