### PR TITLE
Limit the encoding detection to 3 bytes for now.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.5.2"
+version = "0.5.3"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -264,8 +264,8 @@ impl<Sink: TreeSink> TendrilSink<tendril::fmt::Bytes> for BytesParser<Sink> {
 }
 
 /// How many bytes does detect_encoding() need
-// NOTE: 3 would be enough for a BOM, but 1024 is specified for <meta> elements.
-const PRESCAN_BYTES: u32 = 1024;
+// FIXME(#18): should be 1024 for <meta> elements.
+const PRESCAN_BYTES: u32 = 3;
 
 /// https://html.spec.whatwg.org/multipage/syntax.html#determining-the-character-encoding
 fn detect_encoding(bytes: &ByteTendril, opts: &BytesOpts) -> EncodingRef {
@@ -281,7 +281,7 @@ fn detect_encoding(bytes: &ByteTendril, opts: &BytesOpts) -> EncodingRef {
     if let Some(encoding) = opts.transport_layer_encoding {
         return encoding
     }
-    // FIXME: <meta> etc.
+    // FIXME(#18): <meta> etc.
     return encoding::all::UTF_8
 }
 


### PR DESCRIPTION
This is intended to avoid issues when there's a parser-blocking script in the first 1024 bytes. See also #198.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/199)
<!-- Reviewable:end -->
