### PR TITLE
Adding script tag support to parsing SVGs

### DIFF
--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -1658,6 +1658,110 @@ mod test {
     }
 
     #[test]
+    fn check_script_inside_svg(){
+        let opts = TokenizerOpts {
+            exact_errors: false,
+            discard_bom: true,
+            profile: false,
+            initial_state: None,
+            last_start_tag_name: None,
+        };
+        let vector = vec![
+            StrTendril::from("<svg>"),
+            StrTendril::from("<script>"),
+            StrTendril::from("</script>"),
+            StrTendril::from("</svg>")
+        ];
+        let expected = vec![
+            (create_tag(StrTendril::from("svg"), StartTag), 1),
+            (create_tag(StrTendril::from("script"), StartTag), 1),
+            (create_tag(StrTendril::from("script"), EndTag), 1),
+            (create_tag(StrTendril::from("svg"), EndTag), 1)
+        ];
+        let results = tokenize(vector, opts);
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn check_script_inside_svg_with_newlines(){
+        let opts = TokenizerOpts{
+            exact_errors: false,
+            discard_bom: true,
+            profile: false,
+            initial_state: None,
+            last_start_tag_name: None,
+        };
+        let vector = vec![
+            StrTendril::from("<svg>\n"),
+            StrTendril::from("<script>\n"),
+            StrTendril::from("</script>\n"),
+            StrTendril::from("</svg>\n")
+        ];
+        let expected = vec![
+            (create_tag(StrTendril::from("svg"), StartTag), 1),
+            (create_tag(StrTendril::from("script"), StartTag), 2),
+            (create_tag(StrTendril::from("script"), EndTag), 3),
+            (create_tag(StrTendril::from("svg"), EndTag), 4),
+         ];
+        let results = tokenize(vector, opts);
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn check_script_body_inside_svg(){
+        let opts = TokenizerOpts{
+            exact_errors: false,
+            discard_bom: true,
+            profile: false,
+            initial_state: None,
+            last_start_tag_name: None,
+        };
+        let vector = vec![
+            StrTendril::from("<svg>"),
+            StrTendril::from("<script>"),
+            StrTendril::from("console.log('parsed');"),
+            StrTendril::from("</script>"),
+            StrTendril::from("</svg>")
+        ];
+        let expected = vec![
+            (create_tag(StrTendril::from("svg"), StartTag), 1),
+            (create_tag(StrTendril::from("script"), StartTag), 1),
+            (CharacterTokens(StrTendril::from("console.log('parsed');" )), 1),
+            (create_tag(StrTendril::from("script"), EndTag), 1),
+            (create_tag(StrTendril::from("svg"), EndTag), 1),
+        ];
+        let results = tokenize(vector, opts);
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn check_script_body_inside_svg_with_newlines(){
+        let opts = TokenizerOpts{
+            exact_errors: false,
+            discard_bom: true,
+            profile: false,
+            initial_state: None,
+            last_start_tag_name: None,
+        };
+        let vector = vec![
+            StrTendril::from("<svg>\n"),
+            StrTendril::from("<script>\n"),
+            StrTendril::from("console.log('parsed');\n"),
+            StrTendril::from("</script>\n"),
+            StrTendril::from("</svg>\n")
+        ];
+        let expected = vec![
+            (create_tag(StrTendril::from("svg"), StartTag), 1),
+            (create_tag(StrTendril::from("script"), StartTag), 2),
+            (CharacterTokens(StrTendril::from("console.log('parsed');" )), 3),
+            (create_tag(StrTendril::from("script"), EndTag), 4),
+            (create_tag(StrTendril::from("svg"), EndTag), 5),
+        ];
+        let results = tokenize(vector, opts);
+        assert_eq!(results, expected);
+    }
+
+    #[test]
     fn check_lines() {
         let opts = TokenizerOpts {
             exact_errors: false,

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -1818,6 +1818,87 @@ mod test {
     }
 
     #[test]
+    fn check_script_element(){
+        // Input
+        let sink = LineCountingDOM {
+            line_vec: vec![],
+            current_line: 1,
+            rcdom: RcDom::default(),
+        };
+
+        let opts = ParseOpts::default();
+        let mut resultTok = parse_document(sink, opts);
+        resultTok.process(StrTendril::from("<svg>"));
+        resultTok.process(StrTendril::from("<script>"));
+        resultTok.process(StrTendril::from("</script>"));
+        resultTok.process(StrTendril::from("</svg>"));
+        let actual = resultTok.finish();
+        let expected = vec![
+            (QualName::new(None, ns!(html), local_name!("html")), 1),
+            (QualName::new(None, ns!(html), local_name!("head")), 1),
+            (QualName::new(None, ns!(html), local_name!("body")), 1),
+            (QualName::new(None, ns!(svg), local_name!("svg")), 1),
+            (QualName::new(None, ns!(svg), local_name!("script")), 1),
+        ];
+
+        assert_eq!(actual.line_vec, expected);
+    }
+
+    #[test]
+    fn check_script_body_element(){
+        // Input
+        let sink = LineCountingDOM {
+            line_vec: vec![],
+            current_line: 1,
+            rcdom: RcDom::default(),
+        };
+
+        let opts = ParseOpts::default();
+        let mut resultTok = parse_document(sink, opts);
+        resultTok.process(StrTendril::from("<svg>"));
+        resultTok.process(StrTendril::from("<script>"));
+        resultTok.process(StrTendril::from("console.log('parsed');"));
+        resultTok.process(StrTendril::from("</script>"));
+        resultTok.process(StrTendril::from("</svg>"));
+        let actual = resultTok.finish();
+        let expected = vec![
+            (QualName::new(None, ns!(html), local_name!("html")), 1),
+            (QualName::new(None, ns!(html), local_name!("head")), 1),
+            (QualName::new(None, ns!(html), local_name!("body")), 1),
+            (QualName::new(None, ns!(svg), local_name!("svg")), 1),
+            (QualName::new(None, ns!(svg), local_name!("script")), 1),
+        ];
+
+        assert_eq!(actual.line_vec, expected);
+    }
+
+    #[test]
+    fn check_self_closing_script_tag(){
+        // Input
+        let sink = LineCountingDOM {
+            line_vec: vec![],
+            current_line: 1,
+            rcdom: RcDom::default(),
+        };
+
+        let opts = ParseOpts::default();
+        let mut resultTok = parse_document(sink, opts);
+        resultTok.process(StrTendril::from("<svg>"));
+        resultTok.process(StrTendril::from("<script src='cats.js' />"));
+        resultTok.process(StrTendril::from("</svg>"));
+        let actual = resultTok.finish();
+        let expected = vec![
+            (QualName::new(None, ns!(html), local_name!("html")), 1),
+            (QualName::new(None, ns!(html), local_name!("head")), 1),
+            (QualName::new(None, ns!(html), local_name!("body")), 1),
+            (QualName::new(None, ns!(svg), local_name!("svg")), 1),
+            (QualName::new(None, ns!(svg), local_name!("script")), 1),
+        ];
+
+        assert_eq!(actual.line_vec, expected);
+    }
+
+    #[test]
     fn check_four_lines() {
         // Input
         let sink = LineCountingDOM {

--- a/html5ever/src/tree_builder/rules.rs
+++ b/html5ever/src/tree_builder/rules.rs
@@ -1403,6 +1403,18 @@ where
                 }
             }
 
+            tag @ <script> => {
+                    let elem = create_element(
+                        &mut self.sink, QualName::new(None, ns!(svg), local_name!("script")),
+                        tag.attrs);
+                    if self.is_fragment() {
+                        self.sink.mark_script_already_started(&elem);
+                    }
+                    self.insert_appropriately(AppendNode(elem.clone()), None);
+                    self.open_elems.push(elem);
+                    self.to_raw_text_mode(ScriptData)
+                }
+
             tag @ <_> => self.foreign_start_tag(tag),
 
             // FIXME(#118): </script> in SVG


### PR DESCRIPTION
Fixes #118 

Currently, this just includes unit tests and a preliminary attempt at a solution. All the unit tests pass except for two tokenizer tests in which I try to parse out the body of the script element (although, I'm not sure if I should even expect that to be parsed out). Are there any other unit tests I should add so that I have a full specification to develop against? In regard to my current solution, it is at this time, just a copy paste of how the HTML parser handles script elements.