### PR TITLE
Rewrite the high-level API (driver module) to use TendrilSink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.2.11"
+version = "0.3.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -26,7 +26,7 @@ log = "0"
 phf = "0.7"
 string_cache = "0.2.0"
 mac = "0"
-tendril = "0.1.6"
+tendril = "0.2"
 heapsize = { version = "0.1.1", optional = true }
 heapsize_plugin = { version = "0.1.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ mac = "0"
 tendril = "0.2"
 heapsize = { version = "0.1.1", optional = true }
 heapsize_plugin = { version = "0.1.0", optional = true }
+hyper = {version = "0.7", optional = true}
 
 [dev-dependencies]
 rustc-serialize = "0.3.15"

--- a/build.rs
+++ b/build.rs
@@ -29,7 +29,9 @@ fn main() {
 
     named_entities_to_phf(
         &Path::new(&manifest_dir).join("data/entities.json"),
-        &Path::new(&env::var("OUT_DIR").unwrap()).join("named_entities.rs"))
+        &Path::new(&env::var("OUT_DIR").unwrap()).join("named_entities.rs"));
+
+    println!("cargo:rerun-if-changed={}", rules_rs.display());
 }
 
 #[cfg(feature = "codegen")]

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["staticlib"]
 [dependencies]
 libc = "0.2"
 string_cache = "0.2"
-tendril = "0.1.6"
 
 [dependencies.html5ever]
 path = "../"

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -9,7 +9,6 @@
 
 extern crate libc;
 #[macro_use] extern crate string_cache;
-extern crate tendril;
 extern crate html5ever;
 
 use libc::c_int;

--- a/capi/src/tokenizer.rs
+++ b/capi/src/tokenizer.rs
@@ -11,6 +11,7 @@
 
 use c_bool;
 
+use html5ever::tendril::{StrTendril, SliceExt};
 use html5ever::tokenizer::{TokenSink, Token, Doctype, Tag, ParseError, DoctypeToken};
 use html5ever::tokenizer::{CommentToken, CharacterTokens, NullCharacterToken};
 use html5ever::tokenizer::{TagToken, StartTag, EndTag, EOFToken, Tokenizer};
@@ -20,7 +21,6 @@ use std::default::Default;
 
 use libc::{c_void, c_int, size_t};
 use string_cache::Atom;
-use tendril::{StrTendril, SliceExt};
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/examples/html2html.rs
+++ b/examples/html2html.rs
@@ -21,24 +21,26 @@ extern crate html5ever;
 use std::io::{self, Write};
 use std::default::Default;
 
-use tendril::{ByteTendril, ReadExt};
+use tendril::TendrilSink;
 
 use html5ever::driver::ParseOpts;
 use html5ever::tree_builder::TreeBuilderOpts;
-use html5ever::{parse, one_input, serialize};
+use html5ever::{parse_document, serialize};
 use html5ever::rcdom::RcDom;
 
 fn main() {
-    let mut input = ByteTendril::new();
-    io::stdin().read_to_tendril(&mut input).unwrap();
-    let input = input.try_reinterpret().unwrap();
-    let dom: RcDom = parse(one_input(input), ParseOpts {
+    let opts = ParseOpts {
         tree_builder: TreeBuilderOpts {
             drop_doctype: true,
             ..Default::default()
         },
         ..Default::default()
-    });
+    };
+    let stdin = io::stdin();
+    let dom = parse_document(RcDom::default(), opts)
+        .from_utf8()
+        .read_from(&mut stdin.lock())
+        .unwrap();
 
     // The validator.nu HTML2HTML always prints a doctype at the very beginning.
     io::stdout().write_all(b"<!DOCTYPE html>\n")

--- a/examples/noop-tokenize.rs
+++ b/examples/noop-tokenize.rs
@@ -17,8 +17,7 @@ use std::default::Default;
 
 use tendril::{ByteTendril, ReadExt};
 
-use html5ever::tokenizer::{TokenSink, Token};
-use html5ever::driver::{tokenize_to, one_input};
+use html5ever::tokenizer::{TokenSink, Token, Tokenizer};
 
 struct Sink(Vec<Token>);
 
@@ -35,5 +34,7 @@ fn main() {
     io::stdin().read_to_tendril(&mut input).unwrap();
     let input = input.try_reinterpret().unwrap();
 
-    tokenize_to(Sink(Vec::new()), one_input(input), Default::default());
+    let mut tok = Tokenizer::new(Sink(Vec::new()), Default::default());
+    tok.feed(input);
+    tok.end();
 }

--- a/examples/noop-tree-builder.rs
+++ b/examples/noop-tree-builder.rs
@@ -18,9 +18,9 @@ use std::collections::HashMap;
 use std::borrow::Cow;
 use string_cache::QualName;
 
-use tendril::{StrTendril, ByteTendril, ReadExt};
+use tendril::{StrTendril, TendrilSink};
 
-use html5ever::{parse_to, one_input};
+use html5ever::parse_document;
 use html5ever::tokenizer::Attribute;
 use html5ever::tree_builder::{TreeSink, QuirksMode, NodeOrText};
 
@@ -39,6 +39,8 @@ impl Sink {
 
 impl TreeSink for Sink {
     type Handle = usize;
+    type Output = Self;
+    fn finish(self) -> Self { self }
 
     fn get_document(&mut self) -> usize {
         0
@@ -96,9 +98,9 @@ fn main() {
         next_id: 1,
         names: HashMap::new(),
     };
-
-    let mut input = ByteTendril::new();
-    io::stdin().read_to_tendril(&mut input).unwrap();
-    let input = input.try_reinterpret().unwrap();
-    parse_to(sink, one_input(input), Default::default());
+    let stdin = io::stdin();
+    parse_document(sink, Default::default())
+        .from_utf8()
+        .read_from(&mut stdin.lock())
+        .unwrap();
 }

--- a/examples/print-rcdom.rs
+++ b/examples/print-rcdom.rs
@@ -18,8 +18,8 @@ use std::iter::repeat;
 use std::default::Default;
 use std::string::String;
 
-use tendril::{ByteTendril, ReadExt};
-use html5ever::{parse, one_input};
+use tendril::TendrilSink;
+use html5ever::parse_document;
 use html5ever::rcdom::{Document, Doctype, Text, Comment, Element, RcDom, Handle};
 
 // This is not proper HTML serialization, of course.
@@ -63,10 +63,11 @@ pub fn escape_default(s: &str) -> String {
 }
 
 fn main() {
-    let mut input = ByteTendril::new();
-    io::stdin().read_to_tendril(&mut input).unwrap();
-    let input = input.try_reinterpret().unwrap();
-    let dom: RcDom = parse(one_input(input), Default::default());
+    let stdin = io::stdin();
+    let dom = parse_document(RcDom::default(), Default::default())
+        .from_utf8()
+        .read_from(&mut stdin.lock())
+        .unwrap();
     walk(0, dom.document);
 
     if !dom.errors.is_empty() {

--- a/examples/tokenize.rs
+++ b/examples/tokenize.rs
@@ -15,9 +15,8 @@ use std::default::Default;
 
 use tendril::{ByteTendril, ReadExt};
 
-use html5ever::tokenizer::{TokenSink, Token, TokenizerOpts, ParseError};
+use html5ever::tokenizer::{TokenSink, Tokenizer, Token, TokenizerOpts, ParseError};
 use html5ever::tokenizer::{CharacterTokens, NullCharacterToken, TagToken, StartTag, EndTag};
-use html5ever::driver::{tokenize_to, one_input};
 
 #[derive(Copy, Clone)]
 struct TokenPrinter {
@@ -84,9 +83,12 @@ fn main() {
     let mut input = ByteTendril::new();
     io::stdin().read_to_tendril(&mut input).unwrap();
     let input = input.try_reinterpret().unwrap();
-    tokenize_to(sink, one_input(input), TokenizerOpts {
+
+    let mut tok = Tokenizer::new(sink, TokenizerOpts {
         profile: true,
         .. Default::default()
     });
+    tok.feed(input);
+    tok.end();
     sink.is_char(false);
 }

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -10,6 +10,7 @@
 
 set -ex
 
+cargo build --features hyper
 # Test without unstable first, to make sure src/tree_builder/rules.expanded.rs is up-to-date.
 cargo test --no-run
 cargo test | ./scripts/shrink-test-output.py

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -16,6 +16,7 @@ use std::borrow::Cow;
 use std::mem;
 
 use encoding::{self, EncodingRef};
+#[cfg(feature = "hyper")] use hyper::client::IntoUrl;
 use string_cache::QualName;
 use tendril;
 use tendril::{StrTendril, ByteTendril};
@@ -113,6 +114,23 @@ impl<Sink: TreeSink> Parser<Sink> {
             state: BytesParserState::Initial { parser: self },
             opts: opts,
         }
+    }
+
+    /// Fetch an HTTP or HTTPS URL with Hyper and parse.
+    #[cfg(feature = "hyper")]
+    pub fn from_http<U: IntoUrl>(self, url: U) -> Result<Sink::Output, ::hyper::Error> {
+        use hyper::Client;
+        use hyper::header::ContentType;
+        use hyper::mime::Attr::Charset;
+        use encoding::label::encoding_from_whatwg_label;
+
+        let mut response = try!(Client::new().get(url).send());
+        let opts = BytesOpts {
+            transport_layer_encoding: response.headers.get::<ContentType>()
+                .and_then(|content_type| content_type.get_param(Charset))
+                .and_then(|charset| encoding_from_whatwg_label(charset))
+        };
+        Ok(try!(self.from_bytes(opts).read_from(&mut response)))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,6 @@ extern crate log;
 #[macro_use]
 extern crate string_cache;
 
-extern crate tendril;
-
 #[macro_use]
 extern crate mac;
 
@@ -34,7 +32,7 @@ extern crate phf;
 extern crate time;
 
 pub use tokenizer::Attribute;
-pub use driver::{one_input, ParseOpts, parse_to, parse_fragment_to, parse, parse_fragment};
+pub use driver::{ParseOpts, parse_document, parse_fragment, Parser};
 
 pub use serialize::serialize;
 
@@ -52,3 +50,12 @@ pub mod tree_builder;
 pub mod serialize;
 pub mod driver;
 pub mod rcdom;
+
+/// Re-export the tendril crate.
+pub mod tendril {
+    extern crate tendril;
+    pub use self::tendril::*;
+}
+
+/// Re-export the encoding crate.
+pub use tendril::encoding;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 #[cfg(feature = "heap_size")]
 extern crate heapsize;
 
+#[cfg(feature = "hyper")] extern crate hyper;
+
 #[macro_use]
 extern crate log;
 

--- a/src/rcdom.rs
+++ b/src/rcdom.rs
@@ -31,7 +31,6 @@ use tree_builder;
 use serialize::{Serializable, Serializer};
 use serialize::TraversalScope;
 use serialize::TraversalScope::{IncludeNode, ChildrenOnly};
-use driver::ParseResult;
 
 pub use self::ElementEnum::{AnnotationXml, Normal, Script, Template};
 pub use self::NodeEnum::{Document, Doctype, Text, Comment, Element};
@@ -165,6 +164,9 @@ pub struct RcDom {
 }
 
 impl TreeSink for RcDom {
+    type Output = Self;
+    fn finish(self) -> Self { self }
+
     type Handle = Handle;
 
     fn parse_error(&mut self, msg: Cow<'static, str>) {
@@ -333,14 +335,6 @@ impl Default for RcDom {
             errors: vec!(),
             quirks_mode: tree_builder::NoQuirks,
         }
-    }
-}
-
-impl ParseResult for RcDom {
-    type Sink = RcDom;
-
-    fn get_result(sink: RcDom) -> RcDom {
-        sink
     }
 }
 

--- a/src/tree_builder/interface.rs
+++ b/src/tree_builder/interface.rs
@@ -49,6 +49,19 @@ pub enum NextParserState {
 
 /// Types which can process tree modifications from the tree builder.
 pub trait TreeSink {
+    /// The overall result of parsing.
+    ///
+    /// This should default to Self, but default associated types are not stable yet.
+    /// (https://github.com/rust-lang/rust/issues/29661)
+    type Output;
+
+    /// Consume this sink and return the overall result of parsing.
+    ///
+    /// This should default to `fn finish(self) -> Self::Output { self }`,
+    /// but default associated types are not stable yet.
+    /// (https://github.com/rust-lang/rust/issues/29661)
+    fn finish(self) -> Self::Output;
+
     /// `Handle` is a reference to a DOM node.  The tree builder requires
     /// that a `Handle` implements `Clone` to get another reference to
     /// the same node.

--- a/tests/serializer.rs
+++ b/tests/serializer.rs
@@ -13,17 +13,16 @@ extern crate html5ever;
 
 use std::default::Default;
 
-use tendril::{StrTendril, SliceExt};
+use tendril::{StrTendril, SliceExt, TendrilSink};
 
 use html5ever::driver::ParseOpts;
-use html5ever::{parse_fragment, parse, one_input, serialize};
+use html5ever::{parse_fragment, parse_document, serialize};
 use html5ever::rcdom::RcDom;
 
 fn parse_and_serialize(input: StrTendril) -> StrTendril {
-    let dom: RcDom = parse_fragment(one_input(input),
-                                    qualname!(html, "body"),
-                                    vec![],
-                                    ParseOpts::default());
+    let dom = parse_fragment(
+        RcDom::default(), ParseOpts::default(), qualname!(html, "body"), vec![]
+    ).one(input);
     let inner = &dom.document.borrow().children[0];
 
     let mut result = vec![];
@@ -101,7 +100,8 @@ test!(attr_ns_4, r#"<svg xlink:href="bleh"></svg>"#);
 
 #[test]
 fn doctype() {
-    let dom: RcDom = parse(one_input("<!doctype html>".to_tendril()), ParseOpts::default());
+    let dom = parse_document(
+        RcDom::default(), ParseOpts::default()).one("<!doctype html>");
     dom.document.borrow_mut().children.truncate(1);  // Remove <html>
     let mut result = vec![];
     serialize(&mut result, &dom.document, Default::default()).unwrap();

--- a/tests/tree_builder.rs
+++ b/tests/tree_builder.rs
@@ -29,12 +29,12 @@ use std::collections::{HashSet, HashMap};
 #[cfg(feature = "unstable")] use test::{TestDesc, TestDescAndFn, DynTestName, DynTestFn};
 #[cfg(feature = "unstable")] use test::ShouldPanic::No;
 
-use html5ever::{ParseOpts, parse, parse_fragment, one_input};
+use html5ever::{ParseOpts, parse_document, parse_fragment};
 use html5ever::rcdom::{Comment, Document, Doctype, Element, Handle, RcDom};
 use html5ever::rcdom::{Template, Text};
 
 use string_cache::{Atom, QualName};
-use tendril::StrTendril;
+use tendril::{StrTendril, TendrilSink};
 
 fn parse_tests<It: Iterator<Item=String>>(mut lines: It) -> Vec<HashMap<String, String>> {
     let mut tests = vec!();
@@ -215,16 +215,14 @@ fn make_test_desc_with_scripting_flag(
             let mut result = String::new();
             match context {
                 None => {
-                    let dom: RcDom = parse(one_input(data.clone()), opts);
+                    let dom = parse_document(RcDom::default(), opts).one(data.clone());
                     for child in dom.document.borrow().children.iter() {
                         serialize(&mut result, 1, child.clone());
                     }
                 },
                 Some(ref context) => {
-                    let dom: RcDom = parse_fragment(one_input(data.clone()),
-                                                    context.clone(),
-                                                    vec![],
-                                                    opts);
+                    let dom = parse_fragment(RcDom::default(), opts, context.clone(), vec![])
+                        .one(data.clone());
                     // fragment case: serialize children of the html element
                     // rather than children of the document
                     let doc = dom.document.borrow();


### PR DESCRIPTION
This depends on https://github.com/servo/tendril/pull/23.

This also adds an API to parse from bytes, which is part of https://github.com/servo/html5ever/issues/18.

r? @nox

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/188)
<!-- Reviewable:end -->
