### PR TITLE
Use std `is_ascii_whitespace`

### DIFF
--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -24,8 +24,6 @@ use crate::tokenizer;
 use crate::tokenizer::states as tok_state;
 use crate::tokenizer::{Doctype, EndTag, StartTag, Tag, TokenSink, TokenSinkResult};
 
-use crate::util::str::is_ascii_whitespace;
-
 use std::borrow::Cow::Borrowed;
 use std::collections::VecDeque;
 use std::default::Default;
@@ -362,7 +360,7 @@ where
                     token = t;
                 },
                 SplitWhitespace(mut buf) => {
-                    let p = buf.pop_front_char_run(is_ascii_whitespace);
+                    let p = buf.pop_front_char_run(|c| c.is_ascii_whitespace());
                     let (first, is_ws) = unwrap_or_return!(p, tokenizer::TokenSinkResult::Continue);
                     let status = if is_ws { Whitespace } else { NotWhitespace };
                     token = CharacterTokens(status, first);

--- a/html5ever/src/tree_builder/rules.rs
+++ b/html5ever/src/tree_builder/rules.rs
@@ -20,7 +20,7 @@ use crate::tendril::SliceExt;
 
 fn any_not_whitespace(x: &StrTendril) -> bool {
     // FIXME: this might be much faster as a byte scan
-    x.chars().any(|c| !is_ascii_whitespace(c))
+    x.chars().any(|c| !c.is_ascii_whitespace())
 }
 
 fn current_node<Handle>(open_elems: &[Handle]) -> &Handle {

--- a/html5ever/src/util/str.rs
+++ b/html5ever/src/util/str.rs
@@ -7,7 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use mac::{_tt_as_expr_hack, matches};
 use std::fmt;
 
 pub fn to_escaped_string<T: fmt::Debug>(x: &T) -> String {
@@ -24,12 +23,6 @@ pub fn lower_ascii_letter(c: char) -> Option<char> {
         'A'..='Z' => Some((c as u8 - b'A' + b'a') as char),
         _ => None,
     }
-}
-
-/// ASCII whitespace characters, as defined by
-/// tree construction modes that treat them specially.
-pub fn is_ascii_whitespace(c: char) -> bool {
-    matches!(c, '\t' | '\r' | '\n' | '\x0C' | ' ')
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The custom `is_ascii_whitespace` function was added before the standard
library version was added. The standard library `is_ascii_whitespace` method
was added in Rust 1.24 [1]. The implementations are nearly identical except
for the order of the matched characters, which should not matter.

[1] https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii_whitespace