### PR TITLE
Remove needless borrows

### DIFF
--- a/markup5ever/util/buffer_queue.rs
+++ b/markup5ever/util/buffer_queue.rs
@@ -93,10 +93,7 @@ impl BufferQueue {
     /// Look at the next available character without removing it, if the queue is not empty.
     pub fn peek(&self) -> Option<char> {
         debug_assert!(
-            self.buffers
-                .iter()
-                .find(|el| el.len32() == 0)
-                .is_none(),
+            self.buffers.iter().find(|el| el.len32() == 0).is_none(),
             "invariant \"all buffers in the queue are non-empty\" failed"
         );
         self.buffers.front().map(|b| b.chars().next().unwrap())
@@ -152,7 +149,7 @@ impl BufferQueue {
         let (result, now_empty) = match self.buffers.front_mut() {
             None => (None, false),
             Some(buf) => {
-                let n = set.nonmember_prefix_len(&buf);
+                let n = set.nonmember_prefix_len(buf);
                 if n > 0 {
                     let out;
                     unsafe {

--- a/rcdom/lib.rs
+++ b/rcdom/lib.rs
@@ -131,7 +131,11 @@ impl Drop for Node {
         while let Some(node) = nodes.pop() {
             let children = mem::replace(&mut *node.children.borrow_mut(), vec![]);
             nodes.extend(children.into_iter());
-            if let NodeData::Element { ref template_contents, .. } = node.data {
+            if let NodeData::Element {
+                ref template_contents,
+                ..
+            } = node.data
+            {
                 if let Some(template_contents) = template_contents.borrow_mut().take() {
                     nodes.push(template_contents);
                 }
@@ -173,7 +177,7 @@ fn get_parent_and_index(target: &Handle) -> Option<(Handle, usize)> {
             .borrow()
             .iter()
             .enumerate()
-            .find(|&(_, child)| Rc::ptr_eq(&child, &target))
+            .find(|&(_, child)| Rc::ptr_eq(child, target))
         {
             Some((i, _)) => i,
             None => panic!("have parent but couldn't find in parent's children!"),
@@ -235,7 +239,11 @@ impl TreeSink for RcDom {
             ..
         } = target.data
         {
-            template_contents.borrow().as_ref().expect("not a template element!").clone()
+            template_contents
+                .borrow()
+                .as_ref()
+                .expect("not a template element!")
+                .clone()
         } else {
             panic!("not a template element!")
         }
@@ -290,7 +298,7 @@ impl TreeSink for RcDom {
         match child {
             NodeOrText::AppendText(ref text) => match parent.children.borrow().last() {
                 Some(h) => {
-                    if append_to_existing_text(h, &text) {
+                    if append_to_existing_text(h, text) {
                         return;
                     }
                 },
@@ -300,7 +308,7 @@ impl TreeSink for RcDom {
         }
 
         append(
-            &parent,
+            parent,
             match child {
                 NodeOrText::AppendText(text) => Node::new(NodeData::Text {
                     contents: RefCell::new(text),
@@ -311,7 +319,7 @@ impl TreeSink for RcDom {
     }
 
     fn append_before_sibling(&mut self, sibling: &Handle, child: NodeOrText<Handle>) {
-        let (parent, i) = get_parent_and_index(&sibling)
+        let (parent, i) = get_parent_and_index(sibling)
             .expect("append_before_sibling called on node without parent");
 
         let child = match (child, i) {
@@ -397,16 +405,16 @@ impl TreeSink for RcDom {
     }
 
     fn remove_from_parent(&mut self, target: &Handle) {
-        remove_from_parent(&target);
+        remove_from_parent(target);
     }
 
     fn reparent_children(&mut self, node: &Handle, new_parent: &Handle) {
         let mut children = node.children.borrow_mut();
         let mut new_children = new_parent.children.borrow_mut();
         for child in children.iter() {
-            let previous_parent = child.parent.replace(Some(Rc::downgrade(&new_parent)));
+            let previous_parent = child.parent.replace(Some(Rc::downgrade(new_parent)));
             assert!(Rc::ptr_eq(
-                &node,
+                node,
                 &previous_parent.unwrap().upgrade().expect("dangling weak")
             ))
         }
@@ -457,12 +465,13 @@ impl Serialize for SerializableHandle {
         let mut ops = VecDeque::new();
         match traversal_scope {
             IncludeNode => ops.push_back(SerializeOp::Open(self.0.clone())),
-            ChildrenOnly(_) => ops.extend(self
-                .0
-                .children
-                .borrow()
-                .iter()
-                .map(|h| SerializeOp::Open(h.clone())))
+            ChildrenOnly(_) => ops.extend(
+                self.0
+                    .children
+                    .borrow()
+                    .iter()
+                    .map(|h| SerializeOp::Open(h.clone())),
+            ),
         }
 
         while let Some(op) = ops.pop_front() {
@@ -486,13 +495,11 @@ impl Serialize for SerializableHandle {
                         }
                     },
 
-                    NodeData::Doctype { ref name, .. } => serializer.write_doctype(&name)?,
+                    NodeData::Doctype { ref name, .. } => serializer.write_doctype(name)?,
 
-                    NodeData::Text { ref contents } => {
-                        serializer.write_text(&contents.borrow())?
-                    },
+                    NodeData::Text { ref contents } => serializer.write_text(&contents.borrow())?,
 
-                    NodeData::Comment { ref contents } => serializer.write_comment(&contents)?,
+                    NodeData::Comment { ref contents } => serializer.write_comment(contents)?,
 
                     NodeData::ProcessingInstruction {
                         ref target,

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -89,7 +89,7 @@ fn write_to_buf_escaped<W: Write>(writer: &mut W, text: &str, attr_mode: bool) -
 #[inline]
 fn write_qual_name<W: Write>(writer: &mut W, name: &QualName) -> io::Result<()> {
     if let Some(ref prefix) = name.prefix {
-        writer.write_all(&prefix.as_bytes())?;
+        writer.write_all(prefix.as_bytes())?;
         writer.write_all(b":")?;
         writer.write_all(&*name.local.as_bytes())?;
     } else {
@@ -158,7 +158,7 @@ impl<Wr: Write> Serializer for XmlSerializer<Wr> {
                 self.writer.write_all(b" xmlns")?;
                 if let Some(ref p) = *prefix {
                     self.writer.write_all(b":")?;
-                    self.writer.write_all(&*p.as_bytes())?;
+                    self.writer.write_all(p.as_bytes())?;
                 }
 
                 self.writer.write_all(b"=\"")?;
@@ -173,7 +173,7 @@ impl<Wr: Write> Serializer for XmlSerializer<Wr> {
         }
         for (name, value) in attrs {
             self.writer.write_all(b" ")?;
-            self.qual_attr_name(&name)?;
+            self.qual_attr_name(name)?;
             self.writer.write_all(b"=\"")?;
             write_to_buf_escaped(&mut self.writer, value, true)?;
             self.writer.write_all(b"\"")?;

--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -61,16 +61,16 @@ fn process_qname(tag_name: StrTendril) -> QualName {
     //     a:b
     // Since StrTendril are UTF-8, we know that minimal size in bytes must be
     // three bytes minimum.
-    let split = if (&*tag_name).as_bytes().len() < 3 {
+    let split = if (*tag_name).as_bytes().len() < 3 {
         None
     } else {
-        QualNameTokenizer::new((&*tag_name).as_bytes()).run()
+        QualNameTokenizer::new((*tag_name).as_bytes()).run()
     };
 
     match split {
         None => QualName::new(None, ns!(), LocalName::from(&*tag_name)),
         Some(col) => {
-            let len = (&*tag_name).as_bytes().len() as u32;
+            let len = (*tag_name).as_bytes().len() as u32;
             let prefix = tag_name.subtendril(0, col);
             let local = tag_name.subtendril(col + 1, len - col - 1);
             let ns = ns!(); // Actual namespace URL set in XmlTreeBuilder::bind_qname
@@ -248,8 +248,8 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
         }
 
         // Exclude forbidden Unicode characters
-        if self.opts.exact_errors &&
-            match c as u32 {
+        if self.opts.exact_errors
+            && match c as u32 {
                 0x01..=0x08 | 0x0B | 0x0E..=0x1F | 0x7F..=0x9F | 0xFDD0..=0xFDEF => true,
                 n if (n & 0xFFFE) == 0xFFFE => true,
                 _ => false,
@@ -1141,11 +1141,11 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
             },
             XmlState::CommentLessThanBangDash => go!(self: reconsume CommentEndDash),
             XmlState::CommentLessThanBangDashDash => go!(self: reconsume CommentEnd),
-            XmlState::CommentStartDash |
-            XmlState::Comment |
-            XmlState::CommentEndDash |
-            XmlState::CommentEnd |
-            XmlState::CommentEndBang => go!(self: error_eof; emit_comment; eof),
+            XmlState::CommentStartDash
+            | XmlState::Comment
+            | XmlState::CommentEndDash
+            | XmlState::CommentEnd
+            | XmlState::CommentEndBang => go!(self: error_eof; emit_comment; eof),
             XmlState::TagState => go!(self: error_eof; emit '<'; to Data),
             XmlState::EndTagState => go!(self: error_eof; emit '<'; emit '/'; to Data),
             XmlState::TagEmpty => go!(self: error_eof; to TagAttrNameBefore),
@@ -1155,25 +1155,25 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
             XmlState::Pi => go!(self: error_eof; to BogusComment),
             XmlState::PiTargetAfter | XmlState::PiAfter => go!(self: reconsume PiData),
             XmlState::MarkupDecl => go!(self: error_eof; to BogusComment),
-            XmlState::TagName |
-            XmlState::TagAttrNameBefore |
-            XmlState::EndTagName |
-            XmlState::TagAttrNameAfter |
-            XmlState::EndTagNameAfter |
-            XmlState::TagAttrValueBefore |
-            XmlState::TagAttrValue(_) => go!(self: error_eof; emit_tag Data),
+            XmlState::TagName
+            | XmlState::TagAttrNameBefore
+            | XmlState::EndTagName
+            | XmlState::TagAttrNameAfter
+            | XmlState::EndTagNameAfter
+            | XmlState::TagAttrValueBefore
+            | XmlState::TagAttrValue(_) => go!(self: error_eof; emit_tag Data),
             XmlState::PiData | XmlState::PiTarget => go!(self: error_eof; emit_pi Data),
             XmlState::TagAttrName => go!(self: error_eof; emit_start_tag Data),
-            XmlState::BeforeDoctypeName |
-            XmlState::Doctype |
-            XmlState::DoctypeName |
-            XmlState::AfterDoctypeName |
-            XmlState::AfterDoctypeKeyword(_) |
-            XmlState::BeforeDoctypeIdentifier(_) |
-            XmlState::AfterDoctypeIdentifier(_) |
-            XmlState::DoctypeIdentifierSingleQuoted(_) |
-            XmlState::DoctypeIdentifierDoubleQuoted(_) |
-            XmlState::BetweenDoctypePublicAndSystemIdentifiers => {
+            XmlState::BeforeDoctypeName
+            | XmlState::Doctype
+            | XmlState::DoctypeName
+            | XmlState::AfterDoctypeName
+            | XmlState::AfterDoctypeKeyword(_)
+            | XmlState::BeforeDoctypeIdentifier(_)
+            | XmlState::AfterDoctypeIdentifier(_)
+            | XmlState::DoctypeIdentifierSingleQuoted(_)
+            | XmlState::DoctypeIdentifierDoubleQuoted(_)
+            | XmlState::BetweenDoctypePublicAndSystemIdentifiers => {
                 go!(self: error_eof; emit_doctype; to Data)
             },
             XmlState::BogusDoctype => go!(self: emit_doctype; to Data),
@@ -1251,8 +1251,8 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
                 value: replace(&mut self.current_attr_value, StrTendril::new()),
             };
 
-            if qname.local == local_name!("xmlns") ||
-                qname.prefix == Some(namespace_prefix!("xmlns"))
+            if qname.local == local_name!("xmlns")
+                || qname.prefix == Some(namespace_prefix!("xmlns"))
             {
                 self.current_tag_attrs.insert(0, attr);
             } else {

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -246,10 +246,10 @@ where
     pub fn trace_handles(&self, tracer: &dyn Tracer<Handle = Handle>) {
         tracer.trace_handle(&self.doc_handle);
         for e in self.open_elems.iter() {
-            tracer.trace_handle(&e);
+            tracer.trace_handle(e);
         }
         if let Some(h) = self.curr_elem.as_ref() {
-            tracer.trace_handle(&h);
+            tracer.trace_handle(h);
         }
     }
 
@@ -278,7 +278,7 @@ where
     }
 
     fn declare_ns(&mut self, attr: &mut Attribute) {
-        if let Err(msg) = self.current_namespace.insert_ns(&attr) {
+        if let Err(msg) = self.current_namespace.insert_ns(attr) {
             self.sink.parse_error(msg);
         } else {
             attr.name.ns = ns!(xmlns);
@@ -346,17 +346,17 @@ where
     fn process_namespaces(&mut self, tag: &mut Tag) {
         let mut new_attr = vec![];
         // First we extract all namespace declarations
-        for mut attr in tag.attrs.iter_mut().filter(|attr| {
-            attr.name.prefix == Some(namespace_prefix!("xmlns")) ||
-                attr.name.local == local_name!("xmlns")
+        for attr in tag.attrs.iter_mut().filter(|attr| {
+            attr.name.prefix == Some(namespace_prefix!("xmlns"))
+                || attr.name.local == local_name!("xmlns")
         }) {
-            self.declare_ns(&mut attr);
+            self.declare_ns(attr);
         }
 
         // Then we bind those namespace declarations to attributes
         for attr in tag.attrs.iter_mut().filter(|attr| {
-            attr.name.prefix != Some(namespace_prefix!("xmlns")) &&
-                attr.name.local != local_name!("xmlns")
+            attr.name.prefix != Some(namespace_prefix!("xmlns"))
+                && attr.name.local != local_name!("xmlns")
         }) {
             if self.bind_attr_qname(&mut attr.name) {
                 new_attr.push(attr.clone());


### PR DESCRIPTION
Clippy generated several warnings about how "this expression creates a reference which is immediately dereferenced by the compiler" [1]. I've removed the references since they don't do anything.

There are also some rustfmt changes that my editor automatically made.

[1] https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow