### PR TITLE
Add property to local_names

### DIFF
--- a/markup5ever/local_names.txt
+++ b/markup5ever/local_names.txt
@@ -736,6 +736,7 @@ product
 profile
 progress
 prompt
+property
 prsubset
 q
 quotient


### PR DESCRIPTION
`property` can exist as an attribute name in `meta` tags like `<meta property="og:title" content="Title" />`