### PR TITLE
Removed warn-log `stop_parsing not implemented, full speed ahead!`

### DIFF
--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -574,7 +574,6 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
     }
 
     fn stop_parsing(&mut self) -> ProcessResult<Handle> {
-        warn!("stop_parsing not implemented, full speed ahead!");
         Done
     }
 


### PR DESCRIPTION
As mentioned in #219, `stop_parsing` was assumed to be useless. It still triggers in my project, hence considered removing it.

Hopefully this PR is okay, despite already being assigned to @nox. I simply encountered it a few days ago and decided to make the move, as this issue seems to be there for a while, I preferred to do it myself than bothering anyone for such a small fix : )

Not sure if `"FIXME: </script> not fully implemented"` can be removed as well, if so, just inform me and I will change that as well!