### PR TITLE
Make criterion a regular dev-dependency

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -17,10 +17,8 @@ mac = "0.1"
 markup5ever = { version = "0.12", path = "../markup5ever" }
 
 [dev-dependencies]
-typed-arena = "2.0.2"
-
-[target.'cfg(bench)'.dev-dependencies]
 criterion = "0.3"
+typed-arena = "2.0.2"
 
 [build-dependencies]
 quote = "1"

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -21,10 +21,8 @@ mac = "0.1"
 markup5ever = {version = "0.12", path = "../markup5ever" }
 
 [dev-dependencies]
-rustc-test = "0.3"
-
-[target.'cfg(bench)'.dev-dependencies]
 criterion = "0.3"
+rustc-test = "0.3"
 
 [[bench]]
 name = "xml5ever"


### PR DESCRIPTION
This avoids compilation failing for the benchmark targets.