### PR TITLE
Reduces log verbosity

### DIFF
--- a/html5ever/src/tokenizer/char_ref/mod.rs
+++ b/html5ever/src/tokenizer/char_ref/mod.rs
@@ -12,7 +12,7 @@ use crate::buffer_queue::BufferQueue;
 use crate::data;
 use crate::tendril::StrTendril;
 
-use log::debug;
+use log::trace;
 use mac::format_if;
 use std::borrow::Cow::Borrowed;
 use std::char::from_u32;
@@ -123,7 +123,7 @@ impl CharRefTokenizer {
             return Done;
         }
 
-        debug!("char ref tokenizer stepping in state {:?}", self.state);
+        trace!("char ref tokenizer stepping in state {:?}", self.state);
         match self.state {
             Begin => self.do_begin(tokenizer, input),
             Octothorpe => self.do_octothorpe(tokenizer, input),

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -23,7 +23,7 @@ use self::char_ref::{CharRef, CharRefTokenizer};
 
 use crate::util::str::lower_ascii_letter;
 
-use log::debug;
+use log::trace;
 use mac::{_tt_as_expr_hack, format_if, matches};
 use markup5ever::{namespace_url, ns, small_char_set};
 use std::borrow::Cow::{self, Borrowed};
@@ -276,7 +276,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             self.emit_error(Cow::Owned(msg));
         }
 
-        debug!("got character {}", c);
+        trace!("got character {}", c);
         self.current_char = c;
         Some(c)
     }
@@ -304,7 +304,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         }
 
         let d = input.pop_except_from(set);
-        debug!("got characters {:?}", d);
+        trace!("got characters {:?}", d);
         match d {
             Some(FromSet(c)) => self.get_preprocessed_char(c, input).map(FromSet),
 
@@ -605,7 +605,7 @@ macro_rules! shorthand (
 // so it's behind a cfg flag.
 #[cfg(trace_tokenizer)]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ({
-    debug!("  {:s}", stringify!($($cmds)*));
+    trace!("  {:s}", stringify!($($cmds)*));
     shorthand!($me:expr : $($cmds)*);
 }));
 
@@ -689,7 +689,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             return self.step_char_ref_tokenizer(input);
         }
 
-        debug!("processing in state {:?}", self.state);
+        trace!("processing in state {:?}", self.state);
         match self.state {
             //§ data-state
             states::Data => loop {
@@ -1442,7 +1442,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
     }
 
     fn eof_step(&mut self) -> ProcessResult<Sink::Handle> {
-        debug!("processing EOF in state {:?}", self.state);
+        trace!("processing EOF in state {:?}", self.state);
         match self.state {
             states::Data |
             states::RawData(Rcdata) |

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -35,7 +35,7 @@ use crate::tokenizer::states::{RawData, RawKind};
 use crate::tree_builder::tag_sets::*;
 use crate::tree_builder::types::*;
 use crate::util::str::to_escaped_string;
-use log::{debug, log_enabled, warn, Level};
+use log::{log_enabled, trace, warn, Level};
 use mac::{_tt_as_expr_hack, format_if, matches};
 
 pub use self::PushFlag::*;
@@ -306,8 +306,8 @@ where
     }
 
     fn debug_step(&self, mode: InsertionMode, token: &Token) {
-        if log_enabled!(Level::Debug) {
-            debug!(
+        if log_enabled!(Level::Trace) {
+            trace!(
                 "processing {} in insertion mode {:?}",
                 to_escaped_string(token),
                 mode


### PR DESCRIPTION
My root problem: I use the `html5ever` trough the [scraper crate](https://crates.io/crates/scraper) and I usually display the debug log when I develop, but it’s problematic when I looking for a selector in an entire html page…

I think the trace level is more appropriate for log messages.