### PR TITLE
Bump Tendril to 0.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = "0"
 phf = "0.7"
 string_cache = "0.2.0"
 mac = "0"
-tendril = "0.1.3"
+tendril = "0.1.6"
 rc = "0.1.1"
 heapsize = { version = "0.1.1", optional = true }
 heapsize_plugin = { version = "0.1.0", optional = true }

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib"]
 [dependencies]
 libc = "0.2"
 string_cache = "0.2"
-tendril = "0.1"
+tendril = "0.1.6"
 
 [dependencies.html5ever]
 path = "../"


### PR DESCRIPTION
People stuck on 0.1.5 and lower with a Cargo.lock file get a compile error
about using the core_intrinsics feature.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/185)
<!-- Reviewable:end -->
