### PR TITLE
Update to criterion 0.5

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -17,7 +17,7 @@ mac = "0.1"
 markup5ever = { version = "0.12", path = "../markup5ever" }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.5"
 typed-arena = "2.0.2"
 
 [build-dependencies]

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -19,7 +19,7 @@ mac = "0.1"
 markup5ever = { version = "0.12", path = "../markup5ever" }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.5"
 
 [[bench]]
 name = "xml5ever"


### PR DESCRIPTION
Specify the current version of the benchmarking framework to address cargo audit warnings about the dependencies of earlier releases.

Note that this requires rust 1.74.1 or later to run `cargo bench` but MSRV (1.60.0) is only gated against the library target itself and not dev-dependencies, so this is no change in the requirements on downstream users.