### PR TITLE
Reset namespace stack when processing an empty script tag

### DIFF
--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "xml5ever"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["The xml5ever project developers"]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -372,8 +372,10 @@ impl<Handle, Sink> XmlTreeBuilder<Handle, Sink>
         // Finally, we dump current namespace if its unneeded.
         let x = mem::replace(&mut self.current_namespace, NamespaceMap::empty());
 
-        // Only start tag doesn't dump current namespace.
-        if tag.kind == StartTag {
+        // Only start tag doesn't dump current namespace. However, <script /> is treated
+        // differently than every other empty tag, so it needs to retain the current
+        // namespace as well.
+        if tag.kind == StartTag || (tag.kind == EmptyTag && tag.name.local == local_name!("script")) {
             self.namespace_stack.push(x);
         }
 


### PR DESCRIPTION
This addresses the problem from https://github.com/servo/servo/issues/19087. Non-script empty tags go through the `append_tag` code path which does not pop anything from the namespace stack. Empty script tags go through insert_tag/close_tag instead, which does pop an element from the namespace stack.