### PR TITLE
Silence warnings and clean up unused imports

### DIFF
--- a/benches/tokenizer.rs
+++ b/benches/tokenizer.rs
@@ -13,7 +13,6 @@ extern crate html5ever;
 
 use std::{fs, env, cmp};
 use std::path::PathBuf;
-use std::io::Read;
 use std::default::Default;
 
 use test::{black_box, Bencher, TestDesc, TestDescAndFn};
@@ -101,7 +100,7 @@ impl TDynBenchFn for Bench {
                     buffer.push_back(buf);
                     let _ = tok.feed(&mut buffer);
                 }
-                tok.feed(&mut buffer);
+                let _ = tok.feed(&mut buffer);
                 tok.end();
             }
         });

--- a/examples/noop-tokenize.rs
+++ b/examples/noop-tokenize.rs
@@ -40,7 +40,7 @@ fn main() {
     input.push_back(chunk.try_reinterpret().unwrap());
 
     let mut tok = Tokenizer::new(Sink(Vec::new()), Default::default());
-    tok.feed(&mut input);
+    let _ = tok.feed(&mut input);
     assert!(input.is_empty());
     tok.end();
 }

--- a/examples/tokenize.rs
+++ b/examples/tokenize.rs
@@ -93,7 +93,7 @@ fn main() {
         profile: true,
         .. Default::default()
     });
-    tok.feed(&mut input);
+    let _ = tok.feed(&mut input);
     assert!(input.is_empty());
     tok.end();
     sink.is_char(false);

--- a/src/tokenizer/buffer_queue.rs
+++ b/src/tokenizer/buffer_queue.rs
@@ -9,7 +9,6 @@
 
 use util::smallcharset::SmallCharSet;
 
-use std::ascii::AsciiExt;
 use std::collections::VecDeque;
 
 use tendril::StrTendril;
@@ -166,7 +165,7 @@ impl BufferQueue {
 #[allow(non_snake_case)]
 mod test {
     use std::ascii::AsciiExt;
-    use tendril::{StrTendril, SliceExt};
+    use tendril::SliceExt;
     use super::{BufferQueue, FromSet, NotFromSet};
 
     #[test]

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -9,14 +9,11 @@
 
 //! The HTML5 tokenizer.
 
-#![allow(unused_imports)]
-
 pub use self::interface::{Doctype, Attribute, TagKind, StartTag, EndTag, Tag};
 pub use self::interface::{Token, DoctypeToken, TagToken, CommentToken};
 pub use self::interface::{CharacterTokens, NullCharacterToken, EOFToken, ParseError};
 pub use self::interface::{TokenSink, TokenSinkResult};
 
-use self::states::{RawLessThanSign, RawEndTagOpen, RawEndTagName};
 use self::states::{Rcdata, Rawtext, ScriptData, ScriptDataEscaped};
 use self::states::{Escaped, DoubleEscaped};
 use self::states::{Unquoted, SingleQuoted, DoubleQuoted};
@@ -1415,9 +1412,9 @@ mod test {
 
     use super::{TokenSink, Tokenizer, TokenizerOpts, TokenSinkResult};
 
-    use super::interface::{Token, DoctypeToken, TagToken, CommentToken};
+    use super::interface::{Token, TagToken};
     use super::interface::{CharacterTokens, NullCharacterToken, EOFToken, ParseError};
-    use super::interface::{Doctype, Attribute, TagKind, StartTag, EndTag, Tag};
+    use super::interface::{TagKind, StartTag, EndTag, Tag};
 
     use super::buffer_queue::{BufferQueue};
     use std::mem::replace;

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -99,7 +99,7 @@ impl TokenLogger {
 impl TokenSink for TokenLogger {
     type Handle = ();
 
-    fn process_token(&mut self, token: Token, line_number: u64) -> TokenSinkResult<()> {
+    fn process_token(&mut self, token: Token, _line_number: u64) -> TokenSinkResult<()> {
         match token {
             CharacterTokens(b) => {
                 self.current_str.push_slice(&b);
@@ -143,7 +143,7 @@ fn tokenize(input: Vec<StrTendril>, opts: TokenizerOpts) -> Vec<Token> {
         buffer.push_back(chunk);
         let _ = tok.feed(&mut buffer);
     }
-    tok.feed(&mut buffer);
+    let _ = tok.feed(&mut buffer);
     tok.end();
     tok.unwrap().get_tokens()
 }


### PR DESCRIPTION
There was an `#![allow(unused_imports)]` in `src/tokenizer/mod.rs` which looks useless. removed it and other unused imports. Also silenced some warnings in tests/examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/250)
<!-- Reviewable:end -->
