### PR TITLE
Create new types for Tokenizer and TreeBuilder which are `Send`

### DIFF
--- a/html5ever/src/lib.rs
+++ b/html5ever/src/lib.rs
@@ -29,6 +29,12 @@ mod util {
     pub mod str;
 }
 
+pub trait Sendable {
+    type SendableSelf: Send;
+    fn get_sendable(&self) -> Self::SendableSelf;
+    fn get_self_from_sendable(sendable: Self::SendableSelf) -> Self;
+}
+
 pub mod serialize;
 pub mod tokenizer;
 pub mod tree_builder;

--- a/html5ever/src/tree_builder/types.rs
+++ b/html5ever/src/tree_builder/types.rs
@@ -9,10 +9,13 @@
 
 //! Types used within the tree builder code.  Not exported to users.
 
+use {LocalName, QualName};
 use tokenizer::Tag;
 use tokenizer::states::RawKind;
+use tokenizer::TagKind;
 
-use tendril::StrTendril;
+use tendril::{SendTendril, StrTendril};
+use tendril::fmt::UTF8;
 
 pub use self::InsertionMode::*;
 pub use self::SplitStatus::*;
@@ -75,6 +78,18 @@ pub enum ProcessResult<Handle> {
     Script(Handle),
     ToPlaintext,
     ToRawData(RawKind),
+}
+
+#[derive(Clone)]
+pub enum SendableFormatEntry<Handle> {
+    Element {
+        handle: Handle,
+        tag_kind: TagKind,
+        tag_name: LocalName,
+        tag_self_closing: bool,
+        tag_attrs: Vec<(QualName, SendTendril<UTF8>)>,
+    },
+    Marker
 }
 
 pub enum FormatEntry<Handle> {


### PR DESCRIPTION
This is needed for speculative parsing in Servo, where one needs to send the tokenizer state between threads. I created a `Sendable` trait, which is implemented by both the Tokenizer and the TreeBuilder.

Servo side PR: https://github.com/servo/servo/pull/19203