### PR TITLE
Don't store serialized data in memory when fuzzing.

### DIFF
--- a/html5ever/fuzz/fuzz_targets/fuzz_document_parse.rs
+++ b/html5ever/fuzz/fuzz_targets/fuzz_document_parse.rs
@@ -29,7 +29,7 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
-    let mut out = Vec::with_capacity(data.len());
+    let mut out = std::io::sink();
     let document: SerializableHandle = dom.document.into();
     let _ = serialize(&mut out, &document, Default::default());
 });


### PR DESCRIPTION
This shouldn't lose much coverage, since we didn't perform any validation of the actual output bytes. By creating a black hole for serialization, we avoid the risk of OOMing when serializing arbitrary fuzzer inputs.