### PR TITLE
use trace!() in tokenizer, to reduce log spam

### DIFF
--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -23,7 +23,7 @@ use self::char_ref::{CharRef, CharRefTokenizer};
 
 use crate::util::str::lower_ascii_letter;
 
-use log::debug;
+use log::{debug, trace};
 use mac::{_tt_as_expr_hack, format_if, matches};
 use markup5ever::{namespace_url, ns, small_char_set};
 use std::borrow::Cow::{self, Borrowed};
@@ -276,7 +276,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             self.emit_error(Cow::Owned(msg));
         }
 
-        debug!("got character {}", c);
+        trace!("got character {}", c);
         self.current_char = c;
         Some(c)
     }
@@ -304,7 +304,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         }
 
         let d = input.pop_except_from(set);
-        debug!("got characters {:?}", d);
+        trace!("got characters {:?}", d);
         match d {
             Some(FromSet(c)) => self.get_preprocessed_char(c, input).map(FromSet),
 
@@ -605,7 +605,7 @@ macro_rules! shorthand (
 // so it's behind a cfg flag.
 #[cfg(trace_tokenizer)]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ({
-    debug!("  {:s}", stringify!($($cmds)*));
+    trace!("  {:s}", stringify!($($cmds)*));
     shorthand!($me:expr : $($cmds)*);
 }));
 
@@ -689,7 +689,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             return self.step_char_ref_tokenizer(input);
         }
 
-        debug!("processing in state {:?}", self.state);
+        trace!("processing in state {:?}", self.state);
         match self.state {
             //§ data-state
             states::Data => loop {


### PR DESCRIPTION
html5ever doesn't currently use trace!() anywhere. This patch
downgrades a few of the noisiest debug!() calls to use trace!()
instead.

This seems like a more reasonable log level for a tokenizer.

This makes configuring env_logger to debug other code easier
(RUST_LOG=debug rather than RUST_LOG=html5ever=info,debug), and
makes working with minimal wasm log frameworks like console_log
nicer (the console_log crate doesn't have a way to set different
levels for different log prefixes).

There is a single debug statement in html5ever/src/tokenizer/mod.rs that I've not changed:

        debug!("processing EOF in state {:?}", self.state);

I didn't change this to trace, because I notice this log line anywhere in my logs. If you want me to change this too, then I can.

I'm also happy to close this PR, if you think it's not appropriate.