### PR TITLE
Fix doc formatting for markup5ever::interface::QualName.

### DIFF
--- a/markup5ever/interface/mod.rs
+++ b/markup5ever/interface/mod.rs
@@ -61,44 +61,47 @@ pub mod tree_builder;
 #[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 /// Fully qualified name. Used to depict names of tags and attributes.
 ///
-/// Used to differentiate between similar XML fragments. For example
-/// ```ignore
-///    // HTML
-///    <table>
-///      <tr>
-///        <td>Apples</td>
-///        <td>Bananas</td>
-///      </tr>
-///    </table>
-///
-///    // Furniture XML
-///    <table>
-///      <name>African Coffee Table</name>
-///      <width>80</width>
-///      <length>120</length>
-///    </table>
-/// ```
-/// Without XML namespaces we can't use those two fragments in occur
-/// XML at same time. however if we declare a namespace we could instead say:
+/// Used to differentiate between similar XML fragments. For example:
 ///
 /// ```ignore
-///    // Furniture XML
-///    <furn:table>
-///      <furn:name>African Coffee Table</furn:name>
-///      <furn:width>80</furn:width>
-///      <furn:length>120</furn:length>
-///    </furn:table>
+/// // HTML
+/// <table>
+///   <tr>
+///     <td>Apples</td>
+///     <td>Bananas</td>
+///   </tr>
+/// </table>
+///
+/// // Furniture XML
+/// <table>
+///   <name>African Coffee Table</name>
+///   <width>80</width>
+///   <length>120</length>
+/// </table>
 /// ```
+///
+/// Without XML namespaces, we can't use those two fragments in the same document
+/// at the same time. However if we declare a namespace we could instead say:
+///
+/// ```ignore
+/// // Furniture XML
+/// <furn:table>
+///   <furn:name>African Coffee Table</furn:name>
+///   <furn:width>80</furn:width>
+///   <furn:length>120</furn:length>
+/// </furn:table>
+/// ```
+///
 /// and bind it to a different name.
 ///
-/// For this reason we parse names that contain a colon in the following way
+/// For this reason we parse names that contain a colon in the following way:
 ///
 /// ```ignore
-///    < furn:table>
-///        |    |
-///        |    +- local name
-///        |
-///      prefix (when resolved gives namespace_url)
+/// <furn:table>
+///    |    |
+///    |    +- local name
+///    |
+///  prefix (when resolved gives namespace_url)
 /// ```
 pub struct QualName {
     pub prefix: Option<Prefix>,


### PR DESCRIPTION
The documentation for `QualName` uses fenced code blocks (the ones that start with three backticks) incorrectly, so that the fence and the `ignore` directive ends up included in the documentation text.

![image](https://user-images.githubusercontent.com/751272/27651309-bbc70e42-5bec-11e7-94df-7e6848ded802.png)

Fenced code blocks must be separated from the preceding paragraph by a blank line.

This also adds some punctuation and tries to demangle some grammar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/html5ever/283)
<!-- Reviewable:end -->
