### PR TITLE
WIP: optimize open elements stack lookups

### DIFF
--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -889,14 +889,10 @@ where
     }
 
     fn remove_from_stack(&mut self, elem: &Handle) {
-        let sink = &mut self.sink;
-        let position = self
-            .open_elems
-            .iter()
-            .rposition(|x| sink.same_node(elem, &x));
+        let position = self.open_elems.rposition(&self.sink, elem);
         if let Some(position) = position {
             self.open_elems.remove(position);
-            sink.pop(elem);
+            self.sink.pop(elem);
         }
     }
 

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -1038,7 +1038,7 @@ where
     where
         TagSet: Fn(ExpandedName) -> bool,
     {
-        self.open_elems.in_scope_named(&self.sink, scope, name)
+        self.open_elems.in_scope_named(&self.sink, scope, &name).is_some()
     }
 
     //§ closing-elements-that-have-implied-end-tags
@@ -1372,7 +1372,7 @@ where
         use stack::Position;
 
         // Look back for a matching open element.
-        let match_pos = self.open_elems.rposition_in_scope_named(&mut self.sink, &special_tag, &tag.name);
+        let match_pos = self.open_elems.in_scope_named(&mut self.sink, &special_tag, &tag.name);
 
         // Can't use unwrap_or_return!() due to rust-lang/rust#16617.
         let match_idx = match match_pos {

--- a/html5ever/src/tree_builder/rules.rs
+++ b/html5ever/src/tree_builder/rules.rs
@@ -133,7 +133,7 @@ where
                         self.sink.mark_script_already_started(&elem);
                     }
                     self.insert_appropriately(AppendNode(elem.clone()), None);
-                    self.open_elems.push(elem);
+                    self.push(&elem);
                     self.to_raw_text_mode(ScriptData)
                 }
 
@@ -267,7 +267,7 @@ where
                 tag @ <html> => {
                     self.unexpected(&tag);
                     if !self.in_html_elem_named(local_name!("template")) {
-                        let top = html_elem(&self.open_elems);
+                        let top = html_elem(self.open_elems.as_ref());
                         self.sink.add_attrs_if_missing(top, tag.attrs);
                     }
                     Done
@@ -300,7 +300,7 @@ where
 
                     // FIXME: can we get here in the fragment case?
                     // What to do with the first element then?
-                    self.open_elems.truncate(1);
+                    self.open_elems.truncate(&self.sink, 1);
                     self.insert_element_for(tag);
                     self.mode = InFrameset;
                     Done
@@ -732,7 +732,7 @@ where
                 EOFToken => {
                     self.unexpected(&token);
                     if self.current_node_named(local_name!("script")) {
-                        let current = current_node(&self.open_elems);
+                        let current = current_node(self.open_elems.as_ref());
                         self.sink.mark_script_already_started(current);
                     }
                     self.pop();
@@ -1429,7 +1429,7 @@ where
                     }
 
                     if eq {
-                        self.open_elems.truncate(stack_idx);
+                        self.open_elems.truncate(&self.sink, stack_idx);
                         return Done;
                     }
 

--- a/html5ever/src/tree_builder/stack.rs
+++ b/html5ever/src/tree_builder/stack.rs
@@ -186,6 +186,21 @@ where
         Position::None
     }
 
+    pub fn rposition(&mut self, sink: &Sink, elem: &Handle) -> Option<usize> {
+        if let Some(res) = self.rposition_in_scope(sink, |n| false, |n| sink.same_node(n, elem)) {
+            return match res {
+                Position::Some(pos) => return Some(pos),
+                _ => return None,
+            }
+        }
+
+        self.build_index(sink);
+
+        let elem_index = self.elem_index.as_ref().expect("index is missing");
+
+        elem_index.get(&elem_name(sink, elem)).and_then(|v| v.last()).cloned()
+    }
+
     pub fn push(&mut self, sink: &Sink, elem: &Handle) {
         let index = self.open_elems.len();
         self.open_elems.push(elem.clone());


### PR DESCRIPTION
Deeply nested documents can cause `tree_builder` to make a lot of full scans through the stack of open elements, leading to quadratic complexity. For example, each opening `div` tag makes it to scan through the entire list, looking if there are any `p` tags to close.

This PR looks to improve the performance of these lookups by adding a kind of reverse index from element names to stack positions. With this information, finding top-most element with specific name is a constant time operation.

The index is only useful for certain kinds of documents, but adds a considerable overhead for each visited element (roughly about 15% in number of instructions). To avoid penalizing regular documents, the index is only constructed once we can't answer a query (such as `in_scope_named`) by scanning a fixed number of stack elements.

For testing these changes, I collected a few samples of good and misbehaving documents in a [html5ever-bench](https://github.com/vickenty/html5ever-bench) repo, along with some scripts to run simple benchmarks on them.

This is an early PR to gather comments and check if the approach is viable before doing more work. There are many more places where the reverse index can speed things, also active formatting stack can benefit from the same approach. Tests need to be adapted to check that reverse index is working correctly (for now I just tweak threshold to zero and run tests manually).