### PR TITLE
Remove broken BytesParser

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.16.0"
+version = "0.17.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -30,13 +30,12 @@ name = "tokenizer"
 harness = false
 
 [features]
-unstable = ["tendril/unstable"]
+unstable = ["markup5ever/unstable"]
 heap_size = ["markup5ever/heap_size"]
 
 [dependencies]
-log = "0"
-mac = "0"
-tendril = "0.2.2"
+log = "0.3"
+mac = "0.1"
 markup5ever = { version = "0.1", path = "../markup5ever" }
 
 [dev-dependencies]

--- a/html5ever/examples/html2html.rs
+++ b/html5ever/examples/html2html.rs
@@ -15,18 +15,17 @@
 //!
 //! where htmlparser-1.4.jar comes from http://about.validator.nu/htmlparser/
 
-extern crate tendril;
 extern crate html5ever;
 
 use std::io::{self, Write};
 use std::default::Default;
 
-use tendril::TendrilSink;
 
-use html5ever::driver::ParseOpts;
-use html5ever::tree_builder::TreeBuilderOpts;
 use html5ever::{parse_document, serialize};
+use html5ever::driver::ParseOpts;
 use html5ever::rcdom::RcDom;
+use html5ever::tendril::TendrilSink;
+use html5ever::tree_builder::TreeBuilderOpts;
 
 fn main() {
     let opts = ParseOpts {

--- a/html5ever/examples/print-rcdom.rs
+++ b/html5ever/examples/print-rcdom.rs
@@ -8,16 +8,15 @@
 // except according to those terms.
 
 #[macro_use] extern crate html5ever;
-extern crate tendril;
 
 use std::io;
 use std::iter::repeat;
 use std::default::Default;
 use std::string::String;
 
-use tendril::TendrilSink;
 use html5ever::parse_document;
 use html5ever::rcdom::{NodeData, RcDom, Handle};
+use html5ever::tendril::TendrilSink;
 
 // This is not proper HTML serialization, of course.
 

--- a/html5ever/src/driver.rs
+++ b/html5ever/src/driver.rs
@@ -92,7 +92,7 @@ impl<Sink: TreeSink> TendrilSink<tendril::fmt::UTF8> for Parser<Sink> {
 
     // FIXME: Is it too noisy to report every character decoding error?
     fn error(&mut self, desc: Cow<'static, str>) {
-        self.tokenizer.sink_mut().sink_mut().parse_error(desc)
+        self.tokenizer.sink.sink.parse_error(desc)
     }
 
     type Output = Sink::Output;
@@ -102,7 +102,7 @@ impl<Sink: TreeSink> TendrilSink<tendril::fmt::UTF8> for Parser<Sink> {
         while let TokenizerResult::Script(_) = self.tokenizer.feed(&mut self.input_buffer) {}
         assert!(self.input_buffer.is_empty());
         self.tokenizer.end();
-        self.tokenizer.unwrap().unwrap().finish()
+        self.tokenizer.sink.sink.finish()
     }
 }
 

--- a/html5ever/src/driver.rs
+++ b/html5ever/src/driver.rs
@@ -15,12 +15,10 @@ use tokenizer::{Tokenizer, TokenizerOpts, TokenizerResult};
 use tree_builder::{TreeBuilderOpts, TreeBuilder, TreeSink, create_element};
 
 use std::borrow::Cow;
-use std::mem;
 
-use encoding::{self, EncodingRef};
 use tendril;
-use tendril::{StrTendril, ByteTendril};
-use tendril::stream::{TendrilSink, Utf8LossyDecoder, LossyDecoder};
+use tendril::StrTendril;
+use tendril::stream::{TendrilSink, Utf8LossyDecoder};
 
 /// All-encompassing options struct for the parser.
 #[derive(Clone, Default)]
@@ -114,220 +112,20 @@ impl<Sink: TreeSink> Parser<Sink> {
     pub fn from_utf8(self) -> Utf8LossyDecoder<Self> {
         Utf8LossyDecoder::new(self)
     }
-
-    /// Wrap this parser into a `TendrilSink` that accepts bytes
-    /// and tries to detect the correct character encoding.
-    ///
-    /// Currently this looks for a Byte Order Mark,
-    /// then uses `BytesOpts::transport_layer_encoding`,
-    /// then falls back to UTF-8.
-    ///
-    /// FIXME(https://github.com/servo/html5ever/issues/18): this should look for `<meta>` elements
-    /// and other data per
-    /// https://html.spec.whatwg.org/multipage/syntax.html#determining-the-character-encoding
-    pub fn from_bytes(self, opts: BytesOpts) -> BytesParser<Sink> {
-        BytesParser {
-            state: BytesParserState::Initial { parser: self },
-            opts: opts,
-        }
-    }
-}
-
-/// Options for choosing a character encoding
-#[derive(Clone, Default)]
-pub struct BytesOpts {
-    /// The character encoding specified by the transport layer, if any.
-    /// In HTTP for example, this is the `charset` parameter of the `Content-Type` response header.
-    pub transport_layer_encoding: Option<EncodingRef>,
-}
-
-/// An HTML parser,
-/// ready to receive bytes input through the `tendril::TendrilSink` trait’s methods.
-///
-/// See `Parser::from_bytes`.
-pub struct BytesParser<Sink> where Sink: TreeSink {
-    state: BytesParserState<Sink>,
-    opts: BytesOpts,
-}
-
-enum BytesParserState<Sink> where Sink: TreeSink {
-    Initial {
-        parser: Parser<Sink>,
-    },
-    Buffering {
-        parser: Parser<Sink>,
-        buffer: ByteTendril
-    },
-    Parsing {
-        decoder: LossyDecoder<Parser<Sink>>,
-    },
-    Transient
-}
-
-impl<Sink: TreeSink> BytesParser<Sink> {
-    /// Access the underlying Parser
-    pub fn str_parser(&self) -> &Parser<Sink> {
-        match self.state {
-            BytesParserState::Initial { ref parser } => parser,
-            BytesParserState::Buffering { ref parser, .. } => parser,
-            BytesParserState::Parsing { ref decoder } => decoder.inner_sink(),
-            BytesParserState::Transient => unreachable!(),
-        }
-    }
-
-    /// Access the underlying Parser
-    pub fn str_parser_mut(&mut self) -> &mut Parser<Sink> {
-        match self.state {
-            BytesParserState::Initial { ref mut parser } => parser,
-            BytesParserState::Buffering { ref mut parser, .. } => parser,
-            BytesParserState::Parsing { ref mut decoder } => decoder.inner_sink_mut(),
-            BytesParserState::Transient => unreachable!(),
-        }
-    }
-
-    /// Insert a Unicode chunk in the middle of the byte stream.
-    ///
-    /// This is e.g. for supporting `document.write`.
-    pub fn process_unicode(&mut self, t: StrTendril) {
-        if t.is_empty() {
-            return  // Don’t prevent buffering/encoding detection
-        }
-        if let BytesParserState::Parsing { ref mut decoder } = self.state {
-            decoder.inner_sink_mut().process(t)
-        } else {
-            match mem::replace(&mut self.state, BytesParserState::Transient) {
-                BytesParserState::Initial { mut parser } => {
-                    parser.process(t);
-                    self.start_parsing(parser, ByteTendril::new())
-                }
-                BytesParserState::Buffering { parser, buffer } => {
-                    self.start_parsing(parser, buffer);
-                    if let BytesParserState::Parsing { ref mut decoder } = self.state {
-                        decoder.inner_sink_mut().process(t)
-                    } else {
-                        unreachable!()
-                    }
-                }
-                BytesParserState::Parsing { .. } | BytesParserState::Transient => unreachable!(),
-            }
-        }
-    }
-
-    fn start_parsing(&mut self, parser: Parser<Sink>, buffer: ByteTendril) {
-        let encoding = detect_encoding(&buffer, &self.opts);
-        let mut decoder = LossyDecoder::new(encoding, parser);
-        decoder.process(buffer);
-        self.state = BytesParserState::Parsing { decoder: decoder }
-    }
-}
-
-impl<Sink: TreeSink> TendrilSink<tendril::fmt::Bytes> for BytesParser<Sink> {
-    fn process(&mut self, t: ByteTendril) {
-        if let &mut BytesParserState::Parsing { ref mut decoder } = &mut self.state {
-            return decoder.process(t)
-        }
-        let (parser, buffer) = match mem::replace(&mut self.state, BytesParserState::Transient) {
-            BytesParserState::Initial{ parser } => (parser, t),
-            BytesParserState::Buffering { parser, mut buffer } => {
-                buffer.push_tendril(&t);
-                (parser, buffer)
-            }
-            BytesParserState::Parsing { .. } | BytesParserState::Transient => unreachable!(),
-        };
-        if buffer.len32() >= PRESCAN_BYTES {
-            self.start_parsing(parser, buffer)
-        } else {
-            self.state = BytesParserState::Buffering {
-                parser: parser,
-                buffer: buffer,
-            }
-        }
-    }
-
-    fn error(&mut self, desc: Cow<'static, str>) {
-        match self.state {
-            BytesParserState::Initial { ref mut parser } => parser.error(desc),
-            BytesParserState::Buffering { ref mut parser, .. } => parser.error(desc),
-            BytesParserState::Parsing { ref mut decoder } => decoder.error(desc),
-            BytesParserState::Transient => unreachable!(),
-        }
-    }
-
-    type Output = Sink::Output;
-
-    fn finish(self) -> Self::Output {
-        match self.state {
-            BytesParserState::Initial { parser } => parser.finish(),
-            BytesParserState::Buffering { parser, buffer } => {
-                let encoding = detect_encoding(&buffer, &self.opts);
-                let mut decoder = LossyDecoder::new(encoding, parser);
-                decoder.process(buffer);
-                decoder.finish()
-            },
-            BytesParserState::Parsing { decoder } => decoder.finish(),
-            BytesParserState::Transient => unreachable!(),
-        }
-    }
-}
-
-/// How many bytes does detect_encoding() need
-// FIXME(#18): should be 1024 for <meta> elements.
-const PRESCAN_BYTES: u32 = 3;
-
-/// https://html.spec.whatwg.org/multipage/syntax.html#determining-the-character-encoding
-fn detect_encoding(bytes: &ByteTendril, opts: &BytesOpts) -> EncodingRef {
-    if bytes.starts_with(b"\xEF\xBB\xBF") {
-        return encoding::all::UTF_8
-    }
-    if bytes.starts_with(b"\xFE\xFF") {
-        return encoding::all::UTF_16BE
-    }
-    if bytes.starts_with(b"\xFF\xFE") {
-        return encoding::all::UTF_16LE
-    }
-    if let Some(encoding) = opts.transport_layer_encoding {
-        return encoding
-    }
-    // FIXME(#18): <meta> etc.
-    return encoding::all::UTF_8
 }
 
 #[cfg(test)]
 mod tests {
     use rcdom::RcDom;
     use serialize::serialize;
-    use std::iter::repeat;
     use tendril::TendrilSink;
     use super::*;
 
     #[test]
     fn from_utf8() {
-        assert_serialization(
-            parse_document(RcDom::default(), ParseOpts::default())
-                .from_utf8()
-                .one("<title>Test".as_bytes()));
-    }
-
-    #[test]
-    fn from_bytes_one() {
-        assert_serialization(
-            parse_document(RcDom::default(), ParseOpts::default())
-                .from_bytes(BytesOpts::default())
-                .one("<title>Test".as_bytes()));
-    }
-
-    #[test]
-    fn from_bytes_iter() {
-        assert_serialization(
-            parse_document(RcDom::default(), ParseOpts::default())
-                .from_bytes(BytesOpts::default())
-                .from_iter([
-                    "<title>Test".as_bytes(),
-                    repeat(' ').take(1200).collect::<String>().as_bytes(),
-                ].iter().cloned()));
-    }
-
-    fn assert_serialization(dom: RcDom) {
+        let dom = parse_document(RcDom::default(), ParseOpts::default())
+            .from_utf8()
+            .one("<title>Test".as_bytes());
         let mut serialized = Vec::new();
         serialize(&mut serialized, &dom.document, Default::default()).unwrap();
         assert_eq!(String::from_utf8(serialized).unwrap().replace(" ", ""),

--- a/html5ever/src/lib.rs
+++ b/html5ever/src/lib.rs
@@ -34,11 +34,5 @@ pub mod tokenizer;
 pub mod tree_builder;
 pub mod driver;
 
-/// Re-export the tendril crate.
-pub mod tendril {
-    extern crate tendril;
-    pub use self::tendril::*;
-}
-
 /// Re-export the encoding crate.
 pub use tendril::encoding;

--- a/html5ever/src/lib.rs
+++ b/html5ever/src/lib.rs
@@ -33,6 +33,3 @@ pub mod serialize;
 pub mod tokenizer;
 pub mod tree_builder;
 pub mod driver;
-
-/// Re-export the encoding crate.
-pub use tendril::encoding;

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -101,7 +101,7 @@ pub struct Tokenizer<Sink> {
     opts: TokenizerOpts,
 
     /// Destination for tokens we emit.
-    sink: Sink,
+    pub sink: Sink,
 
     /// The abstract machine state as described in the spec.
     state: states::State,
@@ -199,18 +199,6 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             time_in_sink: 0,
             current_line: 1,
         }
-    }
-
-    pub fn unwrap(self) -> Sink {
-        self.sink
-    }
-
-    pub fn sink<'a>(&'a self) -> &'a Sink {
-        &self.sink
-    }
-
-    pub fn sink_mut<'a>(&'a mut self) -> &'a mut Sink {
-        &mut self.sink
     }
 
     /// Feed an input string into the tokenizer.

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -1090,7 +1090,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 '\t' | '\n' | '\x0C' | ' ' => (),
                 '\0' => go!(self: error; create_doctype; push_doctype_name '\u{fffd}'; to DoctypeName),
                 '>'  => go!(self: error; create_doctype; force_quirks; emit_doctype; to Data),
-                c    => go!(self: create_doctype; push_doctype_name (c.to_ascii_lowercase()); 
+                c    => go!(self: create_doctype; push_doctype_name (c.to_ascii_lowercase());
                                   to DoctypeName),
             }},
 
@@ -1418,7 +1418,7 @@ mod test {
 
     use {LocalName};
 
-    // LinesMatch implements the TokenSink trait. It is used for testing to see 
+    // LinesMatch implements the TokenSink trait. It is used for testing to see
     // if current_line is being updated when process_token is called. The lines
     // vector is a collection of the line numbers that each token is on.
     struct LinesMatch {
@@ -1426,7 +1426,7 @@ mod test {
         current_str: StrTendril,
         lines: Vec<(Token, u64)>,
     }
-    
+
     impl LinesMatch {
         fn new() -> LinesMatch {
             LinesMatch {
@@ -1451,11 +1451,11 @@ mod test {
     }
 
     impl TokenSink for LinesMatch {
-        
+
         type Handle = ();
 
         fn process_token(&mut self, token: Token, line_number: u64) -> TokenSinkResult<Self::Handle> {
-            
+
             match token {
                 CharacterTokens(b) => {
                     self.current_str.push_slice(&b);
@@ -1491,7 +1491,7 @@ mod test {
         }
     }
 
-    // Take in tokens, process them, and return vector with line 
+    // Take in tokens, process them, and return vector with line
     // numbers that each token is on
     fn tokenize(input: Vec<StrTendril>, opts: TokenizerOpts) -> Vec<(Token, u64)> {
         let sink = LinesMatch::new();
@@ -1549,8 +1549,8 @@ mod test {
         let vector = vec![StrTendril::from("<a>\n"), StrTendril::from("<b>\n"),
             StrTendril::from("</b>\n"), StrTendril::from("</a>\n")];
         let expected = vec![(create_tag(StrTendril::from("a"), StartTag), 1),
-            (create_tag(StrTendril::from("b"), StartTag), 2), 
-            (create_tag(StrTendril::from("b"), EndTag), 3), 
+            (create_tag(StrTendril::from("b"), StartTag), 2),
+            (create_tag(StrTendril::from("b"), EndTag), 3),
             (create_tag(StrTendril::from("a"), EndTag), 4)];
         let results = tokenize(vector, opts);
         assert_eq!(results, expected);
@@ -1568,8 +1568,8 @@ mod test {
         let vector = vec![StrTendril::from("<a>\r\n"), StrTendril::from("<b>\r\n"),
             StrTendril::from("</b>\r\n"), StrTendril::from("</a>\r\n")];
         let expected = vec![(create_tag(StrTendril::from("a"), StartTag), 1),
-            (create_tag(StrTendril::from("b"), StartTag), 2), 
-            (create_tag(StrTendril::from("b"), EndTag), 3), 
+            (create_tag(StrTendril::from("b"), StartTag), 2),
+            (create_tag(StrTendril::from("b"), EndTag), 3),
             (create_tag(StrTendril::from("a"), EndTag), 4)];
         let results = tokenize(vector, opts);
         assert_eq!(results, expected);

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -88,7 +88,7 @@ pub struct TreeBuilder<Handle, Sink> {
     opts: TreeBuilderOpts,
 
     /// Consumer of tree modifications.
-    sink: Sink,
+    pub sink: Sink,
 
     /// Insertion mode.
     mode: InsertionMode,
@@ -243,18 +243,6 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
 
             _ => tok_state::Data
         }
-    }
-
-    pub fn unwrap(self) -> Sink {
-        self.sink
-    }
-
-    pub fn sink<'a>(&'a self) -> &'a Sink {
-        &self.sink
-    }
-
-    pub fn sink_mut<'a>(&'a mut self) -> &'a mut Sink {
-        &mut self.sink
     }
 
     /// Call the `Tracer`'s `trace_handle` method on every `Handle` in the tree builder's

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -500,7 +500,7 @@ mod test {
     use ExpandedName;
     use QualName;
     use tendril::StrTendril;
-    use tendril::stream::{TendrilSink, Utf8LossyDecoder, LossyDecoder};
+    use tendril::stream::{TendrilSink, Utf8LossyDecoder};
 
     use tokenizer;
     use tokenizer::{Tokenizer, TokenizerOpts};

--- a/html5ever/tests/serializer.rs
+++ b/html5ever/tests/serializer.rs
@@ -7,15 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate tendril;
 #[macro_use] extern crate html5ever;
 
 use std::default::Default;
-use tendril::{StrTendril, SliceExt, TendrilSink};
 
-use html5ever::driver::ParseOpts;
 use html5ever::{parse_fragment, parse_document, serialize, QualName};
+use html5ever::driver::ParseOpts;
 use html5ever::rcdom::RcDom;
+use html5ever::tendril::{StrTendril, SliceExt, TendrilSink};
 
 fn parse_and_serialize(input: StrTendril) -> StrTendril {
     let dom = parse_fragment(

--- a/html5ever/tests/tokenizer.rs
+++ b/html5ever/tests/tokenizer.rs
@@ -143,7 +143,7 @@ fn tokenize(input: Vec<StrTendril>, opts: TokenizerOpts) -> Vec<Token> {
     }
     let _ = tok.feed(&mut buffer);
     tok.end();
-    tok.unwrap().get_tokens()
+    tok.sink.get_tokens()
 }
 
 trait JsonExt: Sized {

--- a/html5ever/tests/tree_builder.rs
+++ b/html5ever/tests/tree_builder.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 extern crate test;
-extern crate tendril;
 #[macro_use] extern crate html5ever;
 
 mod foreach_html5lib_test;
@@ -28,8 +27,8 @@ use test::ShouldPanic::No;
 use html5ever::{LocalName, QualName};
 use html5ever::{ParseOpts, parse_document, parse_fragment};
 use html5ever::rcdom::{NodeData, Handle, RcDom};
+use html5ever::tendril::{StrTendril, TendrilSink};
 
-use tendril::{StrTendril, TendrilSink};
 
 fn parse_tests<It: Iterator<Item=String>>(mut lines: It) -> Vec<HashMap<String, String>> {
     let mut tests = vec!();

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -18,7 +18,7 @@ unstable = ["tendril/unstable"]
 [dependencies]
 string_cache = "0.5"
 phf = "0.7"
-tendril = "0.2"
+tendril = "0.3"
 heapsize = { version = "0.3", optional = true }
 heapsize_derive = { version = "0.1", optional = true }
 

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib.rs"
 
 [features]
 heap_size = ["heapsize", "heapsize_derive", "string_cache/heapsize"]
+unstable = ["tendril/unstable"]
 
 [dependencies]
 string_cache = "0.5"

--- a/markup5ever/lib.rs
+++ b/markup5ever/lib.rs
@@ -12,7 +12,7 @@
 #[cfg(feature = "heap_size")] extern crate heapsize;
 extern crate string_cache;
 extern crate phf;
-extern crate tendril;
+pub extern crate tendril;
 
 #[macro_export]
 macro_rules! small_char_set ( ($($e:expr)+) => (

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -19,13 +19,12 @@ name = "xml5ever"
 doctest = true
 
 [features]
-unstable = ["tendril/unstable"]
+unstable = ["markup5ever/unstable"]
 
 [dependencies]
 time = "0.1"
 log = "0.3"
 mac = "0.1"
-tendril = "0.2"
 markup5ever = {version = "0.1", path = "../markup5ever" }
 
 [dev-dependencies]

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "xml5ever"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The xml5ever project developers"]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/xml5ever/examples/hello_xml.rs
+++ b/xml5ever/examples/hello_xml.rs
@@ -13,19 +13,15 @@ extern crate xml5ever;
 use std::default::Default;
 
 use xml5ever::tendril::TendrilSink;
-use xml5ever::driver::{parse_document, BytesOpts};
+use xml5ever::driver::parse_document;
 use xml5ever::tree_builder::{TreeSink};
 use xml5ever::rcdom::{RcDom, NodeData};
 
 fn main() {
     // To parse a string into a tree of nodes, we need to invoke
     // `parse_document` and supply it with a TreeSink implementation (RcDom).
-    //
-    // Since this is a string, it's best to use `from_bytes` to create a
-    // BytesParser for given string.
     let dom: RcDom = parse_document(RcDom::default(), Default::default())
-        .from_bytes(BytesOpts::default())
-        .one("<hello>XML</hello>".as_bytes());
+        .one("<hello>XML</hello>");
 
     // Do some processing
     let doc = &dom.document;

--- a/xml5ever/src/driver.rs
+++ b/xml5ever/src/driver.rs
@@ -11,12 +11,10 @@ use tokenizer::{XmlTokenizerOpts, XmlTokenizer};
 use tree_builder::{TreeSink, XmlTreeBuilder, XmlTreeBuilderOpts};
 
 use std::borrow::Cow;
-use std::mem;
 
-use encoding::{self, EncodingRef};
 use tendril;
-use tendril::{StrTendril, ByteTendril};
-use tendril::stream::{TendrilSink, Utf8LossyDecoder, LossyDecoder};
+use tendril::StrTendril;
+use tendril::stream::{TendrilSink, Utf8LossyDecoder};
 
 /// All-encompasing parser setting structure.
 #[derive(Clone, Default)]
@@ -77,180 +75,6 @@ impl<Sink: TreeSink> XmlParser<Sink> {
     pub fn from_utf8(self) -> Utf8LossyDecoder<Self> {
         Utf8LossyDecoder::new(self)
     }
-
-    /// Wrap this parser into a `TendrilSink` that accepts bytes
-    /// and tries to detect the correct character encoding.
-    ///
-    /// Currently this looks for a Byte Order Mark,
-    /// then uses `BytesOpts::transport_layer_encoding`,
-    /// then falls back to UTF-8.
-    ///
-    /// FIXME(https://github.com/servo/html5ever/issues/18): this should look for `<meta>` elements
-    pub fn from_bytes(self, opts: BytesOpts) -> BytesParser<Sink> {
-        BytesParser {
-            state: BytesParserState::Initial { parser: self },
-            opts: opts,
-        }
-    }
-}
-
-/// Options for choosing a character encoding
-#[derive(Clone, Default)]
-pub struct BytesOpts {
-    /// The character encoding specified by the transport layer, if any.
-    /// In HTTP for example, this is the `charset` parameter of the `Content-Type` response header.
-    pub transport_layer_encoding: Option<EncodingRef>,
-}
-
-/// An HTML parser,
-/// ready to receive bytes input through the `tendril::TendrilSink` trait’s methods.
-///
-/// See `Parser::from_bytes`.
-pub struct BytesParser<Sink> where Sink: TreeSink {
-    state: BytesParserState<Sink>,
-    opts: BytesOpts,
-}
-
-enum BytesParserState<Sink> where Sink: TreeSink {
-    Initial {
-        parser: XmlParser<Sink>,
-    },
-    Buffering {
-        parser: XmlParser<Sink>,
-        buffer: ByteTendril
-    },
-    Parsing {
-        decoder: LossyDecoder<XmlParser<Sink>>,
-    },
-    Transient
-}
-
-impl<Sink: TreeSink> BytesParser<Sink> {
-    /// Access the underlying Parser
-    pub fn str_parser(&self) -> &XmlParser<Sink> {
-        match self.state {
-            BytesParserState::Initial { ref parser } => parser,
-            BytesParserState::Buffering { ref parser, .. } => parser,
-            BytesParserState::Parsing { ref decoder } => decoder.inner_sink(),
-            BytesParserState::Transient => unreachable!(),
-        }
-    }
-
-    /// Access the underlying Parser
-    pub fn str_parser_mut(&mut self) -> &mut XmlParser<Sink> {
-        match self.state {
-            BytesParserState::Initial { ref mut parser } => parser,
-            BytesParserState::Buffering { ref mut parser, .. } => parser,
-            BytesParserState::Parsing { ref mut decoder } => decoder.inner_sink_mut(),
-            BytesParserState::Transient => unreachable!(),
-        }
-    }
-
-    /// Insert a Unicode chunk in the middle of the byte stream.
-    ///
-    /// This is e.g. for supporting `document.write`.
-    pub fn process_unicode(&mut self, t: StrTendril) {
-        if t.is_empty() {
-            return  // Don’t prevent buffering/encoding detection
-        }
-        if let BytesParserState::Parsing { ref mut decoder } = self.state {
-            decoder.inner_sink_mut().process(t)
-        } else {
-            match mem::replace(&mut self.state, BytesParserState::Transient) {
-                BytesParserState::Initial { mut parser } => {
-                    parser.process(t);
-                    self.start_parsing(parser, ByteTendril::new())
-                }
-                BytesParserState::Buffering { parser, buffer } => {
-                    self.start_parsing(parser, buffer);
-                    if let BytesParserState::Parsing { ref mut decoder } = self.state {
-                        decoder.inner_sink_mut().process(t)
-                    } else {
-                        unreachable!()
-                    }
-                }
-                BytesParserState::Parsing { .. } | BytesParserState::Transient => unreachable!(),
-            }
-        }
-    }
-
-    fn start_parsing(&mut self, parser: XmlParser<Sink>, buffer: ByteTendril) {
-        let encoding = detect_encoding(&buffer, &self.opts);
-        let mut decoder = LossyDecoder::new(encoding, parser);
-        decoder.process(buffer);
-        self.state = BytesParserState::Parsing { decoder: decoder }
-    }
-}
-
-impl<Sink: TreeSink> TendrilSink<tendril::fmt::Bytes> for BytesParser<Sink> {
-    fn process(&mut self, t: ByteTendril) {
-        if let &mut BytesParserState::Parsing { ref mut decoder } = &mut self.state {
-            return decoder.process(t)
-        }
-        let (parser, buffer) = match mem::replace(&mut self.state, BytesParserState::Transient) {
-            BytesParserState::Initial{ parser } => (parser, t),
-            BytesParserState::Buffering { parser, mut buffer } => {
-                buffer.push_tendril(&t);
-                (parser, buffer)
-            }
-            BytesParserState::Parsing { .. } | BytesParserState::Transient => unreachable!(),
-        };
-        if buffer.len32() >= PRESCAN_BYTES {
-            self.start_parsing(parser, buffer)
-        } else {
-            self.state = BytesParserState::Buffering {
-                parser: parser,
-                buffer: buffer,
-            }
-        }
-    }
-
-    fn error(&mut self, desc: Cow<'static, str>) {
-        match self.state {
-            BytesParserState::Initial { ref mut parser } => parser.error(desc),
-            BytesParserState::Buffering { ref mut parser, .. } => parser.error(desc),
-            BytesParserState::Parsing { ref mut decoder } => decoder.error(desc),
-            BytesParserState::Transient => unreachable!(),
-        }
-    }
-
-    type Output = Sink::Output;
-
-    fn finish(self) -> Self::Output {
-        match self.state {
-            BytesParserState::Initial { parser } => parser.finish(),
-            BytesParserState::Buffering { parser, buffer } => {
-                let encoding = detect_encoding(&buffer, &self.opts);
-                let mut decoder = LossyDecoder::new(encoding, parser);
-                decoder.process(buffer);
-                decoder.finish()
-            },
-            BytesParserState::Parsing { decoder } => decoder.finish(),
-            BytesParserState::Transient => unreachable!(),
-        }
-    }
-}
-
-/// How many bytes does detect_encoding() need
-// FIXME(#18): should be 1024 for <meta> elements.
-const PRESCAN_BYTES: u32 = 3;
-
-/// https://html.spec.whatwg.org/multipage/syntax.html#determining-the-character-encoding
-fn detect_encoding(bytes: &ByteTendril, opts: &BytesOpts) -> EncodingRef {
-    if bytes.starts_with(b"\xEF\xBB\xBF") {
-        return encoding::all::UTF_8
-    }
-    if bytes.starts_with(b"\xFE\xFF") {
-        return encoding::all::UTF_16BE
-    }
-    if bytes.starts_with(b"\xFF\xFE") {
-        return encoding::all::UTF_16LE
-    }
-    if let Some(encoding) = opts.transport_layer_encoding {
-        return encoding
-    }
-    // FIXME(#18): <meta> etc.
-    return encoding::all::UTF_8
 }
 
 #[cfg(test)]
@@ -316,20 +140,12 @@ mod tests {
                 .one("<title>Test".as_bytes()));
     }
 
-    #[test]
-    fn from_bytes_one() {
-        assert_serialization("<title>Test</title>",
-            parse_document(RcDom::default(), XmlParseOpts::default())
-                .from_bytes(BytesOpts::default())
-                .one("<title>Test".as_bytes()));
-    }
-
     fn assert_eq_serialization(text: &'static str, dom: RcDom) {
         let mut serialized = Vec::new();
         serialize(&mut serialized, &dom.document, Default::default()).unwrap();
 
         let dom_from_text = parse_document(RcDom::default(), XmlParseOpts::default())
-            .from_bytes(BytesOpts::default())
+            .from_utf8()
             .one(text.as_bytes());
 
         let mut reserialized = Vec::new();

--- a/xml5ever/src/driver.rs
+++ b/xml5ever/src/driver.rs
@@ -60,12 +60,12 @@ impl<Sink: TreeSink> TendrilSink<tendril::fmt::UTF8> for XmlParser<Sink> {
 
     // FIXME: Is it too noisy to report every character decoding error?
     fn error(&mut self, desc: Cow<'static, str>) {
-        self.tokenizer.sink_mut().sink_mut().parse_error(desc)
+        self.tokenizer.sink.sink.parse_error(desc)
     }
 
     fn finish(mut self) -> Self::Output {
         self.tokenizer.end();
-        self.tokenizer.unwrap().unwrap().finish()
+        self.tokenizer.sink.sink.finish()
     }
 }
 

--- a/xml5ever/src/lib.rs
+++ b/xml5ever/src/lib.rs
@@ -39,12 +39,6 @@ extern crate time;
 
 pub use markup5ever::*;
 
-/// Re-export the tendril crate so that users don’t need to depend on it.
-pub mod tendril {
-    extern crate tendril;
-    pub use self::tendril::*;
-}
-
 macro_rules! time {
     ($e:expr) => {{
         let t0 = ::time::precise_time_ns();

--- a/xml5ever/src/lib.rs
+++ b/xml5ever/src/lib.rs
@@ -58,6 +58,3 @@ pub mod tree_builder;
 pub mod serialize;
 /// Driver
 pub mod driver;
-
-/// Re-export the encoding crate.
-pub use tendril::encoding;

--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -104,7 +104,7 @@ pub struct XmlTokenizer<Sink> {
     opts: XmlTokenizerOpts,
 
     /// Destination for tokens we emit.
-    sink: Sink,
+    pub sink: Sink,
 
     /// The abstract machine state as described in the spec.
     state: states::XmlState,
@@ -199,21 +199,6 @@ impl <Sink:TokenSink> XmlTokenizer<Sink> {
             state_profile: BTreeMap::new(),
             time_in_sink: 0,
         }
-    }
-
-    /// Returns destination of token events.
-    pub fn unwrap(self) -> Sink {
-        self.sink
-    }
-
-    /// Immutably borrows destination of token events.
-    pub fn sink<'a>(&'a self) -> &'a Sink {
-        &self.sink
-    }
-
-    /// Mutably borrows destinantion of token events.
-    pub fn sink_mut<'a>(&'a mut self) -> &'a mut Sink {
-        &mut self.sink
     }
 
     /// Feed an input string into the tokenizer.

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -199,7 +199,7 @@ pub struct XmlTreeBuilder<Handle, Sink> {
     _opts: XmlTreeBuilderOpts,
 
     /// Consumer of tree modifications.
-    sink: Sink,
+    pub sink: Sink,
 
     /// The document node, which is created by the sink.
     doc_handle: Handle,
@@ -246,21 +246,6 @@ impl<Handle, Sink> XmlTreeBuilder<Handle, Sink>
             present_attrs: HashSet::new(),
             phase: StartPhase,
         }
-    }
-
-    /// Returns consumer of tree modifications.
-    pub fn unwrap(self) -> Sink {
-        self.sink
-    }
-
-    /// Immutably borrows consumer of tree modifications.
-    pub fn sink<'a>(&'a self) -> &'a Sink {
-        &self.sink
-    }
-
-    /// Mutably borrows consumer of tree modifications.
-    pub fn sink_mut<'a>(&'a mut self) -> &'a mut Sink {
-        &mut self.sink
     }
 
     /// Call the `Tracer`'s `trace_handle` method on every `Handle` in the tree builder's

--- a/xml5ever/tests/tokenizer.rs
+++ b/xml5ever/tests/tokenizer.rs
@@ -136,7 +136,7 @@ fn tokenize_xml(input: Vec<StrTendril>, opts: XmlTokenizerOpts) -> Vec<Token> {
         tok.feed(chunk);
     }
     tok.end();
-    tok.unwrap().get_tokens()
+    tok.sink.get_tokens()
 }
 
 trait JsonExt: Sized {


### PR DESCRIPTION
It cannot be the future API for handling `<meta charset>` since it does not support interrupting for scripts.

Update Tendril to a version that doesn’t depend on rust-encoding (unless a Cargo feature is enabled).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/272)
<!-- Reviewable:end -->
