### PR TITLE
Run tree builder and tokenizer tests again.

### DIFF
--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg_attr(feature = "unstable", feature(start, rt, test, plugin))]
+#![cfg_attr(feature = "unstable", feature(test, plugin))]
 #![cfg_attr(feature = "unstable", plugin(string_cache_plugin))]
 
 #[cfg(feature = "unstable")] extern crate test;
@@ -20,7 +20,7 @@ extern crate html5ever;
 mod foreach_html5lib_test;
 use foreach_html5lib_test::foreach_html5lib_test;
 
-use std::{char, env, rt};
+use std::{char, env};
 use std::ffi::OsStr;
 use std::mem::replace;
 use std::default::Default;
@@ -422,12 +422,8 @@ fn tests(src_dir: &Path) -> Vec<TestDescAndFn> {
 }
 
 #[cfg(feature = "unstable")]
-#[start]
-fn start(argc: isize, argv: *const *const u8) -> isize {
-    unsafe {
-        rt::args::init(argc, argv);
-    }
+#[test]
+fn run() {
     let args: Vec<_> = env::args().collect();
     test::test_main(&args, tests(Path::new(env!("CARGO_MANIFEST_DIR"))));
-    0
 }

--- a/tests/tree_builder.rs
+++ b/tests/tree_builder.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg_attr(feature = "unstable", feature(start, rt, test, plugin))]
+#![cfg_attr(feature = "unstable", feature(test, plugin))]
 #![cfg_attr(feature = "unstable", plugin(string_cache_plugin))]
 
 #[cfg(feature = "unstable")] extern crate test;
@@ -19,7 +19,7 @@ extern crate html5ever;
 mod foreach_html5lib_test;
 use foreach_html5lib_test::foreach_html5lib_test;
 
-use std::{fs, io, env, rt};
+use std::{fs, io, env};
 use std::io::BufRead;
 use std::ffi::OsStr;
 use std::iter::repeat;
@@ -266,11 +266,8 @@ fn tests(src_dir: &Path, ignores: &HashSet<String>) -> Vec<TestDescAndFn> {
 }
 
 #[cfg(feature = "unstable")]
-#[start]
-fn start(argc: isize, argv: *const *const u8) -> isize {
-    unsafe {
-        rt::args::init(argc, argv);
-    }
+#[test]
+fn run() {
     let args: Vec<_> = env::args().collect();
     let src_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut ignores = HashSet::new();
@@ -283,5 +280,4 @@ fn start(argc: isize, argv: *const *const u8) -> isize {
     }
 
     test::test_main(&args, tests(src_dir, &ignores));
-    0
 }


### PR DESCRIPTION
Something change in rustc and the #[start] trick doesn’t run anymore.

This runs a test harness nested in another. It’s not pretty, but it works.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/168)
<!-- Reviewable:end -->
