### PR TITLE
fix benchmarking broken by  "Make tokenizer not own the input stream"

### DIFF
--- a/benches/tokenizer.rs
+++ b/benches/tokenizer.rs
@@ -22,6 +22,7 @@ use test::ShouldPanic::No;
 
 use tendril::{ByteTendril, StrTendril, ReadExt, SliceExt};
 use html5ever::tokenizer::{TokenSink, Token, Tokenizer, TokenizerOpts};
+use html5ever::tokenizer::buffer_queue::BufferQueue;
 
 struct Sink;
 
@@ -92,9 +93,12 @@ impl TDynBenchFn for Bench {
                 black_box(input);
             } else {
                 let mut tok = Tokenizer::new(Sink, self.opts.clone());
+                let mut buffer = BufferQueue::new();
                 for buf in input.into_iter() {
-                    tok.feed(buf);
+                    buffer.push_back(buf);
+                    let _ = tok.feed(&mut buffer);
                 }
+                tok.feed(&mut buffer);
                 tok.end();
             }
         });


### PR DESCRIPTION
Was curious about project benchmarks and noticed it was broken. A quick bisect revealed it was recently broken in 7fec1da. Thankfully there was examples of testing that needed to be updated which correlated directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/227)
<!-- Reviewable:end -->
