### PR TITLE
Bump to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.5.5"
+version = "0.6.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -41,7 +41,7 @@ phf = "0.7"
 string_cache = "0.2.0"
 mac = "0"
 tendril = "0.2.2"
-heapsize = { version = ">=0.1.1, <0.4", optional = true }
+heapsize = { version = "0.3", optional = true }
 heapsize_plugin = { version = "0.1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
0.5.5 was yanked because the change to get_template_contents was a breaking change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/221)
<!-- Reviewable:end -->
