### PR TITLE
compile fix for haiku

### DIFF
--- a/html5ever/build.rs
+++ b/html5ever/build.rs
@@ -21,9 +21,15 @@ fn main() {
     let output = Path::new(&env::var("OUT_DIR").unwrap()).join("rules.rs");
     println!("cargo:rerun-if-changed={}", input.display());
 
+    #[cfg(target_os = "haiku")]
+    let stack_size = 16;
+
+    #[cfg(not(target_os = "haiku"))]
+    let stack_size = 128;
+
     // We have stack overflows on Servo's CI.
     let handle = Builder::new()
-        .stack_size(128 * 1024 * 1024)
+        .stack_size(stack_size * 1024 * 1024)
         .spawn(move || {
             match_token::expand(&input, &output);
         })


### PR DESCRIPTION
hello, the following patch allows compilation to work for haiku.

example build run is shown below:

```
> uname -a
Haiku shredder 1 hrev56154 Jun  3 2022 18:56:03 x86_64 x86_64 Haiku

> rustc --version
rustc 1.60.0 (2e3e23e17 2022-04-05)

> cargo build
   Compiling cfg-if v1.0.0
   Compiling libc v0.2.112
   Compiling getrandom v0.1.16
   Compiling siphasher v0.3.7
   Compiling ppv-lite86 v0.2.16
   Compiling proc-macro2 v1.0.36
   Compiling unicode-xid v0.2.2
   Compiling parking_lot_core v0.8.5
   Compiling smallvec v1.8.0
   Compiling new_debug_unreachable v1.0.4
   Compiling serde v1.0.133
   Compiling scopeguard v1.1.0
   Compiling mac v0.1.1
   Compiling syn v1.0.85
   Compiling log v0.4.14
   Compiling lazy_static v1.4.0
   Compiling utf-8 v0.7.6
   Compiling precomputed-hash v0.1.1
   Compiling instant v0.1.12
   Compiling phf_shared v0.10.0
   Compiling phf_shared v0.8.0
   Compiling lock_api v0.4.5
   Compiling futf v0.1.4
   Compiling phf v0.10.1
   Compiling tendril v0.4.2
   Compiling quote v1.0.14
   Compiling getrandom v0.2.4
   Compiling rand_core v0.6.3
   Compiling rand_core v0.5.1
   Compiling parking_lot v0.11.2
   Compiling rand_chacha v0.3.1
   Compiling rand_pcg v0.2.1
   Compiling rand_chacha v0.2.2
   Compiling rand v0.8.4
   Compiling rand v0.7.3
   Compiling phf_generator v0.10.0
   Compiling phf_codegen v0.10.0
   Compiling phf_generator v0.8.0
   Compiling string_cache_codegen v0.5.1
   Compiling markup5ever v0.11.0 (/boot/home/src/git/rust-libs/html5ever/markup5ever)
   Compiling string_cache v0.8.2
   Compiling xml5ever v0.17.0 (/boot/home/src/git/rust-libs/html5ever/xml5ever)
   Compiling html5ever v0.26.0 (/boot/home/src/git/rust-libs/html5ever/html5ever)
   Compiling markup5ever_rcdom v0.2.0 (/boot/home/src/git/rust-libs/html5ever/rcdom)
    Finished dev [unoptimized + debuginfo] target(s) in 2m 00s

```