### PR TITLE
Update to rustc-test 0.3, unbreak tests on nightly-2018-02-25

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -37,7 +37,7 @@ markup5ever = { version = "0.7", path = "../markup5ever" }
 
 [dev-dependencies]
 rustc-serialize = "0.3.15"
-rustc-test = "0.2"
+rustc-test = "0.3"
 typed-arena = "1.3.0"
 
 [build-dependencies]

--- a/html5ever/benches/tokenizer.rs
+++ b/html5ever/benches/tokenizer.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate test;
+extern crate rustc_test as test;
 extern crate html5ever;
 
 use std::{fs, env, cmp};

--- a/html5ever/tests/tokenizer.rs
+++ b/html5ever/tests/tokenizer.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 extern crate rustc_serialize;
-extern crate test;
+extern crate rustc_test as test;
 #[macro_use] extern crate html5ever;
 
 mod foreach_html5lib_test;

--- a/html5ever/tests/tree_builder.rs
+++ b/html5ever/tests/tree_builder.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate test;
+extern crate rustc_test as test;
 #[macro_use] extern crate html5ever;
 
 mod foreach_html5lib_test;

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -27,4 +27,4 @@ markup5ever = {version = "0.7", path = "../markup5ever" }
 
 [dev-dependencies]
 rustc-serialize = "0.3.15"
-rustc-test = "0.2"
+rustc-test = "0.3"

--- a/xml5ever/tests/tokenizer.rs
+++ b/xml5ever/tests/tokenizer.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 extern crate rustc_serialize;
-extern crate test;
+extern crate rustc_test as test;
 #[macro_use] extern crate xml5ever;
 
 use std::borrow::Cow::Borrowed;

--- a/xml5ever/tests/tree_builder.rs
+++ b/xml5ever/tests/tree_builder.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 extern crate rustc_serialize;
-extern crate test;
+extern crate rustc_test as test;
 #[macro_use] extern crate xml5ever;
 
 use std::collections::{HashSet, HashMap};


### PR DESCRIPTION
Version 0.2 of the crates.io package `rustc_test` uses `test` as its rustc crate name, shadowing the `test` crate from the standard library. This made us subject to breaking changes to its private APIs.