### PR TITLE
Remove redundant FIXME comment

### DIFF
--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -508,7 +508,6 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
         // Check for a duplicate attribute.
         // FIXME: the spec says we should error as soon as the name is finished.
-        // FIXME: linear time search, do we care?
         let dup = {
             let name = &*self.current_attr_name;
             self.current_tag_attrs

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -27,7 +27,7 @@ use log::{debug, trace};
 use mac::format_if;
 use markup5ever::{namespace_url, ns, small_char_set};
 use std::borrow::Cow::{self, Borrowed};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::default::Default;
 use std::mem::replace;
 
@@ -143,9 +143,6 @@ pub struct Tokenizer<Sink> {
     /// Current tag attributes.
     current_tag_attrs: Vec<Attribute>,
 
-    /// Current tag names hashset
-    current_tag_attrs_names: HashSet<StrTendril>,
-
     /// Current attribute name.
     current_attr_name: StrTendril,
 
@@ -197,7 +194,6 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             current_tag_name: StrTendril::new(),
             current_tag_self_closing: false,
             current_tag_attrs: vec![],
-            current_tag_attrs_names: HashSet::new(),
             current_attr_name: StrTendril::new(),
             current_attr_value: StrTendril::new(),
             current_comment: StrTendril::new(),
@@ -484,7 +480,6 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         self.current_tag_name.clear();
         self.current_tag_self_closing = false;
         self.current_tag_attrs = vec![];
-        self.current_tag_attrs_names.clear();
     }
 
     fn create_tag(&mut self, kind: TagKind, c: char) {
@@ -514,7 +509,12 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         // Check for a duplicate attribute.
         // FIXME: the spec says we should error as soon as the name is finished.
         // FIXME: linear time search, do we care?
-        let dup = self.current_tag_attrs_names.contains(&self.current_attr_name);
+        let dup = {
+            let name = &*self.current_attr_name;
+            self.current_tag_attrs
+                .iter()
+                .any(|a| &*a.name.local == name)
+        };
 
         if dup {
             self.emit_error(Borrowed("Duplicate attribute"));
@@ -522,7 +522,6 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             self.current_attr_value.clear();
         } else {
             let name = LocalName::from(&*self.current_attr_name);
-            self.current_tag_attrs_names.insert(self.current_attr_name.clone());
             self.current_attr_name.clear();
             self.current_tag_attrs.push(Attribute {
                 // The tree builder will adjust the namespace if necessary.


### PR DESCRIPTION
## Background
While searching for potential points in the code to which I could contribute I came across this FIXME comment 
which seemed like an easy-win:

```rust
        // FIXME: linear time search, do we care?
```
(line 511 in `html5ever/src/tokenizer/mod.rs`)

## Fix attempt
I Tries using a HashSet for the attributes names so the search's complexity would be O(1) instead of O(n), as 
can be seen in [this commit](https://github.com/servo/html5ever/commit/df17e5b87ce43f5a3206bf21c4b21ed78276874e)

and once I ran some benchmarks on multiple websites (by [modifying the noop-tokenizer example](https://hatebin.com/bndkyirfnm)) I realized I only made things worst, the Parsing process took a tiny bit longer than before. This is probably because of the overhead within maintaining a HashSet of the attributes names, and because most elements do not have enough attributes for the HashSet to improve performance.

## Conclusion
I think it's a good Idea to remove this comment so no one else will try to optimize this section for no reason.



