### PR TITLE
Expose public Node constructor.

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.22.8"
+version = "0.23.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.8.0"
+version = "0.8.1"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/markup5ever/rcdom.rs
+++ b/markup5ever/rcdom.rs
@@ -115,7 +115,7 @@ pub struct Node {
 
 impl Node {
     /// Create a new node from its contents
-    fn new(data: NodeData) -> Rc<Self> {
+    pub fn new(data: NodeData) -> Rc<Self> {
         Rc::new(Node {
             data: data,
             parent: Cell::new(None),

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "xml5ever"
-version = "0.13.2"
+version = "0.14.0"
 authors = ["The xml5ever project developers"]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"


### PR DESCRIPTION
Since #372 there is a private field in Node that prevents constructing them manually. If we want to support that, we need to expose the constructor.