### PR TITLE
Update phf

### DIFF
--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -15,10 +15,10 @@ path = "lib.rs"
 
 [dependencies]
 string_cache = "0.8"
-phf = "0.8"
+phf = "0.9"
 tendril = "0.4"
 log = "0.4"
 
 [build-dependencies]
 string_cache_codegen = "0.5.1"
-phf_codegen = "0.8"
+phf_codegen = "0.9"


### PR DESCRIPTION
phf 0.8 depends on rand 0.7 This causes rand to be included twice
as most other projects have updated to rand 0.8.

phf 0.9 uses rand 0.8 so update to avoid the duplicate dependency.