### PR TITLE
Update actions/checkout in GitHub Actions to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version: [1.56.0, stable, beta, nightly]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set toolchain
         run: |


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflow to its newest version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

As far as I can tell this should all be backwards compatible, so I do not expect any breakage.