### PR TITLE
Fixed too sure .unwrap in tokenizer.rs

### DIFF
--- a/tests/foreach_html5lib_test/mod.rs
+++ b/tests/foreach_html5lib_test/mod.rs
@@ -23,12 +23,19 @@ pub fn foreach_html5lib_test<Mk>(
     test_dir_path.push("html5lib-tests");
     test_dir_path.push(subdir);
 
-    let test_files = fs::read_dir(&test_dir_path).unwrap();
-    for entry in test_files {
-        let path = entry.unwrap().path();
-        if path.extension() == Some(ext) {
-            let file = fs::File::open(&path).unwrap();
-            mk(&path, file);
+    let maybe_test_files = fs::read_dir(&test_dir_path);
+    match maybe_test_files {
+        Ok(test_files) => {
+            for entry in test_files {
+                let path = entry.unwrap().path();
+                if path.extension() == Some(ext) {
+                    let file = fs::File::open(&path).unwrap();
+                    mk(&path, file);
+                }
+            }
+        },
+        Err(_) => {
+            panic!("Before launching the tests, please run this command:\n\n\tgit submodule update --init\n\nto retrieve an html5lib-tests snapshot.");
         }
     }
 }

--- a/tests/foreach_html5lib_test/mod.rs
+++ b/tests/foreach_html5lib_test/mod.rs
@@ -23,19 +23,12 @@ pub fn foreach_html5lib_test<Mk>(
     test_dir_path.push("html5lib-tests");
     test_dir_path.push(subdir);
 
-    let maybe_test_files = fs::read_dir(&test_dir_path);
-    match maybe_test_files {
-        Ok(test_files) => {
-            for entry in test_files {
-                let path = entry.unwrap().path();
-                if path.extension() == Some(ext) {
-                    let file = fs::File::open(&path).unwrap();
-                    mk(&path, file);
-                }
-            }
-        },
-        Err(e) => {
-            println!("{}", e);
+    let test_files = fs::read_dir(&test_dir_path).unwrap();
+    for entry in test_files {
+        let path = entry.unwrap().path();
+        if path.extension() == Some(ext) {
+            let file = fs::File::open(&path).unwrap();
+            mk(&path, file);
         }
     }
 }

--- a/tests/foreach_html5lib_test/mod.rs
+++ b/tests/foreach_html5lib_test/mod.rs
@@ -23,12 +23,19 @@ pub fn foreach_html5lib_test<Mk>(
     test_dir_path.push("html5lib-tests");
     test_dir_path.push(subdir);
 
-    let test_files = fs::read_dir(&test_dir_path).unwrap();
-    for entry in test_files {
-        let path = entry.unwrap().path();
-        if path.extension() == Some(ext) {
-            let file = fs::File::open(&path).unwrap();
-            mk(&path, file);
+    let maybe_test_files = fs::read_dir(&test_dir_path);
+    match maybe_test_files {
+        Ok(test_files) => {
+            for entry in test_files {
+                let path = entry.unwrap().path();
+                if path.extension() == Some(ext) {
+                    let file = fs::File::open(&path).unwrap();
+                    mk(&path, file);
+                }
+            }
+        },
+        Err(e) => {
+            println!("{}", e);
         }
     }
 }


### PR DESCRIPTION
I propose the change because I had this problem when I did cargo test:
```
[....]$ RUST_BACKTRACE=1 cargo test
     Running target/debug/html5ever-ebbb862bf0664388

running 20 tests
....................
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured

     Running target/debug/serializer-bd6e4b6794d0e313

running 40 tests
........................................
test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured

     Running target/debug/tokenizer-9fee19ffe67616b5
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { repr: Os { code: 2, message: "No such file or directory" } }', ../src/libcore/result.rs:788
stack backtrace:
   1:        0x10f9e54bb - std::sys::backtrace::tracing::imp::write::h46e546df6e4e4fe6
   2:        0x10f9e775a - std::panicking::default_hook::_$u7b$$u7b$closure$u7d$$u7d$::h077deeda8b799591
   3:        0x10f9e738a - std::panicking::default_hook::heb8b6fd640571a4f
   4:        0x10f9dc178 - std::panicking::rust_panic_with_hook::hd7b83626099d3416
   5:        0x10f9e7d36 - std::panicking::begin_panic::h941ea76fc945d925
   6:        0x10f9dcdb8 - std::panicking::begin_panic_fmt::h30280d4dd3f149f5
   7:        0x10f9e798f - rust_begin_unwind
   8:        0x10fa0d570 - core::panicking::panic_fmt::h2d3cc8234dde51b4
   9:        0x10f903469 - core::result::unwrap_failed::h77e8f7274d900d66
  10:        0x10f902d9a - _<core..result..Result<T, E>>::unwrap::h832a73c540c5d590
  11:        0x10f902782 - tokenizer::foreach_html5lib_test::foreach_html5lib_test::h2ce9421430543c73
  12:        0x10f901f8d - tokenizer::tests::h3cbd3447622b6aa9
  13:        0x10f905c2f - tokenizer::main::h4149a347b29284d8
  14:        0x10f9e6f4d - std::panicking::try::call::hca715a47aa047c49
  15:        0x10f9e7e0b - __rust_try
  16:        0x10f9e7da5 - __rust_maybe_catch_panic
  17:        0x10f9e6d71 - std::rt::lang_start::h162055cb2e4b9fe7
  18:        0x10f907399 - main
error: test failed
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/215)
<!-- Reviewable:end -->
