### PR TITLE
Stop allocating string for rcdom example

### DIFF
--- a/rcdom/examples/print-rcdom.rs
+++ b/rcdom/examples/print-rcdom.rs
@@ -22,7 +22,7 @@ use rcdom::{Handle, NodeData, RcDom};
 
 fn walk(indent: usize, handle: &Handle) {
     let node = handle;
-    for _ in 0..indent{ print!(" "); }
+    for _ in 0..indent { print!(" "); }
     match node.data {
         NodeData::Document => println!("#Document"),
 

--- a/rcdom/examples/print-rcdom.rs
+++ b/rcdom/examples/print-rcdom.rs
@@ -13,8 +13,6 @@ extern crate markup5ever_rcdom as rcdom;
 
 use std::default::Default;
 use std::io;
-use std::iter::repeat;
-use std::string::String;
 
 use html5ever::parse_document;
 use html5ever::tendril::TendrilSink;
@@ -24,8 +22,7 @@ use rcdom::{Handle, NodeData, RcDom};
 
 fn walk(indent: usize, handle: &Handle) {
     let node = handle;
-    // FIXME: don't allocate
-    print!("{}", repeat(" ").take(indent).collect::<String>());
+    for _ in 0..indent{ print!(" "); }
     match node.data {
         NodeData::Document => println!("#Document"),
 


### PR DESCRIPTION
As a Rust noob, I _think_ this is the simplest way to stop string allocations for the indentation, but I'd love to know if there is a better way to do this. I believe `.collect::<String>()` in the old code was causing a String allocation, and I think a simplified version that I almost went with (`print!("{}", " ".repeat(indent));`) would [do the same thing](https://doc.rust-lang.org/std/primitive.str.html#method.repeat), so I think this PR should be sufficient.

/cc @jdm 