### PR TITLE
Fix parsing of bogus comments after end tags

### DIFF
--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -862,8 +862,8 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
                 let c = get_char!(self, input);
                 if self.have_appropriate_end_tag() {
                     match c {
-                        '\t' | '\n' | '\x0C' | ' ' => go!(self: to BeforeAttributeName),
-                        '/' => go!(self: to SelfClosingStartTag),
+                        '\t' | '\n' | '\x0C' | ' ' => go!(self: clear_temp; to BeforeAttributeName),
+                        '/' => go!(self: clear_temp; to SelfClosingStartTag),
                         '>' => go!(self: clear_temp; emit_tag Data),
                         _ => (),
                     }

--- a/rcdom/custom-html5lib-tokenizer-tests/regression.test
+++ b/rcdom/custom-html5lib-tokenizer-tests/regression.test
@@ -39,6 +39,31 @@
 {"description": "Windows newline after bogusname",
 "input": "&0\r\n",
 "output": [["Character", "&0\n"]],
-"errors": []}
+"errors": []},
+
+{"description": "Bogus comment after end tag with space",
+"initialStates": ["Data state", "RCDATA state", "RAWTEXT state", "Script data state"],
+"lastStartTag": "style",
+"input": "</style ><!a>",
+"output": [
+    ["EndTag", "style"],
+    ["Comment", "a"]
+],
+"errors": [
+    {"code": "incorrectly-opened-comment"}
+]},
+
+{"description": "Bogus comment after end tag with solidus",
+"initialStates": ["Data state", "RCDATA state", "RAWTEXT state", "Script data state"],
+"lastStartTag": "style",
+"input": "</style/><!a>",
+"output": [
+    ["EndTag", "style"],
+    ["Comment", "a"]
+],
+"errors": [
+    {"code": "unexpected-solidus-in-tag"},
+    {"code": "incorrectly-opened-comment"}
+]}
 
 ]}


### PR DESCRIPTION
This fixes a bug in the tokenizer where the tag name was included in a bogus comment after an appropriate end tag.

For example, this:
```html
<style></style ><!a>
```
is incorrectly parsed as the following:
```html
<style></style><!--stylea-->
```
instead of the expected:
```html
<style></style><!--a-->
```
For this bug to trigger, the end tag needs to be parsed in one of the raw text states (RCDATA, RAWTEXT, or Script data) and have whitespace or a slash after the tag name. I don't know how the contents of the temporary buffer end up inside the comment, but clearing the temporary buffer when exiting the `RawEndTagName` state seems to be enough to fix it.