### PR TITLE
Remove more unnecessary imports

### DIFF
--- a/html5ever/examples/noop-tokenize.rs
+++ b/html5ever/examples/noop-tokenize.rs
@@ -11,7 +11,6 @@
 
 extern crate html5ever;
 
-use std::default::Default;
 use std::io;
 
 use html5ever::tendril::*;

--- a/html5ever/examples/noop-tree-builder.rs
+++ b/html5ever/examples/noop-tree-builder.rs
@@ -12,7 +12,6 @@ extern crate html5ever;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::default::Default;
 use std::io;
 
 use html5ever::parse_document;

--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -12,7 +12,6 @@ extern crate html5ever;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::default::Default;
 use std::io;
 
 use html5ever::parse_document;

--- a/html5ever/examples/tokenize.rs
+++ b/html5ever/examples/tokenize.rs
@@ -9,7 +9,6 @@
 
 extern crate html5ever;
 
-use std::default::Default;
 use std::io;
 
 use html5ever::tendril::*;

--- a/html5ever/src/serialize/mod.rs
+++ b/html5ever/src/serialize/mod.rs
@@ -10,7 +10,6 @@
 use log::warn;
 pub use markup5ever::serialize::{AttrRef, Serialize, Serializer, TraversalScope};
 use markup5ever::{local_name, namespace_url, ns};
-use std::default::Default;
 use std::io::{self, Write};
 
 use crate::{LocalName, QualName};

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -26,7 +26,6 @@ use crate::tokenizer::{Doctype, EndTag, StartTag, Tag, TokenSink, TokenSinkResul
 
 use std::borrow::Cow::Borrowed;
 use std::collections::VecDeque;
-use std::default::Default;
 use std::iter::{Enumerate, Rev};
 use std::mem::replace;
 use std::{fmt, slice};

--- a/rcdom/examples/hello_xml.rs
+++ b/rcdom/examples/hello_xml.rs
@@ -11,8 +11,6 @@
 extern crate markup5ever_rcdom as rcdom;
 extern crate xml5ever;
 
-use std::default::Default;
-
 use rcdom::{NodeData, RcDom};
 use xml5ever::driver::parse_document;
 use xml5ever::tendril::TendrilSink;

--- a/rcdom/examples/html2html.rs
+++ b/rcdom/examples/html2html.rs
@@ -18,7 +18,6 @@
 extern crate html5ever;
 extern crate markup5ever_rcdom as rcdom;
 
-use std::default::Default;
 use std::io::{self, Write};
 
 use html5ever::driver::ParseOpts;

--- a/rcdom/examples/print-rcdom.rs
+++ b/rcdom/examples/print-rcdom.rs
@@ -11,7 +11,6 @@
 extern crate html5ever;
 extern crate markup5ever_rcdom as rcdom;
 
-use std::default::Default;
 use std::io;
 
 use html5ever::parse_document;

--- a/rcdom/examples/xml_tree_printer.rs
+++ b/rcdom/examples/xml_tree_printer.rs
@@ -11,9 +11,7 @@
 extern crate markup5ever_rcdom as rcdom;
 extern crate xml5ever;
 
-use std::default::Default;
 use std::io;
-use std::string::String;
 
 use rcdom::{Handle, NodeData, RcDom};
 use xml5ever::driver::parse_document;

--- a/rcdom/lib.rs
+++ b/rcdom/lib.rs
@@ -42,7 +42,6 @@ extern crate tendril;
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashSet, VecDeque};
-use std::default::Default;
 use std::fmt;
 use std::io;
 use std::mem;

--- a/rcdom/tests/html-tokenizer.rs
+++ b/rcdom/tests/html-tokenizer.rs
@@ -21,7 +21,6 @@ use html5ever::{namespace_url, ns, Attribute, LocalName, QualName};
 use rustc_test::{DynTestFn, DynTestName, TestDesc, TestDescAndFn};
 use serde_json::{Map, Value};
 use std::borrow::Cow;
-use std::default::Default;
 use std::ffi::OsStr;
 use std::io::Read;
 use std::fs::File;

--- a/rcdom/tests/html-tree-builder.rs
+++ b/rcdom/tests/html-tree-builder.rs
@@ -16,7 +16,6 @@ mod foreach_html5lib_test;
 use foreach_html5lib_test::foreach_html5lib_test;
 
 use std::collections::{HashMap, HashSet};
-use std::default::Default;
 use std::ffi::OsStr;
 use std::io::BufRead;
 use std::iter::repeat;


### PR DESCRIPTION
Not completely sure why I missed these [the last time around](https://github.com/servo/html5ever/pull/517), probably because they're in examples?