### PR TITLE
Complete Default documentation of `SerializeOpts`

### DIFF
--- a/html5ever/src/serialize/mod.rs
+++ b/html5ever/src/serialize/mod.rs
@@ -26,7 +26,7 @@ where
 
 #[derive(Clone)]
 pub struct SerializeOpts {
-    /// Is scripting enabled?
+    /// Is scripting enabled? Default: true
     pub scripting_enabled: bool,
 
     /// Serialize the root node? Default: ChildrenOnly


### PR DESCRIPTION
This adds the default value for `scripting_enabled` in the documentation.