### PR TITLE
Fix panic on wrongly closed elements

### DIFF
--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -17,6 +17,7 @@ use std::io;
 
 use html5ever::parse_document;
 use html5ever::tendril::*;
+use html5ever::tree_builder::TreeBuilder;
 use html5ever::tree_builder::{
     AppendNode, AppendText, ElementFlags, NodeOrText, QuirksMode, TreeSink,
 };
@@ -154,8 +155,9 @@ impl TreeSink for Sink {
         println!("Set current line to {}", line_number);
     }
 
-    fn pop(&mut self, elem: &usize) {
+    fn pop(&mut self, elem: &usize) -> Result<(), SuperfluousClosingElement> {
         println!("Popped element {}", elem);
+        Ok(())
     }
 }
 

--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -155,9 +155,15 @@ impl TreeSink for Sink {
         println!("Set current line to {}", line_number);
     }
 
+    #[cfg(api_v2)]
     fn pop(&mut self, elem: &usize) -> Result<(), SuperfluousClosingElement> {
         println!("Popped element {}", elem);
         Ok(())
+    }
+
+    #[cfg(not(api_v2))]
+    fn pop(&mut self, elem: &usize) {
+        println!("Popped element {}", elem);
     }
 }
 

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -655,16 +655,23 @@ where
     #[cfg(not(api_v2))]
     #[deprecated(note = "You are using an outdated API. Please use api_v2 feature.")]
     fn current_node(&self) -> &Handle {
-        self.current_node_unconditional()
+        self.open_elems.last().expect("no current node")
     }
 
-    /// Like pop(), but in the case of no open element, just warn instead of returning an error.
+    #[cfg(api_v2)]
+    /// Like current_node(), but in the case of no open element, just warn instead of returning an error.
     fn current_node_unconditional(&self) -> &Handle {
         let current = self.current_node();
         if self.current_node_v2().is_none() {
             warn!("no current element");
         }
         current
+    }
+
+    #[cfg(not(api_v2))]
+    /// Like current_node(), but in the case of no open element, just warn instead of returning an error.
+    fn current_node_unconditional(&self) -> &Handle {
+        self.current_node()
     }
 
     /// Note: Don't use this function, use pop() with api_v2 feature instead.

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -647,29 +647,29 @@ where
 
     /// Indicate that a node was popped off the stack of open elements.
     #[cfg(api_v2)]
-    fn current_node(&mut self, node: &Self::Handle) -> Option<&Handle> {
-        self.current_node_v2(node)
+    fn current_node(&self) -> Option<&Handle> {
+        self.current_node_v2()
     }
 
     /// Indicate that a node was popped off the stack of open elements.
     #[cfg(not(api_v2))]
     #[deprecated(note = "You are using an outdated API. Please use api_v2 feature.")]
-    fn current_node(&mut self, node: &Handle) -> &Handle {
-        self.current_node_unconditional(node)
+    fn current_node(&self) -> &Handle {
+        self.current_node_unconditional()
     }
 
     /// Like pop(), but in the case of no open element, just warn instead of returning an error.
-    fn current_node_unconditional(&mut self, node: &Handle) -> &Handle {
-        let current = self.current_node(node);
-        if self.current_node_v2(node).is_none() {
+    fn current_node_unconditional(&self) -> &Handle {
+        let current = self.current_node();
+        if self.current_node_v2().is_none() {
             warn!("no current element");
         }
         current
     }
 
     /// Note: Don't use this function, use pop() with api_v2 feature instead.
-    fn current_node_v2(&mut self, node: &Self::Handle) -> Option<&Handle> {
-        self.open_elems.last(node)
+    fn current_node_v2(&self) -> Option<&Handle> {
+        self.open_elems.last()
     }
 
     fn adjusted_current_node(&self) -> &Handle {

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -913,11 +913,9 @@ where
         }
     }
 
-    fn pop_unconditional(&mut self) -> Handle {
-        if let Ok(result) = self.pop_v2() {
-            result
-        } else {
-            panic!("no current element");
+    fn pop_unconditional(&mut self) {
+        if  self.pop_v2().is_err() {
+            warn!("no current element");
         }
     }
 
@@ -1091,7 +1089,7 @@ where
                     return;
                 }
             }
-            self.pop();
+            self.pop_unconditional();
         }
     }
 
@@ -1701,13 +1699,13 @@ where
         if self.is_fragment() {
             self.foreign_start_tag(tag)
         } else {
-            self.pop();
+            self.pop_unconditional();
             while !self.current_node_in(|n| {
                 *n.ns == ns!(html) ||
                     mathml_text_integration_point(n) ||
                     svg_html_integration_point(n)
             }) {
-                self.pop();
+                self.pop_unconditional();
             }
             ReprocessForeign(TagToken(tag))
         }

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -655,7 +655,7 @@ where
     #[cfg(not(api_v2))]
     #[deprecated(note = "You are using an outdated API. Please use api_v2 feature.")]
     fn current_node(&self) -> &Handle {
-        self.open_elems.last().expect("no current node")
+        self.open_elems.last().expect("no current element")
     }
 
     #[cfg(api_v2)]

--- a/html5ever/src/tree_builder/rules.rs
+++ b/html5ever/src/tree_builder/rules.rs
@@ -138,7 +138,7 @@ where
                 }
 
                 </head> => {
-                    self.pop();
+                    self.pop_unconditional();
                     self.mode = AfterHead;
                     Done
                 }
@@ -171,7 +171,7 @@ where
                 tag @ </_> => self.unexpected(&tag),
 
                 token => {
-                    self.pop();
+                    self.pop_unconditional();
                     Reprocess(AfterHead, token)
                 }
             }),
@@ -181,7 +181,7 @@ where
                 <html> => self.step(InBody, token),
 
                 </noscript> => {
-                    self.pop();
+                    self.pop_unconditional();
                     self.mode = InHead;
                     Done
                 },
@@ -201,7 +201,7 @@ where
 
                 token => {
                     self.unexpected(&token);
-                    self.pop();
+                    self.pop_unconditional();
                     Reprocess(InHead, token)
                 },
             }),
@@ -353,7 +353,7 @@ where
                     self.close_p_element_in_button_scope();
                     if self.current_node_in(heading_tag) {
                         self.sink.parse_error(Borrowed("nested heading tags"));
-                        self.pop();
+                        self.pop_unconditional();
                     }
                     self.insert_element_for(tag);
                     Done
@@ -666,7 +666,7 @@ where
 
                 tag @ <optgroup> <option> => {
                     if self.current_node_named(local_name!("option")) {
-                        self.pop();
+                        self.pop_unconditional();
                     }
                     self.reconstruct_formatting();
                     self.insert_element_for(tag);
@@ -735,7 +735,7 @@ where
                         let current = current_node(&self.open_elems);
                         self.sink.mark_script_already_started(current);
                     }
-                    self.pop();
+                    self.pop_unconditional();
                     Reprocess(self.orig_mode.take().unwrap(), token)
                 }
 
@@ -928,7 +928,7 @@ where
 
                 </colgroup> => {
                     if self.current_node_named(local_name!("colgroup")) {
-                        self.pop();
+                        self.pop_unconditional();
                         self.mode = InTable;
                     } else {
                         self.unexpected(&token);
@@ -944,7 +944,7 @@ where
 
                 token => {
                     if self.current_node_named(local_name!("colgroup")) {
-                        self.pop();
+                        self.pop_unconditional();
                         Reprocess(InTable, token)
                     } else {
                         self.unexpected(&token)
@@ -971,7 +971,7 @@ where
                 tag @ </tbody> </tfoot> </thead> => {
                     if self.in_scope_named(table_scope, tag.name.clone()) {
                         self.pop_until_current(table_body_context);
-                        self.pop();
+                        self.pop_unconditional();
                         self.mode = InTable;
                     } else {
                         self.unexpected(&tag);
@@ -983,7 +983,7 @@ where
                     declare_tag_set!(table_outer = "table" "tbody" "tfoot");
                     if self.in_scope(table_scope, |e| self.elem_in(&e, table_outer)) {
                         self.pop_until_current(table_body_context);
-                        self.pop();
+                        self.pop_unconditional();
                         Reprocess(InTable, token)
                     } else {
                         self.unexpected(&token)
@@ -1098,7 +1098,7 @@ where
 
                 tag @ <option> => {
                     if self.current_node_named(local_name!("option")) {
-                        self.pop();
+                        self.pop_unconditional();
                     }
                     self.insert_element_for(tag);
                     Done
@@ -1106,10 +1106,10 @@ where
 
                 tag @ <optgroup> => {
                     if self.current_node_named(local_name!("option")) {
-                        self.pop();
+                        self.pop_unconditional();
                     }
                     if self.current_node_named(local_name!("optgroup")) {
-                        self.pop();
+                        self.pop_unconditional();
                     }
                     self.insert_element_for(tag);
                     Done
@@ -1120,10 +1120,10 @@ where
                         && self.current_node_named(local_name!("option"))
                         && self.html_elem_named(&self.open_elems[self.open_elems.len() - 2],
                             local_name!("optgroup")) {
-                        self.pop();
+                        self.pop_unconditional();
                     }
                     if self.current_node_named(local_name!("optgroup")) {
-                        self.pop();
+                        self.pop_unconditional();
                     } else {
                         self.unexpected(&token);
                     }
@@ -1132,7 +1132,7 @@ where
 
                 </option> => {
                     if self.current_node_named(local_name!("option")) {
-                        self.pop();
+                        self.pop_unconditional();
                     } else {
                         self.unexpected(&token);
                     }
@@ -1289,7 +1289,7 @@ where
                     if self.open_elems.len() == 1 {
                         self.unexpected(&token);
                     } else {
-                        self.pop();
+                        self.pop_unconditional();
                         if !self.is_fragment() && !self.current_node_named(local_name!("frameset")) {
                             self.mode = AfterFrameset;
                         }

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -22,3 +22,6 @@ log = "0.4"
 [build-dependencies]
 string_cache_codegen = "0.5.1"
 phf_codegen = "0.9"
+
+[features]
+api_v2 = []

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -24,4 +24,5 @@ string_cache_codegen = "0.5.1"
 phf_codegen = "0.9"
 
 [features]
+# Always use this feature in new code. In the future it will become the default.
 api_v2 = []

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -11,7 +11,6 @@
 //!
 //! It can be used by a parser to create the DOM graph structure in memory.
 
-use log::warn;
 use crate::interface::{Attribute, ExpandedName, QualName};
 use std::borrow::Cow;
 use tendril::StrTendril;
@@ -215,15 +214,20 @@ pub trait TreeSink {
     /// Indicate that a node was popped off the stack of open elements.
     #[cfg(not(api_v2))]
     #[deprecated(note = "You are using an outdated API. Please use api_v2 feature.")]
-    fn pop(&mut self, node: &Self::Handle) {
-        self.pop_unconditional(node)
-    }
+    fn pop(&mut self, _node: &Self::Handle) {}
 
+    #[cfg(api_v2)]
     /// Like pop(), but in the case of no open element, just warn instead of returning an error.
     fn pop_unconditional(&mut self, node: &Self::Handle) {
         if self.pop_v2(node).is_err() {
             warn!("no current element");
         };
+    }
+
+    #[cfg(not(api_v2))]
+    /// Like pop(), but in the case of no open element, just warn instead of returning an error.
+    fn pop_unconditional(&mut self, node: &Self::Handle) {
+        self.pop(node)
     }
 
     /// Indicate that a node was popped off the stack of open elements.

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -11,6 +11,7 @@
 //!
 //! It can be used by a parser to create the DOM graph structure in memory.
 
+use log::warn;
 use crate::interface::{Attribute, ExpandedName, QualName};
 use std::borrow::Cow;
 use tendril::StrTendril;
@@ -73,6 +74,27 @@ pub struct ElementFlags {
 
     // Prevent construction from outside module
     _private: (),
+}
+
+#[derive(Debug)]
+pub enum TreeBuilderError {
+    WronglyClosed(SuperfluousClosingElement),
+}
+
+// TODO: Error message.
+#[derive(Debug)]
+pub struct SuperfluousClosingElement {}
+
+impl SuperfluousClosingElement {
+    pub fn new() -> Self {
+        Self { }
+    }
+}
+
+impl From<SuperfluousClosingElement> for TreeBuilderError {
+    fn from(value: SuperfluousClosingElement) -> Self {
+        Self::WronglyClosed(value)
+    }
 }
 
 /// A constructor for an element.
@@ -185,7 +207,31 @@ pub trait TreeSink {
     fn mark_script_already_started(&mut self, _node: &Self::Handle) {}
 
     /// Indicate that a node was popped off the stack of open elements.
-    fn pop(&mut self, _node: &Self::Handle) {}
+    #[cfg(api_v2)]
+    fn pop(&mut self, _node: &Self::Handle) -> Result<(), SuperfluousClosingElement> {
+        self.pop_v2(node)
+    }
+
+    /// Indicate that a node was popped off the stack of open elements.
+    #[cfg(not(api_v2))]
+    #[deprecated(note = "You are using an outdated API. Please use api_v2 feature.")]
+    fn pop(&mut self, node: &Self::Handle) {
+        self.pop_unconditional(node)
+    }
+
+    /// Like pop(), but in the case of no open element, just warn instead of returning an error.
+    fn pop_unconditional(&mut self, node: &Self::Handle) {
+        if self.pop_v2(node).is_err() {
+            warn!("no current element");
+        };
+    }
+
+    /// Indicate that a node was popped off the stack of open elements.
+    ///
+    /// Note: Don't use this function, use pop() with api_v2 feature instead.
+    fn pop_v2(&mut self, _node: &Self::Handle) -> Result<(), SuperfluousClosingElement> {
+        Ok(())
+    }
 
     /// Get a handle to a template's template contents. The tree builder
     /// promises this will never be called with something else than

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -213,6 +213,7 @@ pub trait TreeSink {
 
     /// Indicate that a node was popped off the stack of open elements.
     #[cfg(not(api_v2))]
+    #[deprecated(note = "You are using an outdated API. Please use api_v2 feature.")]
     fn pop(&mut self, _node: &Self::Handle) {}
 
     #[cfg(api_v2)]
@@ -226,6 +227,7 @@ pub trait TreeSink {
     #[cfg(not(api_v2))]
     /// Like pop(), but in the case of no open element, just warn instead of returning an error.
     fn pop_unconditional(&mut self, node: &Self::Handle) {
+        #[allow(deprecated)]
         self.pop(node)
     }
 

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -213,7 +213,6 @@ pub trait TreeSink {
 
     /// Indicate that a node was popped off the stack of open elements.
     #[cfg(not(api_v2))]
-    #[deprecated(note = "You are using an outdated API. Please use api_v2 feature.")]
     fn pop(&mut self, _node: &Self::Handle) {}
 
     #[cfg(api_v2)]

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -60,7 +60,7 @@ impl NamespaceMapStack {
     }
 
     fn pop(&mut self) {
-        self.0.pop();
+        self.0.pop().expect("no such element");
     }
 }
 

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -438,10 +438,10 @@ where
 }
 
 /// Indicate that a node was popped off the stack of open elements.
-#[cfg(api_v2)]
-fn current_node<Handle>(open_elems: &[Handle]) -> Option<&Handle> {
-    current_node_v2(open_elems)
-}
+// #[cfg(api_v2)]
+// fn current_node<Handle>(open_elems: &[Handle]) -> Option<&Handle> {
+//     current_node_v2(open_elems)
+// }
 
 // /// Indicate that a node was popped off the stack of open elements.
 // #[cfg(not(api_v2))]
@@ -614,6 +614,15 @@ where
         self.pop_v2()
     }
 
+    #[cfg(not(api_v2))]
+    fn pop(&mut self) -> Handle {
+        if let Ok(result) = self.pop_v2() {
+            result
+        } else {
+            panic!("no current element");
+        }
+    }
+
     // #[cfg(not(api_v2))]
     // #[deprecated(note = "You are using an outdated API. Please use api_v2 feature.")]
     // fn pop(&mut self) -> Handle {
@@ -621,12 +630,16 @@ where
     // }
 
     /// Like pop(), but in the case of no open element, just warn instead of returning an error.
-    fn pop_unconditional(&mut self) -> Handle {
-        if let Ok(result) = self.pop_v2() {
-            result
-        } else {
-            panic!("no current element");
+    #[cfg(api_v2)]
+    fn pop_unconditional(&mut self) {
+        if self.pop_v2().is_err() {
+            warn!("no current element");
         }
+    }
+
+    #[cfg(not(api_v2))]
+    fn pop_unconditional(&mut self) -> Handle {
+        self.pop()
     }
 
     /// Indicate that a node was popped off the stack of open elements.


### PR DESCRIPTION
`html5ever` (HTML in quirks mode specifically) was crashing on superfluous closing tags (I don't provide a test case, but that was a case).

This PR is a WIP (You may choose to accept this PR now or wait until it is tested or reviewed more.) that attempts to fix that bug. Need to add tests to ensure my code really fixed the bug.

This PR introduces new feature `api_v2` to be used with new code. Enabling the feature makes the library incompatible with old code.