### PR TITLE
docs: Fix bare URL in rustdoc

### DIFF
--- a/html5ever/src/tokenizer/interface.rs
+++ b/html5ever/src/tokenizer/interface.rs
@@ -92,7 +92,7 @@ pub trait TokenSink {
     /// Used in the markup declaration open state. By default, this always
     /// returns false and thus all CDATA sections are tokenized as bogus
     /// comments.
-    /// https://html.spec.whatwg.org/multipage/#markup-declaration-open-state
+    /// <https://html.spec.whatwg.org/multipage/#markup-declaration-open-state>
     fn adjusted_current_node_present_but_not_in_html_namespace(&self) -> bool {
         false
     }


### PR DESCRIPTION
Bare URLs are not automatically turned into clickable links.