### PR TITLE
Remove escape_default workarounds

### DIFF
--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -80,7 +80,7 @@ impl TreeSink for Sink {
 
     fn create_comment(&mut self, text: StrTendril) -> usize {
         let id = self.get_id();
-        println!("Created comment \"{}\" as {}", escape_default(&text), id);
+        println!("Created comment \"{}\" as {}", text.escape_default(), id);
         id
     }
 
@@ -92,14 +92,14 @@ impl TreeSink for Sink {
     fn append(&mut self, parent: &usize, child: NodeOrText<usize>) {
         match child {
             AppendNode(n) => println!("Append node {} to {}", n, parent),
-            AppendText(t) => println!("Append text to {}: \"{}\"", parent, escape_default(&t)),
+            AppendText(t) => println!("Append text to {}: \"{}\"", parent, t.escape_default()),
         }
     }
 
     fn append_before_sibling(&mut self, sibling: &usize, new_node: NodeOrText<usize>) {
         match new_node {
             AppendNode(n) => println!("Append node {} before {}", n, sibling),
-            AppendText(t) => println!("Append text before {}: \"{}\"", sibling, escape_default(&t)),
+            AppendText(t) => println!("Append text before {}: \"{}\"", sibling, t.escape_default()),
         }
     }
 
@@ -157,11 +157,6 @@ impl TreeSink for Sink {
     fn pop(&mut self, elem: &usize) {
         println!("Popped element {}", elem);
     }
-}
-
-// FIXME: Copy of str::escape_default from std, which is currently unstable
-pub fn escape_default(s: &str) -> String {
-    s.chars().flat_map(|c| c.escape_default()).collect()
 }
 
 fn main() {

--- a/rcdom/examples/print-rcdom.rs
+++ b/rcdom/examples/print-rcdom.rs
@@ -36,10 +36,10 @@ fn walk(indent: usize, handle: &Handle) {
         } => println!("<!DOCTYPE {} \"{}\" \"{}\">", name, public_id, system_id),
 
         NodeData::Text { ref contents } => {
-            println!("#text: {}", escape_default(&contents.borrow()))
+            println!("#text: {}", contents.borrow().escape_default())
         },
 
-        NodeData::Comment { ref contents } => println!("<!-- {} -->", escape_default(contents)),
+        NodeData::Comment { ref contents } => println!("<!-- {} -->", contents.escape_default()),
 
         NodeData::Element {
             ref name,
@@ -61,11 +61,6 @@ fn walk(indent: usize, handle: &Handle) {
     for child in node.children.borrow().iter() {
         walk(indent + 4, child);
     }
-}
-
-// FIXME: Copy of str::escape_default from std, which is currently unstable
-pub fn escape_default(s: &str) -> String {
-    s.chars().flat_map(|c| c.escape_default()).collect()
 }
 
 fn main() {

--- a/rcdom/examples/xml_tree_printer.rs
+++ b/rcdom/examples/xml_tree_printer.rs
@@ -26,7 +26,7 @@ fn walk(prefix: &str, handle: &Handle) {
     match node.data {
         NodeData::Document => println!("#document"),
 
-        NodeData::Text { ref contents } => println!("#text {}", escape_default(&contents.borrow())),
+        NodeData::Text { ref contents } => println!("#text {}", contents.borrow().escape_default()),
 
         NodeData::Element { ref name, .. } => {
             println!("{}", name.local);
@@ -53,10 +53,6 @@ fn walk(prefix: &str, handle: &Handle) {
     {
         walk(&new_indent, child);
     }
-}
-
-pub fn escape_default(s: &str) -> String {
-    s.chars().flat_map(|c| c.escape_default()).collect()
 }
 
 fn main() {

--- a/xml5ever/examples/README.md
+++ b/xml5ever/examples/README.md
@@ -185,7 +185,7 @@ kind of function that will help us traverse it. We shall call that function `wal
                 => println!("#document"),
 
             Text(ref text)  => {
-                println!("#text {}", escape_default(text))
+                println!("#text {}", text.escape_default())
             },
 
             Element(ref name, _) => {


### PR DESCRIPTION
The `escape_default` method was stabilized in Rust 1.34 [1] and workarounds
are no longer needed.

[1] https://doc.rust-lang.org/std/primitive.str.html#method.escape_default