### PR TITLE
Added a document parse fuzzer

### DIFF
--- a/html5ever/fuzz/.gitignore
+++ b/html5ever/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/html5ever/fuzz/Cargo.toml
+++ b/html5ever/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+
+[package]
+name = "html5ever-fuzz"
+version = "0.0.0"
+authors = ["David Korczynski <david@adalogics.com>"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.html5ever]
+path = ".."
+
+[dependencies.markup5ever_rcdom]
+path = "../../rcdom/"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_document_parse"
+path = "fuzz_targets/fuzz_document_parse.rs"

--- a/html5ever/fuzz/fuzz_targets/fuzz_document_parse.rs
+++ b/html5ever/fuzz/fuzz_targets/fuzz_document_parse.rs
@@ -1,9 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-extern crate markup5ever_rcdom as rcdom;
-extern crate html5ever;
-
 use std::io::BufReader;
 use html5ever::driver::ParseOpts;
 use markup5ever_rcdom::{RcDom, SerializableHandle};

--- a/html5ever/fuzz/fuzz_targets/fuzz_document_parse.rs
+++ b/html5ever/fuzz/fuzz_targets/fuzz_document_parse.rs
@@ -1,0 +1,38 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+extern crate markup5ever_rcdom as rcdom;
+extern crate html5ever;
+
+use std::io::BufReader;
+use html5ever::driver::ParseOpts;
+use markup5ever_rcdom::{RcDom, SerializableHandle};
+use html5ever::tendril::TendrilSink;
+use html5ever::tree_builder::TreeBuilderOpts;
+use html5ever::{parse_document, serialize};
+
+// Target inspired by the Rust-Fuzz project
+// https://github.com/rust-fuzz/targets
+fuzz_target!(|data: &[u8]| {
+    let opts = ParseOpts {
+        tree_builder: TreeBuilderOpts {
+            drop_doctype: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let dom = parse_document(RcDom::default(), opts)
+        .from_utf8()
+        .read_from(&mut BufReader::new(data));
+
+    let dom = if let Ok(dom) = dom {
+        dom
+    } else {
+        return;
+    };
+
+    let mut out = Vec::with_capacity(data.len());
+    let document: SerializableHandle = dom.document.into();
+    let _ = serialize(&mut out, &document, Default::default());
+});


### PR DESCRIPTION
This is work that will be coordinated with integration of the [OSS-Fuzz](https://github.com/google/oss-fuzz) infrastructure, which allows continuous fuzzing for the project. 

I had a short talk with @jdm about this. 

Once this has been merged I will set up the project on the OSS-Fuzz side and then we should be up and running :)!