### PR TITLE
Add names used by the HTMLTrackElement

### DIFF
--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.7.4"
+version = "0.7.5"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/markup5ever/local_names.txt
+++ b/markup5ever/local_names.txt
@@ -437,6 +437,7 @@ keyPoints
 keySplines
 keyTimes
 keygen
+kind
 label
 lambda
 lang
@@ -839,6 +840,7 @@ speed
 spreadMethod
 src
 srcdoc
+srclang
 srcset
 standby
 start


### PR DESCRIPTION
Add `kind` and `srclang` to the list of `local_names`. They are needed
by the HTMLTrackElement.