### PR TITLE
html5ever: prepare 0.26.1 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [1.60.0, stable, beta, nightly]
+        version: [stable, beta, nightly]
     steps:
       - uses: actions/checkout@v3
 
@@ -43,6 +43,19 @@ jobs:
       - name: Cargo doc
         if: matrix.version == 'nightly'
         run: cargo doc
+
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        run: |
+          rustup set profile minimal
+          rustup override set 1.60.0
+
+      - run: cargo check --lib --all-features
 
   build_result:
     name: Result

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "html5ever"
-version = "0.26.0"
+version = "0.27.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.11", path = "../markup5ever" }
+markup5ever = { version = "0.12", path = "../markup5ever" }
 
 [dev-dependencies]
 typed-arena = "2.0.2"

--- a/html5ever/src/lib.rs
+++ b/html5ever/src/lib.rs
@@ -11,6 +11,7 @@
 #![crate_type = "dylib"]
 #![cfg_attr(test, deny(warnings))]
 #![allow(unused_parens)]
+#![warn(unreachable_pub)]
 
 pub use driver::{parse_document, parse_fragment, ParseOpts, Parser};
 pub use markup5ever::*;
@@ -21,7 +22,7 @@ pub use serialize::serialize;
 mod macros;
 
 mod util {
-    pub mod str;
+    pub(crate) mod str;
 }
 
 pub mod driver;

--- a/html5ever/src/tokenizer/char_ref/mod.rs
+++ b/html5ever/src/tokenizer/char_ref/mod.rs
@@ -18,18 +18,18 @@ use std::borrow::Cow::Borrowed;
 use std::char::from_u32;
 
 use self::State::*;
-pub use self::Status::*;
+pub(super) use self::Status::*;
 
 //§ tokenizing-character-references
-pub struct CharRef {
+pub(super) struct CharRef {
     /// The resulting character(s)
-    pub chars: [char; 2],
+    pub(super) chars: [char; 2],
 
     /// How many slots in `chars` are valid?
-    pub num_chars: u8,
+    pub(super) num_chars: u8,
 }
 
-pub enum Status {
+pub(super) enum Status {
     Stuck,
     Progress,
     Done,
@@ -45,7 +45,7 @@ enum State {
     BogusName,
 }
 
-pub struct CharRefTokenizer {
+pub(super) struct CharRefTokenizer {
     state: State,
     result: Option<CharRef>,
     is_consumed_in_attribute: bool,
@@ -61,7 +61,7 @@ pub struct CharRefTokenizer {
 }
 
 impl CharRefTokenizer {
-    pub fn new(is_consumed_in_attribute: bool) -> CharRefTokenizer {
+    pub(super) fn new(is_consumed_in_attribute: bool) -> CharRefTokenizer {
         CharRefTokenizer {
             is_consumed_in_attribute,
             state: Begin,
@@ -78,7 +78,7 @@ impl CharRefTokenizer {
 
     // A CharRefTokenizer can only tokenize one character reference,
     // so this method consumes the tokenizer.
-    pub fn get_result(self) -> CharRef {
+    pub(super) fn get_result(self) -> CharRef {
         self.result.expect("get_result called before done")
     }
 
@@ -112,7 +112,7 @@ impl CharRefTokenizer {
 }
 
 impl CharRefTokenizer {
-    pub fn step<Sink: TokenSink>(
+    pub(super) fn step<Sink: TokenSink>(
         &mut self,
         tokenizer: &mut Tokenizer<Sink>,
         input: &mut BufferQueue,
@@ -411,7 +411,7 @@ impl CharRefTokenizer {
         self.finish_none()
     }
 
-    pub fn end_of_file<Sink: TokenSink>(
+    pub(super) fn end_of_file<Sink: TokenSink>(
         &mut self,
         tokenizer: &mut Tokenizer<Sink>,
         input: &mut BufferQueue,

--- a/html5ever/src/util/str.rs
+++ b/html5ever/src/util/str.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-pub fn to_escaped_string<T: fmt::Debug>(x: &T) -> String {
+pub(crate) fn to_escaped_string<T: fmt::Debug>(x: &T) -> String {
     // FIXME: don't allocate twice
     let string = format!("{:?}", x);
     string.chars().flat_map(|c| c.escape_default()).collect()
@@ -17,7 +17,7 @@ pub fn to_escaped_string<T: fmt::Debug>(x: &T) -> String {
 
 /// If `c` is an ASCII letter, return the corresponding lowercase
 /// letter, otherwise None.
-pub fn lower_ascii_letter(c: char) -> Option<char> {
+pub(crate) fn lower_ascii_letter(c: char) -> Option<char> {
     match c {
         'a'..='z' => Some(c),
         'A'..='Z' => Some((c as u8 - b'A' + b'a') as char),

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.11.0"
+version = "0.12.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever_rcdom"
-version = "0.2.0"
+version = "0.3.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -16,9 +16,9 @@ path = "lib.rs"
 
 [dependencies]
 tendril = "0.4"
-html5ever = { version = "0.26", path = "../html5ever" }
-markup5ever = { version = "0.11", path = "../markup5ever" }
-xml5ever = { version = "0.17", path = "../xml5ever" }
+html5ever = { version = "0.27", path = "../html5ever" }
+markup5ever = { version = "0.12", path = "../markup5ever" }
+xml5ever = { version = "0.18", path = "../xml5ever" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "xml5ever"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["The xml5ever project developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -18,7 +18,7 @@ edition = "2021"
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = {version = "0.11", path = "../markup5ever" }
+markup5ever = {version = "0.12", path = "../markup5ever" }
 
 [dev-dependencies]
 rustc-test = "0.3"


### PR DESCRIPTION
Not completely sure if changes from #460 should be considered semver-incompatible? It looks like they add new states but then also the `states` module has these comments:

```
//! This is public for use by the tokenizer tests.  Other library
//! users should not have to care about this.
```

So maybe it doesn't matter?

As far as I can tell other changes are not semver-incompatible.