### PR TITLE
Use log_enabled! to avoid calling to_escaped_string

### DIFF
--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -37,6 +37,7 @@ use tokenizer::states::{RawData, RawKind};
 use tree_builder::types::*;
 use tree_builder::tag_sets::*;
 use util::str::to_escaped_string;
+use log::Level;
 
 pub use self::PushFlag::*;
 
@@ -293,8 +294,9 @@ impl<Handle, Sink> TreeBuilder<Handle, Sink>
     }
 
     fn debug_step(&self, mode: InsertionMode, token: &Token) {
-        use util::str::to_escaped_string;
-        debug!("processing {} in insertion mode {:?}", to_escaped_string(token), mode);
+        if log_enabled!(Level::Debug) {
+            debug!("processing {} in insertion mode {:?}", to_escaped_string(token), mode);
+        }
     }
 
     fn process_to_completion(&mut self, mut token: Token) -> TokenSinkResult<Handle> {

--- a/html5ever/src/util/str.rs
+++ b/html5ever/src/util/str.rs
@@ -10,13 +10,9 @@
 use std::fmt;
 
 pub fn to_escaped_string<T: fmt::Debug>(x: &T) -> String {
-    use std::fmt::Write;
-
     // FIXME: don't allocate twice
-    let mut buf = String::new();
-    let _ = buf.write_fmt(format_args!("{:?}", x));
-    buf.shrink_to_fit();
-    buf.chars().flat_map(|c| c.escape_default()).collect()
+    let string = format!("{:?}", x);
+    string.chars().flat_map(|c| c.escape_default()).collect()
 }
 
 /// If `c` is an ASCII letter, return the corresponding lowercase


### PR DESCRIPTION
`to_escaped_string` is somewhat expensive because it allocates twice and iterates over each char individually to escape it. Furthermore, `TreeBuilder::step` produces a lot of `debug_step` messages. So, we use `log_enabled!` to not escape any strings unless debug messages are being printed.