### PR TITLE
Update markup5ever major version and all other crates.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [1.41.0, stable, beta, nightly]
+        version: [1.49.0, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v2
 

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.25.2"
+version = "0.26.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.10", path = "../markup5ever" }
+markup5ever = { version = "0.11", path = "../markup5ever" }
 
 [dev-dependencies]
 typed-arena = "1.3.0"

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.10.1"
+version = "0.11.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever_rcdom"
-version = "0.1.0"
+version = "0.2.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -16,9 +16,9 @@ path = "lib.rs"
 
 [dependencies]
 tendril = "0.4"
-html5ever = { version = "0.25", path = "../html5ever" }
-markup5ever = { version = "0.10", path = "../markup5ever" }
-xml5ever = { version = "0.16", path = "../xml5ever" }
+html5ever = { version = "0.26", path = "../html5ever" }
+markup5ever = { version = "0.11", path = "../markup5ever" }
+xml5ever = { version = "0.17", path = "../xml5ever" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "xml5ever"
-version = "0.16.2"
+version = "0.17.0"
 authors = ["The xml5ever project developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -18,7 +18,7 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = {version = "0.10", path = "../markup5ever" }
+markup5ever = {version = "0.11", path = "../markup5ever" }
 
 [dev-dependencies]
 rustc-test = "0.3"


### PR DESCRIPTION
Since the pfh map is exposed in markup5ever's public API, we need to release a new major version when the phf dependency is updated.