### PR TITLE
Remove time dependency

### DIFF
--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "parser-implementations", "web-programming" ]
 edition = "2018"
 
 [dependencies]
-time = "0.1"
 log = "0.4"
 mac = "0.1"
 markup5ever = {version = "0.10", path = "../markup5ever" }

--- a/xml5ever/src/lib.rs
+++ b/xml5ever/src/lib.rs
@@ -36,9 +36,9 @@ pub use markup5ever::*;
 
 macro_rules! time {
     ($e:expr) => {{
-        let t0 = ::time::precise_time_ns();
+        let t0 = ::std::time::Instant::now();
         let result = $e;
-        let dt = ::time::precise_time_ns() - t0;
+        let dt = t0.elapsed().as_nanos() as u64;
         (result, dt)
     }};
 }


### PR DESCRIPTION
time 0.1 has known security issues, and it's not really necessary to use time crate anymore for getting precise instants as std::time::Instant::now [has the same implementation as precise_time_ns on popular platforms](https://stackoverflow.com/a/55619763).