### PR TITLE
Remove rustc-test dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,11 +30,6 @@ jobs:
         env:
           RUSTFLAGS: --cfg bench
 
-      - name: Test "rustc-test/capture" feature
-        if: matrix.version == 'nightly'
-        working-directory: rcdom
-        run: cargo test --features "rustc-test/capture"
-
       - name: Cargo test
         if: matrix.version != 'nightly'
         run: cargo test --all

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -22,7 +22,6 @@ xml5ever = { version = "0.18", path = "../xml5ever" }
 
 [dev-dependencies]
 serde_json = "1.0"
-rustc-test = "0.3"
 
 [[test]]
 name = "html-tokenizer"

--- a/rcdom/tests/util/runner.rs
+++ b/rcdom/tests/util/runner.rs
@@ -1,0 +1,32 @@
+// Copyright 2024 The html5ever Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Simple container for storing tests for later execution
+pub struct Test {
+    pub name: String,
+    pub skip: bool,
+    pub test: Box<dyn Fn()>,
+}
+
+impl Test {
+    /// Invoke the stored test function
+    ///
+    /// A status message is printed if the wrapped closure completes
+    /// or is marked as skipped. The test should panic to report
+    /// failure.
+    pub fn run(&self) {
+        print!("test {} ...", self.name);
+        if self.skip {
+            println!(" SKIPPED");
+        } else {
+            (self.test)();
+            println!(" ok");
+        }
+    }
+}

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -22,7 +22,6 @@ markup5ever = {version = "0.12", path = "../markup5ever" }
 
 [dev-dependencies]
 criterion = "0.3"
-rustc-test = "0.3"
 
 [[bench]]
 name = "xml5ever"


### PR DESCRIPTION
The `rustc-test` crate v0.3.1 depends on rustc-serialize v0.3 which is unmaintained and unfortunately no longer compiles under rust 1.77.1.

Remove this crate in favour of a trivial test runner. This drops many nice features of the rustc test runner like parallelization, colour output, per-subtest command line selection support, and output capture on failure. On the other hand, it reduces the maintenance surface and unbreaks the build.

Resolves #526 