### PR TITLE
Allow publishing of markup5ever_rcdom

### DIFF
--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 documentation = "https://docs.rs/markup5ever_rcdom"
 categories = [ "parser-implementations", "web-programming" ]
 edition = "2018"
-publish = false
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
Turns out some Android font code uses this with xml5ever in Servo.