### PR TITLE
Fix errors in CI.

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -11,6 +11,9 @@ build = "build.rs"
 categories = [ "parser-implementations", "web-programming" ]
 edition = "2021"
 
+[features]
+trace_tokenizer = []
+
 [dependencies]
 log = "0.4"
 mac = "0.1"

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -618,7 +618,7 @@ macro_rules! shorthand (
 // so it's behind a cfg flag.
 #[cfg(feature = "trace_tokenizer")]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ({
-    trace!("  {:s}", stringify!($($cmds)*));
+    trace!("  {:?}", stringify!($($cmds)*));
     shorthand!($me:expr : $($cmds)*);
 }));
 

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -619,7 +619,7 @@ macro_rules! shorthand (
 #[cfg(feature = "trace_tokenizer")]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ({
     trace!("  {:?}", stringify!($($cmds)*));
-    shorthand!($me:expr : $($cmds)*);
+    shorthand!($me : $($cmds)*);
 }));
 
 #[cfg(not(feature = "trace_tokenizer"))]

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -616,13 +616,13 @@ macro_rules! shorthand (
 
 // Tracing of tokenizer actions.  This adds significant bloat and compile time,
 // so it's behind a cfg flag.
-#[cfg(trace_tokenizer)]
+#[cfg(feature = "trace_tokenizer")]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ({
     trace!("  {:s}", stringify!($($cmds)*));
     shorthand!($me:expr : $($cmds)*);
 }));
 
-#[cfg(not(trace_tokenizer))]
+#[cfg(not(feature = "trace_tokenizer"))]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ( shorthand!($me: $($cmds)*) ) );
 
 // A little DSL for sequencing shorthand actions.

--- a/rcdom/tests/xml-tokenizer.rs
+++ b/rcdom/tests/xml-tokenizer.rs
@@ -140,6 +140,7 @@ fn tokenize_xml(input: Vec<StrTendril>, opts: XmlTokenizerOpts) -> Vec<Token> {
     tok.sink.get_tokens()
 }
 
+#[allow(dead_code)]
 trait JsonExt: Sized {
     fn get_str(&self) -> String;
     fn get_tendril(&self) -> StrTendril;

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -13,6 +13,9 @@ exclude = ["xml5lib-tests/*"]
 categories = ["parser-implementations", "web-programming"]
 edition = "2021"
 
+[features]
+trace_tokenizer = []
+
 [dependencies]
 log = "0.4"
 mac = "0.1"

--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -548,7 +548,7 @@ macro_rules! shorthand (
 // so it's behind a cfg flag.
 #[cfg(feature = "trace_tokenizer")]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ({
-    debug!("  {:s}", stringify!($($cmds)*));
+    debug!("  {:?}", stringify!($($cmds)*));
     shorthand!($me:expr : $($cmds)*);
 }));
 

--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -546,13 +546,13 @@ macro_rules! shorthand (
 
 // Tracing of tokenizer actions.  This adds significant bloat and compile time,
 // so it's behind a cfg flag.
-#[cfg(trace_tokenizer)]
+#[cfg(feature = "trace_tokenizer")]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ({
     debug!("  {:s}", stringify!($($cmds)*));
     shorthand!($me:expr : $($cmds)*);
 }));
 
-#[cfg(not(trace_tokenizer))]
+#[cfg(not(feature = "trace_tokenizer"))]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ( shorthand!($me: $($cmds)*) ) );
 
 // A little DSL for sequencing shorthand actions.

--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -549,7 +549,7 @@ macro_rules! shorthand (
 #[cfg(feature = "trace_tokenizer")]
 macro_rules! sh_trace ( ( $me:ident : $($cmds:tt)* ) => ({
     debug!("  {:?}", stringify!($($cmds)*));
-    shorthand!($me:expr : $($cmds)*);
+    shorthand!($me : $($cmds)*);
 }));
 
 #[cfg(not(feature = "trace_tokenizer"))]


### PR DESCRIPTION
From the lint job:
```
 error: methods `get_bool` and `get_list` are never used
   --> rcdom/tests/xml-tokenizer.rs:147:8
    |
143 | trait JsonExt: Sized {
    |       ------- methods in this trait
...
147 |     fn get_bool(&self) -> bool;
    |        ^^^^^^^^
148 |     fn get_obj(&self) -> &Map<String, Self>;
149 |     fn get_list(&self) -> &Vec<Self>;
    |        ^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`
```

From the nightly CI:
```
error: unexpected `cfg` condition name: `trace_tokenizer`
   --> html5ever/src/tokenizer/mod.rs:625:11
    |
625 | #[cfg(not(trace_tokenizer))]
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(trace_tokenizer)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(trace_tokenizer)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```