### PR TITLE
Add comments for html5ever/examples

### DIFF
--- a/html5ever/examples/arena.rs
+++ b/html5ever/examples/arena.rs
@@ -19,36 +19,35 @@ use std::collections::HashSet;
 use std::io::{self, Read};
 use std::ptr;
 
-fn main() {
-    let mut bytes = Vec::new();
-    io::stdin().read_to_end(&mut bytes).unwrap();
-    let arena = typed_arena::Arena::new();
-    html5ever_parse_slice_into_arena(&bytes, &arena);
-}
-
+/// By using our Sink type, we fill the arena with the parsed HTML.
 fn html5ever_parse_slice_into_arena<'a>(bytes: &[u8], arena: Arena<'a>) -> Ref<'a> {
+    // Create a sink object
     let sink = Sink {
         arena: arena,
         document: arena.alloc(Node::new(NodeData::Document)),
         quirks_mode: QuirksMode::NoQuirks,
     };
+
+    // Parse the input document into the arena (by using the sink)
     parse_document(sink, Default::default())
         .from_utf8()
         .one(bytes)
 }
 
+// Helper types
 type Arena<'arena> = &'arena typed_arena::Arena<Node<'arena>>;
-
 type Ref<'arena> = &'arena Node<'arena>;
-
 type Link<'arena> = Cell<Option<Ref<'arena>>>;
 
+/// Sink struct is responsible for handling how the data that comes out of the HTML parsing
+/// unit (TreeBuilder in our case) is handled.
 struct Sink<'arena> {
     arena: Arena<'arena>,
     document: Ref<'arena>,
     quirks_mode: QuirksMode,
 }
 
+/// Dom node which will be stored in the arena.
 pub struct Node<'arena> {
     parent: Link<'arena>,
     next_sibling: Link<'arena>,
@@ -58,6 +57,7 @@ pub struct Node<'arena> {
     data: NodeData<'arena>,
 }
 
+/// HTML node data which can be an element, a comment, a string, a DOCTYPE, etc...
 pub enum NodeData<'arena> {
     Document,
     Doctype {
@@ -95,6 +95,7 @@ impl<'arena> Node<'arena> {
         }
     }
 
+    /// Detach the current node from the tree.
     fn detach(&self) {
         let parent = self.parent.take();
         let previous_sibling = self.previous_sibling.take();
@@ -113,6 +114,7 @@ impl<'arena> Node<'arena> {
         }
     }
 
+    /// Add a new node as a child to the current node
     fn append(&'arena self, new_child: &'arena Self) {
         new_child.detach();
         new_child.parent.set(Some(self));
@@ -127,6 +129,7 @@ impl<'arena> Node<'arena> {
         self.last_child.set(Some(new_child));
     }
 
+    /// Insert a node as a sibling before the current node.
     fn insert_before(&'arena self, new_sibling: &'arena Self) {
         new_sibling.detach();
         new_sibling.parent.set(self.parent.get());
@@ -147,10 +150,12 @@ impl<'arena> Node<'arena> {
 }
 
 impl<'arena> Sink<'arena> {
+    /// Allocate a new node in the arena
     fn new_node(&self, data: NodeData<'arena>) -> Ref<'arena> {
         self.arena.alloc(Node::new(data))
     }
 
+    /// Append a new node (or text) to the DOM
     fn append_common<P, A>(&self, child: NodeOrText<Ref<'arena>>, previous: P, append: A)
     where
         P: FnOnce() -> Option<Ref<'arena>>,
@@ -178,6 +183,11 @@ impl<'arena> Sink<'arena> {
     }
 }
 
+/// By implementing the TreeSink trait we determine how the data from the tree building step
+/// is processed. In our case, our data is allocated in the arena and added to the Node data
+/// structure.
+///
+/// For deeper understating of each function go to the TreeSink declaration.
 impl<'arena> TreeSink for Sink<'arena> {
     type Handle = Ref<'arena>;
     type Output = Ref<'arena>;
@@ -332,4 +342,22 @@ impl<'arena> TreeSink for Sink<'arena> {
             new_parent.append(child)
         }
     }
+}
+
+/// In this example an "arena" is created and filled with the DOM nodes.
+/// "Arena" is a type of allocation in which a block of memory is allocated
+/// and later filled with data, DOM nodes in this case. When the arena is deallocated
+/// it is destroyed with all of its items.
+///
+/// Further info about arena: https://docs.rs/typed-arena/latest/typed_arena/
+fn main() {
+    // Read HTML from the standard input
+    let mut bytes = Vec::new();
+    io::stdin().read_to_end(&mut bytes).unwrap();
+
+    // Create a new arena
+    let arena = typed_arena::Arena::new();
+
+    // Fill the arena with nodes
+    html5ever_parse_slice_into_arena(&bytes, &arena);
 }

--- a/html5ever/examples/noop-tokenize.rs
+++ b/html5ever/examples/noop-tokenize.rs
@@ -17,25 +17,37 @@ use std::io;
 use html5ever::tendril::*;
 use html5ever::tokenizer::{BufferQueue, Token, TokenSink, TokenSinkResult, Tokenizer};
 
+
+/// In our case, our sink only contains a tokens vector
 struct Sink(Vec<Token>);
 
 impl TokenSink for Sink {
     type Handle = ();
 
+    /// Each processed token will be handled by this method
     fn process_token(&mut self, token: Token, _line_number: u64) -> TokenSinkResult<()> {
-        // Don't use the token, but make sure we don't get
-        // optimized out entirely.
+        // Push the token into a vector, in order to make sure we are not
+        // optimized entirely.
         self.0.push(token);
+
+
+        // Continue to the next token
         TokenSinkResult::Continue
     }
 }
 
+/// In this example we implement the TokenSink trait which lets us implement how each
+/// parsed token is treated. In our example we take each token and insert it into a vector.
 fn main() {
+    // Read HTML from standard input
     let mut chunk = ByteTendril::new();
     io::stdin().read_to_tendril(&mut chunk).unwrap();
+
+    // Create a buffer queue for the tokenizer
     let mut input = BufferQueue::new();
     input.push_back(chunk.try_reinterpret().unwrap());
 
+    // Run the tokenizer using our sink
     let mut tok = Tokenizer::new(Sink(Vec::new()), Default::default());
     let _ = tok.feed(&mut input);
     assert!(input.is_empty());

--- a/html5ever/examples/noop-tree-builder.rs
+++ b/html5ever/examples/noop-tree-builder.rs
@@ -26,6 +26,7 @@ struct Sink {
 }
 
 impl Sink {
+    /// Generate a unique id for
     fn get_id(&mut self) -> usize {
         let id = self.next_id;
         self.next_id += 2;
@@ -33,6 +34,10 @@ impl Sink {
     }
 }
 
+/// By implementing the TreeSink trait we determine how the data from the tree building step
+/// is processed. In this case the DOM elements are written into the "names" hashmap.
+///
+/// For deeper understating of each function go to the TreeSink declaration.
 impl TreeSink for Sink {
     type Handle = usize;
     type Output = Self;
@@ -99,11 +104,16 @@ impl TreeSink for Sink {
     fn mark_script_already_started(&mut self, _node: &usize) {}
 }
 
+/// In this example we implement the TreeSink trait which takes each parsed elements and insert
+/// it to a hashmap, while each element is given a numeric id.
 fn main() {
+    // Create a sink object with first id of 1
     let sink = Sink {
         next_id: 1,
         names: HashMap::new(),
     };
+
+    // Read HTML from the standard input and parse it
     let stdin = io::stdin();
     parse_document(sink, Default::default())
         .from_utf8()

--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -159,6 +159,9 @@ impl TreeSink for Sink {
     }
 }
 
+/// Same example as the "noop-tree-builder", but this time every function implemented in our
+/// Sink object prints a log, so it's easier to get an understating of when each function is
+/// called.
 fn main() {
     let sink = Sink {
         next_id: 1,

--- a/html5ever/examples/tokenize.rs
+++ b/html5ever/examples/tokenize.rs
@@ -82,13 +82,19 @@ impl TokenSink for TokenPrinter {
     }
 }
 
+/// In this example we implement the TokenSink trait in such a way that each token is printed.
+/// If a there's an error while processing a token it is printed as well.
 fn main() {
+    // Read HTML from standard input
     let mut sink = TokenPrinter { in_char_run: false };
     let mut chunk = ByteTendril::new();
     io::stdin().read_to_tendril(&mut chunk).unwrap();
+
+    // Create a buffer queue for the tokenizer
     let mut input = BufferQueue::new();
     input.push_back(chunk.try_reinterpret().unwrap());
 
+    // Parse the tokens while using our TokenPrinter as sink
     let mut tok = Tokenizer::new(
         sink,
         TokenizerOpts {
@@ -97,6 +103,8 @@ fn main() {
         },
     );
     let _ = tok.feed(&mut input);
+
+    // Input buffer should be empty because the tokenizer has finished reading it
     assert!(input.is_empty());
     tok.end();
     sink.is_char(false);


### PR DESCRIPTION
My first PR here :)

I decided I wanted to contribute to this cool project, and when I started learning about it, I headed over to the examples directory, and it was quite hard for me to understand what I was reading because it lacked some comments.

Someone already opened [an issue](https://github.com/servo/html5ever/issues/451) about it.


**Changes**
- Add comments to the main function in each example with a short description of what the code does.
- Added comments for structs and traits implemented in the examples.
- Move the main function in `arena.rs` example to the end of the file (to match the other examples)