### PR TITLE
Update string_cache to 0.7

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.21.0"
+version = "0.22.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -33,7 +33,7 @@ harness = false
 [dependencies]
 log = "0.3"
 mac = "0.1"
-markup5ever = { version = "0.6", path = "../markup5ever" }
+markup5ever = { version = "0.7", path = "../markup5ever" }
 
 [dev-dependencies]
 rustc-serialize = "0.3.15"

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -30,9 +30,6 @@ name = "serializer"
 name = "tokenizer"
 harness = false
 
-[features]
-heap_size = ["markup5ever/heap_size"]
-
 [dependencies]
 log = "0.3"
 mac = "0.1"

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.6.2"
+version = "0.7.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -13,7 +13,7 @@ categories = [ "parser-implementations", "web-programming" ]
 path = "lib.rs"
 
 [dependencies]
-string_cache = "0.6"
+string_cache = "0.7"
 phf = "0.7"
 tendril = "0.4"
 

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -12,15 +12,10 @@ categories = [ "parser-implementations", "web-programming" ]
 [lib]
 path = "lib.rs"
 
-[features]
-heap_size = ["heapsize", "heapsize_derive", "string_cache/heapsize"]
-
 [dependencies]
 string_cache = "0.6"
 phf = "0.7"
 tendril = "0.4"
-heapsize = { version = ">= 0.3, < 0.5", optional = true }
-heapsize_derive = { version = "0.1", optional = true }
 
 [build-dependencies]
 string_cache_codegen = "0.4"

--- a/markup5ever/interface/mod.rs
+++ b/markup5ever/interface/mod.rs
@@ -58,7 +58,6 @@ pub mod tree_builder;
 
 /// A name with a namespace.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone)]
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 /// Fully qualified name. Used to depict names of tags and attributes.
 ///
 /// Used to differentiate between similar XML fragments. For example:

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -31,7 +31,6 @@ pub enum NodeOrText<Handle> {
 
 /// A document's quirks mode.
 #[derive(PartialEq, Eq, Copy, Clone, Hash, Debug)]
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub enum QuirksMode {
     Quirks,
     LimitedQuirks,

--- a/markup5ever/lib.rs
+++ b/markup5ever/lib.rs
@@ -7,8 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(feature = "heap_size")] #[macro_use] extern crate heapsize_derive;
-#[cfg(feature = "heap_size")] extern crate heapsize;
 extern crate string_cache;
 extern crate phf;
 pub extern crate tendril;

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "xml5ever"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["The xml5ever project developers"]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -23,7 +23,7 @@ doctest = true
 time = "0.1"
 log = "0.3"
 mac = "0.1"
-markup5ever = {version = "0.6", path = "../markup5ever" }
+markup5ever = {version = "0.7", path = "../markup5ever" }
 
 [dev-dependencies]
 rustc-serialize = "0.3.15"


### PR DESCRIPTION
Since heapsize isn't used anymore and that string_cache removed its heapsize feature, I removed the feature as a whole meaning that this is a breaking change for h5e and m5e.