### PR TITLE
change type ChildrenOnly to ChildrenOnly(Option<QualName>)

### DIFF
--- a/html5ever/tests/serializer.rs
+++ b/html5ever/tests/serializer.rs
@@ -165,15 +165,15 @@ test!(noframes_literal, r#"<noframes>(x & 1) < 2; y > "foo" + 'bar'</noframes>"#
 
 test!(pre_lf_0, "<pre>foo bar</pre>");
 test!(pre_lf_1, "<pre>\nfoo bar</pre>", "<pre>foo bar</pre>");
-test!(pre_lf_2, "<pre>\n\nfoo bar</pre>");
+test!(pre_lf_2, "<pre>\n\nfoo bar</pre>", "<pre>\nfoo bar</pre>");
 
 test!(textarea_lf_0, "<textarea>foo bar</textarea>");
 test!(textarea_lf_1, "<textarea>\nfoo bar</textarea>", "<textarea>foo bar</textarea>");
-test!(textarea_lf_2, "<textarea>\n\nfoo bar</textarea>");
+test!(textarea_lf_2, "<textarea>\n\nfoo bar</textarea>", "<textarea>\nfoo bar</textarea>");
 
 test!(listing_lf_0, "<listing>foo bar</listing>");
 test!(listing_lf_1, "<listing>\nfoo bar</listing>", "<listing>foo bar</listing>");
-test!(listing_lf_2, "<listing>\n\nfoo bar</listing>");
+test!(listing_lf_2, "<listing>\n\nfoo bar</listing>", "<listing>\nfoo bar</listing>");
 
 test!(comment_1, r#"<p>hi <!--world--></p>"#);
 test!(comment_2, r#"<p>hi <!-- world--></p>"#);

--- a/markup5ever/rcdom.rs
+++ b/markup5ever/rcdom.rs
@@ -326,7 +326,7 @@ impl Default for RcDom {
 impl Serialize for Handle {
     fn serialize<S>(&self, serializer: &mut S, traversal_scope: TraversalScope) -> io::Result<()>
     where S: Serializer {
-        match (traversal_scope, &self.data) {
+        match (&traversal_scope, &self.data) {
             (_, &NodeData::Element { ref name, ref attrs, .. }) => {
                 if traversal_scope == IncludeNode {
                     try!(serializer.start_elem(name.clone(),
@@ -343,28 +343,28 @@ impl Serialize for Handle {
                 Ok(())
             }
 
-            (ChildrenOnly, &NodeData::Document) => {
+            (&ChildrenOnly(_), &NodeData::Document) => {
                 for handle in self.children.borrow().iter() {
                     try!(handle.clone().serialize(serializer, IncludeNode));
                 }
                 Ok(())
             }
 
-            (ChildrenOnly, _) => Ok(()),
+            (&ChildrenOnly(_), _) => Ok(()),
 
-            (IncludeNode, &NodeData::Doctype { ref name, .. }) => {
+            (&IncludeNode, &NodeData::Doctype { ref name, .. }) => {
                 serializer.write_doctype(&name)
             }
-            (IncludeNode, &NodeData::Text { ref contents }) => {
+            (&IncludeNode, &NodeData::Text { ref contents }) => {
                 serializer.write_text(&contents.borrow())
             }
-            (IncludeNode, &NodeData::Comment { ref contents }) => {
+            (&IncludeNode, &NodeData::Comment { ref contents }) => {
                 serializer.write_comment(&contents)
             }
-            (IncludeNode, &NodeData::ProcessingInstruction { ref target, ref contents }) => {
+            (&IncludeNode, &NodeData::ProcessingInstruction { ref target, ref contents }) => {
                 serializer.write_processing_instruction(target, contents)
             },
-            (IncludeNode, &NodeData::Document) => {
+            (&IncludeNode, &NodeData::Document) => {
                 panic!("Can't serialize Document node itself")
             }
         }

--- a/markup5ever/serialize.rs
+++ b/markup5ever/serialize.rs
@@ -11,10 +11,10 @@ use QualName;
 use std::io;
 
 //§ serializing-html-fragments
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum TraversalScope {
     IncludeNode,
-    ChildrenOnly
+    ChildrenOnly(Option<QualName>)
 }
 
 pub trait Serialize {

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -12,7 +12,7 @@ pub use markup5ever::serialize::{Serialize, Serializer, TraversalScope, AttrRef}
 use std::io::{self, Write};
 use tree_builder::NamespaceMap;
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 /// Struct for setting serializer options.
 pub struct SerializeOpts {
     /// Serialize the root node? Default: ChildrenOnly
@@ -22,7 +22,7 @@ pub struct SerializeOpts {
 impl Default for SerializeOpts {
     fn default() -> SerializeOpts {
         SerializeOpts {
-            traversal_scope: TraversalScope::ChildrenOnly
+            traversal_scope: TraversalScope::ChildrenOnly(None)
         }
     }
 }


### PR DESCRIPTION
This is necessary so that these nodes exist on the stack when we
serialize the children nodes and may need the parent for context.
Addresses servo/servo#14975

---
Opening this PR for feedback/review

~~This does work and solves the above bug. I'm not sure if this is the best implementation, as there's a bit of duplicated code. I thought about adding a boolean flag to `start_elem` that would determine whether the writes should be performed. But then I thought maybe when not writing, it's best not to call a function returning `io::Result<()>`?~~

Also not 100% sure if the xml implementation is the right thing to do

Anyway, please let me know of any improvements/changes to make. Thanks :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/277)
<!-- Reviewable:end -->
