### PR TITLE
TreeBuilder no longer relies on `same_tree` and `has_parent_node`

### DIFF
--- a/html5ever/examples/noop-tree-builder.rs
+++ b/html5ever/examples/noop-tree-builder.rs
@@ -86,6 +86,11 @@ impl TreeSink for Sink {
             _sibling: &usize,
             _new_node: NodeOrText<usize>) { }
 
+    fn append_based_on_parent_node(&mut self,
+        _element: &usize,
+        _prev_element: &usize,
+        _new_node: NodeOrText<usize>) { }
+
     fn parse_error(&mut self, _msg: Cow<'static, str>) { }
     fn set_quirks_mode(&mut self, _mode: QuirksMode) { }
     fn append(&mut self, _parent: &usize, _child: NodeOrText<usize>) { }

--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -109,6 +109,18 @@ impl TreeSink for Sink {
         }
     }
 
+    fn append_based_on_parent_node(&mut self,
+        element: &Self::Handle,
+        prev_element: &Self::Handle,
+        child: NodeOrText<Self::Handle>) {
+
+        if self.has_parent_node(element) {
+            self.append_before_sibling(element, child);
+        } else {
+            self.append(prev_element, child);
+        }
+    }
+
     fn append_doctype_to_document(&mut self,
                                   name: StrTendril,
                                   public_id: StrTendril,
@@ -124,7 +136,7 @@ impl TreeSink for Sink {
         }
     }
 
-    fn associate_with_form(&mut self, _target: &usize, _form: &usize) {
+    fn associate_with_form(&mut self, _target: &usize, _form: &usize, _nodes: (&usize, Option<&usize>)) {
         // No form owner support. Since same_tree always returns
         // true we cannot be sure that this associate_with_form call is
         // valid

--- a/html5ever/src/tree_builder/types.rs
+++ b/html5ever/src/tree_builder/types.rs
@@ -86,5 +86,7 @@ pub enum InsertionPoint<Handle> {
     /// Insert as last child in this parent.
     LastChild(Handle),
     /// Insert before this following sibling.
-    BeforeSibling(Handle)
+    BeforeSibling(Handle),
+    /// Insertion point is decided based on existence of element's parent node.
+    TableFosterParenting { element: Handle, prev_element: Handle },
 }

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -140,6 +140,14 @@ pub trait TreeSink {
     /// The child node will not already have a parent.
     fn append(&mut self, parent: &Self::Handle, child: NodeOrText<Self::Handle>);
 
+    /// When the insertion point is decided by the existence of a parent node of the
+    /// element, we consider both possibilities and send the element which will be used
+    /// if a parent node exists, along with the element to be used if there isn't one.
+    fn append_based_on_parent_node(&mut self,
+        element: &Self::Handle,
+        prev_element: &Self::Handle,
+        child: NodeOrText<Self::Handle>);
+
     /// Append a `DOCTYPE` element to the `Document` node.
     fn append_doctype_to_document(&mut self,
                                   name: StrTendril,
@@ -188,7 +196,10 @@ pub trait TreeSink {
     fn add_attrs_if_missing(&mut self, target: &Self::Handle, attrs: Vec<Attribute>);
 
     /// Associate the given form-associatable element with the form element
-    fn associate_with_form(&mut self, _target: &Self::Handle, _form: &Self::Handle) {}
+    fn associate_with_form(&mut self,
+        _target: &Self::Handle,
+        _form: &Self::Handle,
+        _nodes: (&Self::Handle, Option<&Self::Handle>)) {}
 
     /// Detach the given node from its parent.
     fn remove_from_parent(&mut self, target: &Self::Handle);

--- a/markup5ever/rcdom.rs
+++ b/markup5ever/rcdom.rs
@@ -265,6 +265,18 @@ impl TreeSink for RcDom {
         parent.children.borrow_mut().insert(i, child);
     }
 
+    fn append_based_on_parent_node(&mut self,
+        element: &Self::Handle,
+        prev_element: &Self::Handle,
+        child: NodeOrText<Self::Handle>) {
+
+        if self.has_parent_node(element) {
+            self.append_before_sibling(element, child);
+        } else {
+            self.append(prev_element, child);
+        }
+    }
+
     fn append_doctype_to_document(&mut self,
                                   name: StrTendril,
                                   public_id: StrTendril,


### PR DESCRIPTION
The use of `same_tree` and `has_parent_node` meant that the TreeBuilder needed access to the DOM state to carry out its tasks.