### PR TITLE
Separate tree_builder/rules.rs code generation from unstable optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.2.8"
+version = "0.2.9"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -16,8 +16,9 @@ name = "html5ever"
 doctest = false
 
 [features]
-unstable = ["html5ever_macros", "tendril/unstable", "string_cache/unstable", "string_cache_plugin", "rc/unstable"]
+unstable = ["tendril/unstable", "string_cache/unstable", "string_cache_plugin", "rc/unstable"]
 heap_size = ["heapsize", "heapsize_plugin"]
+codegen = ["html5ever_macros"]
 
 [dependencies]
 time = "0"

--- a/build.rs
+++ b/build.rs
@@ -32,14 +32,14 @@ fn main() {
         &Path::new(&env::var("OUT_DIR").unwrap()).join("named_entities.rs"))
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(feature = "codegen")]
 fn expand_match_tokens(from: &Path, to: &Path) {
     extern crate html5ever_macros;
 
     html5ever_macros::pre_expand(from, to);
 }
 
-#[cfg(not(feature = "unstable"))]
+#[cfg(not(feature = "codegen"))]
 fn expand_match_tokens(from: &Path, to: &Path) {
     use std::io::stderr;
     use std::process::exit;
@@ -51,7 +51,7 @@ fn expand_match_tokens(from: &Path, to: &Path) {
 {} is missing or not up to date with {}:
 {}
 
-Run `cargo build --features unstable` to update it.
+Run `cargo build --features codegen` to update it.
 
 If you’re using html5ever as a dependency, this is a bad release.
 Please file an issue at https://github.com/servo/html5ever/issues/new
@@ -65,7 +65,7 @@ with the output of `cargo pkgid html5ever`.
     }
 }
 
-#[cfg(not(feature = "unstable"))]
+#[cfg(not(feature = "codegen"))]
 fn check_hash(from: &Path, to: &Path) -> Result<(), String> {
     use std::hash::{Hash, Hasher, SipHasher};
     use std::io::Read;


### PR DESCRIPTION
… in Cargo features.

The 'codegen' feature is only useful when working on that file, dependency don’t need it. But they might still want NonZero/unsafe_no_drop_flag optimizations when on Rust Nightly.

This will reduce breaking of dependent crates when libsyntax changes.

r? @nox

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/182)
<!-- Reviewable:end -->
