### PR TITLE
Removed has_parent_node and same_tree methods from TreeSink trait

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.20.0"
+version = "0.21.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -36,7 +36,7 @@ heap_size = ["markup5ever/heap_size"]
 [dependencies]
 log = "0.3"
 mac = "0.1"
-markup5ever = { version = "0.5", path = "../markup5ever" }
+markup5ever = { version = "0.6", path = "../markup5ever" }
 
 [dev-dependencies]
 rustc-serialize = "0.3.15"

--- a/html5ever/examples/arena.rs
+++ b/html5ever/examples/arena.rs
@@ -211,10 +211,6 @@ impl<'arena> TreeSink for Sink<'arena> {
         }
     }
 
-    fn has_parent_node(&self, node: &Ref<'arena>) -> bool {
-        node.parent.get().is_some()
-    }
-
     fn create_element(&mut self, name: QualName, attrs: Vec<Attribute>, flags: ElementFlags) -> Ref<'arena> {
         self.new_node(NodeData::Element {
             name: name,
@@ -255,7 +251,7 @@ impl<'arena> TreeSink for Sink<'arena> {
 
     fn append_based_on_parent_node(&mut self, element: &Ref<'arena>,
                                    prev_element: &Ref<'arena>, child: NodeOrText<Ref<'arena>>) {
-        if self.has_parent_node(element) {
+        if element.parent.get().is_some() {
             self.append_before_sibling(element, child)
         } else {
             self.append(prev_element, child)

--- a/html5ever/examples/noop-tree-builder.rs
+++ b/html5ever/examples/noop-tree-builder.rs
@@ -53,10 +53,6 @@ impl TreeSink for Sink {
         x == y
     }
 
-    fn same_tree(&self, _x: &usize, _y: &usize) -> bool {
-        true
-    }
-
     fn elem_name(&self, target: &usize) -> ExpandedName {
         self.names.get(target).expect("not an element").expanded()
     }
@@ -74,12 +70,6 @@ impl TreeSink for Sink {
     #[allow(unused_variables)]
     fn create_pi(&mut self, target: StrTendril, value: StrTendril) -> usize {
         unimplemented!()
-    }
-
-    fn has_parent_node(&self, _node: &usize) -> bool {
-        // `node` will have a parent unless a script moved it, and we're
-        // not running scripts.  Therefore we can aways return true.
-        true
     }
 
     fn append_before_sibling(&mut self,

--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -83,12 +83,6 @@ impl TreeSink for Sink {
         unimplemented!()
     }
 
-    fn has_parent_node(&self, _node: &usize) -> bool  {
-        // `node` will have a parent unless a script moved it, and we're
-        // not running scripts.  Therefore we can aways return true
-        true
-    }
-
     fn append(&mut self, parent: &usize, child: NodeOrText<usize>) {
         match child {
             AppendNode(n)
@@ -114,11 +108,7 @@ impl TreeSink for Sink {
         prev_element: &Self::Handle,
         child: NodeOrText<Self::Handle>) {
 
-        if self.has_parent_node(element) {
-            self.append_before_sibling(element, child);
-        } else {
-            self.append(prev_element, child);
-        }
+        self.append_before_sibling(element, child);
     }
 
     fn append_doctype_to_document(&mut self,
@@ -137,9 +127,7 @@ impl TreeSink for Sink {
     }
 
     fn associate_with_form(&mut self, _target: &usize, _form: &usize, _nodes: (&usize, Option<&usize>)) {
-        // No form owner support. Since same_tree always returns
-        // true we cannot be sure that this associate_with_form call is
-        // valid
+        // No form owner support.
     }
 
     fn remove_from_parent(&mut self, target: &usize) {

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -1632,10 +1632,6 @@ mod test {
             self.rcdom.create_pi(target, content)
         }
 
-        fn has_parent_node(&self, node: &Handle) -> bool {
-            self.rcdom.has_parent_node(node)
-        }
-
         fn append(&mut self, parent: &Handle, child: NodeOrText<Handle>) {
             self.rcdom.append(parent, child)
         }

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.5.0"
+version = "0.6.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -168,17 +168,10 @@ pub trait TreeSink {
     /// Do two handles refer to the same node?
     fn same_node(&self, x: &Self::Handle, y: &Self::Handle) -> bool;
 
-    /// Are two handles present in the same tree
-    fn same_tree(&self, _x: &Self::Handle, _y: &Self::Handle) -> bool { true }
-
     /// Set the document's quirks mode.
     fn set_quirks_mode(&mut self, mode: QuirksMode);
 
-    /// Does the node have a parent?
-    fn has_parent_node(&self, node: &Self::Handle) -> bool;
-
     /// Append a node as the sibling immediately before the given node.
-    /// This method will only be called if has_parent_node(sibling) is true
     ///
     /// The tree builder promises that `sibling` is not a text node.  However its
     /// old previous sibling, which would become the new node's previous sibling,

--- a/markup5ever/rcdom.rs
+++ b/markup5ever/rcdom.rs
@@ -207,13 +207,6 @@ impl TreeSink for RcDom {
         Node::new(NodeData::ProcessingInstruction { target: target, contents: data })
     }
 
-    fn has_parent_node(&self, node: &Handle) -> bool {
-        let parent = node.parent.take();
-        let has_parent = parent.is_some();
-        node.parent.set(parent);
-        has_parent
-    }
-
     fn append(&mut self, parent: &Handle, child: NodeOrText<Handle>) {
         // Append to an existing Text node if we have one.
         match child {
@@ -269,8 +262,11 @@ impl TreeSink for RcDom {
         element: &Self::Handle,
         prev_element: &Self::Handle,
         child: NodeOrText<Self::Handle>) {
+        let parent = element.parent.take();
+        let has_parent = parent.is_some();
+        element.parent.set(parent);
 
-        if self.has_parent_node(element) {
+        if has_parent {
             self.append_before_sibling(element, child);
         } else {
             self.append(prev_element, child);

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "xml5ever"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["The xml5ever project developers"]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -23,7 +23,7 @@ doctest = true
 time = "0.1"
 log = "0.3"
 mac = "0.1"
-markup5ever = {version = "0.5", path = "../markup5ever" }
+markup5ever = {version = "0.6", path = "../markup5ever" }
 
 [dev-dependencies]
 rustc-serialize = "0.3.15"


### PR DESCRIPTION
fixes #303 
Continued from https://github.com/servo/html5ever/pull/308