### PR TITLE
Update inline tokenize example

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -29,7 +29,7 @@ pub fn one_input<T>(x: T) -> option::IntoIter<T> {
 ///
 /// ```ignore
 /// let sink = MySink;
-/// tokenize_to(&mut sink, one_input(my_str), Default::default());
+/// tokenize_to(sink, one_input(my_str), Default::default());
 /// ```
 pub fn tokenize_to<Sink, It>(sink: Sink, input: It, opts: TokenizerOpts) -> Sink
     where Sink: TokenSink,


### PR DESCRIPTION
`tokenize_to` was at some point changed to move the `sink` value instead of taking a mut ref, but the inline rustdoc example was not updated, causing lots of confusion

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/170)
<!-- Reviewable:end -->
