### PR TITLE
Enable debugging information in dev and test builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,3 @@ members = [
     "html5ever",
     "xml5ever"
 ]
-
-[profile.dev]
-debug = false
-
-[profile.test]
-debug = false


### PR DESCRIPTION
It's pretty surprising when tests and dev builds can't be debugged. Debugging information was disabled in 1223b23 (2015-3-31) because of rust-lang/rust#23110, which was closed 2016-7-14. It should be okay to turn it back on now.
