### PR TITLE
Fix ambiguity of glob import with `matches!` now in the standard library

### DIFF
--- a/html5ever/src/tree_builder/tag_sets.rs
+++ b/html5ever/src/tree_builder/tag_sets.rs
@@ -10,7 +10,7 @@
 //! Various sets of HTML tag names, and macros for declaring them.
 
 use crate::ExpandedName;
-use mac::*;
+use mac::{matches, _tt_as_expr_hack};
 use markup5ever::{expanded_name, local_name, namespace_prefix, namespace_url, ns};
 
 macro_rules! declare_tag_set_impl ( ($param:ident, $b:ident, $supr:ident, $($tag:tt)+) => (

--- a/html5ever/src/util/str.rs
+++ b/html5ever/src/util/str.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use mac::*;
+use mac::{matches, _tt_as_expr_hack};
 use std::fmt;
 
 pub fn to_escaped_string<T: fmt::Debug>(x: &T) -> String {

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -10,7 +10,7 @@
 mod types;
 
 use log::{debug, warn};
-use mac::*;
+use mac::{matches, _tt_as_expr_hack, unwrap_or_return};
 use markup5ever::{local_name, namespace_prefix, namespace_url, ns};
 use std::borrow::Cow;
 use std::borrow::Cow::Borrowed;

--- a/xml5ever/src/util/mod.rs
+++ b/xml5ever/src/util/mod.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use mac::*;
+use mac::{matches, _tt_as_expr_hack};
 
 /// Is the character an ASCII alphanumeric character?
 pub fn is_ascii_alnum(c: char) -> bool {


### PR DESCRIPTION
```rust
error[E0659]: `matches` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
   --> html5ever/src/tree_builder/tag_sets.rs:109:5
    |
109 |     matches!(
    |     ^^^^^^^ ambiguous name
    |
    = note: `matches` could refer to a macro from prelude
note: `matches` could also refer to the macro imported here
   --> html5ever/src/tree_builder/tag_sets.rs:13:5
    |
13  | use mac::*;
    |     ^^^^^^
    = help: consider adding an explicit import of `matches` to disambiguate
    = help: or use `self::matches` to refer to this macro unambiguously

error: aborting due to 2 previous errors
```