### PR TITLE
Revert "Add "contents" and "scroll-position" keywords to local names"

### DIFF
--- a/atoms/Cargo.toml
+++ b/atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html5ever-atoms"
-version = "0.2.1"
+version = "0.2.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/atoms/local_names.txt
+++ b/atoms/local_names.txt
@@ -183,7 +183,6 @@ compose
 condition
 conjugate
 content
-contents
 contentScriptType
 contentStyleType
 contenteditable
@@ -792,7 +791,6 @@ scriptminsize
 scriptsizemultiplier
 scrolldelay
 scrolling
-scroll-position
 sdev
 seamless
 sec


### PR DESCRIPTION
This reverts PR #256 / commit 6089ea41ad7acae12913d5c8b85864969da8fe5f.

Turns out these atoms are needed in `servo_atoms::Atom`, not `LocalName`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/257)
<!-- Reviewable:end -->
