### PR TITLE
Call sink's complete_script method on closing script tag

### DIFF
--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -340,6 +340,7 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
                 }
                 Script(node) => {
                     assert!(more_tokens.is_empty());
+                    self.sink.complete_script(&node);
                     return tokenizer::TokenSinkResult::Script(node);
                 }
                 ToPlaintext => {


### PR DESCRIPTION
Based on https://html.spec.whatwg.org/multipage/parsing.html#scriptEndTag.