### PR TITLE
Remove unnecessary version check from the benchmark build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
         run: git submodule update --init
 
       - name: Cargo bench
-        if: matrix.version != '1.41.0'
         run: cargo bench --all
         env:
           RUSTFLAGS: --cfg bench


### PR DESCRIPTION
The check is from the time when the MSRV was included in the build matrix.