### PR TITLE
Ensure all RcDom nodes drop children iteratively

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.23.0"
+version = "0.24.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -29,7 +29,7 @@ name = "serializer"
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.8", path = "../markup5ever" }
+markup5ever = { version = "0.9", path = "../markup5ever" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.8.1"
+version = "0.9.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "xml5ever"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["The xml5ever project developers"]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -23,7 +23,7 @@ doctest = true
 time = "0.1"
 log = "0.4"
 mac = "0.1"
-markup5ever = {version = "0.8", path = "../markup5ever" }
+markup5ever = {version = "0.9", path = "../markup5ever" }
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
This is a better solution for the problem solved by 8bf65ef61daf612a3b4d7e6007fde7297d6210eb which doesn't require destroying all nodes when the RcDom is dropped. Fixes #383.