### PR TITLE
Mark rust code block as regular text in docs.

### DIFF
--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -94,7 +94,7 @@ pub type AttrRef<'a> = (&'a QName, &'a str);
 /// depending on where the text is written inside the tag or attribute value.
 ///
 /// For example
-///```
+///```text
 ///    <tag>'&-quotes'</tag>   becomes      <tag>'&amp;-quotes'</tag>
 ///    <tag = "'&-quotes'">    becomes      <tag = "&apos;&amp;-quotes&apos;"
 ///```


### PR DESCRIPTION
This should fix https://github.com/servo/servo/issues/16213.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/262)
<!-- Reviewable:end -->
