### PR TITLE
Use references to handles while tracing

### DIFF
--- a/src/tree_builder/interface.rs
+++ b/src/tree_builder/interface.rs
@@ -160,5 +160,5 @@ pub trait Tracer {
 
     /// Upon a call to `trace_handles`, the tree builder will call this method
     /// for each handle in its internal state.
-    fn trace_handle(&self, node: Self::Handle);
+    fn trace_handle(&self, node: &Self::Handle);
 }

--- a/src/tree_builder/mod.rs
+++ b/src/tree_builder/mod.rs
@@ -262,19 +262,19 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
     /// Call the `Tracer`'s `trace_handle` method on every `Handle` in the tree builder's
     /// internal state.  This is intended to support garbage-collected DOMs.
     pub fn trace_handles(&self, tracer: &Tracer<Handle=Handle>) {
-        tracer.trace_handle(self.doc_handle.clone());
-        for e in self.open_elems.iter() {
-            tracer.trace_handle(e.clone());
+        tracer.trace_handle(&self.doc_handle);
+        for e in &self.open_elems {
+            tracer.trace_handle(e);
         }
-        for e in self.active_formatting.iter() {
+        for e in &self.active_formatting {
             match e {
-                &Element(ref h, _) => tracer.trace_handle(h.clone()),
+                &Element(ref h, _) => tracer.trace_handle(h),
                 _ => (),
             }
         }
-        self.head_elem.as_ref().map(|h| tracer.trace_handle(h.clone()));
-        self.form_elem.as_ref().map(|h| tracer.trace_handle(h.clone()));
-        self.context_elem.as_ref().map(|h| tracer.trace_handle(h.clone()));
+        self.head_elem.as_ref().map(|h| tracer.trace_handle(h));
+        self.form_elem.as_ref().map(|h| tracer.trace_handle(h));
+        self.context_elem.as_ref().map(|h| tracer.trace_handle(h));
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
This allows Handles to be moved while tracing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/193)
<!-- Reviewable:end -->
