### PR TITLE
Remove blank line after serializing doctype

### DIFF
--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -223,7 +223,7 @@ impl<'wr, Wr: Write> Serializer<'wr, Wr> {
     pub fn write_doctype(&mut self, name: &str) -> io::Result<()> {
         try!(self.writer.write_all(b"<!DOCTYPE "));
         try!(self.writer.write_all(name.as_bytes()));
-        self.writer.write_all(b">\n")
+        self.writer.write_all(b">")
     }
 
     pub fn write_processing_instruction(&mut self, target: &str, data: &str) -> io::Result<()> {

--- a/tests/serializer.rs
+++ b/tests/serializer.rs
@@ -105,5 +105,5 @@ fn doctype() {
     dom.document.borrow_mut().children.truncate(1);  // Remove <html>
     let mut result = vec![];
     serialize(&mut result, &dom.document, Default::default()).unwrap();
-    assert_eq!(String::from_utf8(result).unwrap(), "<!DOCTYPE html>\n");
+    assert_eq!(String::from_utf8(result).unwrap(), "<!DOCTYPE html>");
 }


### PR DESCRIPTION
As said here [1], the line break after the doctype is undesirable.

[1] https://github.com/servo/servo/pull/10604#issuecomment-209942021

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/206)
<!-- Reviewable:end -->
