### PR TITLE
Use std::time instead of deprecated crate time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ heap_size = ["heapsize", "heapsize_plugin"]
 codegen = ["html5ever_macros"]
 
 [dependencies]
-time = "0"
 log = "0"
 phf = "0.7"
 string_cache = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,6 @@ extern crate mac;
 
 extern crate phf;
 
-extern crate time;
-
 pub use tokenizer::Attribute;
 pub use driver::{ParseOpts, parse_document, parse_fragment, Parser};
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,7 +26,8 @@ macro_rules! time {
     ($e:expr) => {{
         let now = ::std::time::Instant::now();
         let result = $e;
-        let dt = now.elapsed().as_secs() as u64;
+        let d = now.elapsed();
+        let dt = d.as_secs() * 1_000_000_000 + u64::from(d.subsec_nanos());
         (result, dt)
     }}
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,9 +24,9 @@ macro_rules! unwrap_or_return {
 
 macro_rules! time {
     ($e:expr) => {{
-        let t0 = ::time::precise_time_ns();
+        let now = ::std::time::Instant::now();
         let result = $e;
-        let dt = ::time::precise_time_ns() - t0;
+        let dt = now.elapsed().as_secs() as u64;
         (result, dt)
     }}
 }


### PR DESCRIPTION
Crate time is deprecated; switch to `std::time`
Cheers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/213)
<!-- Reviewable:end -->
