### PR TITLE
fix: add 'as' to local_names

### DIFF
--- a/markup5ever/local_names.txt
+++ b/markup5ever/local_names.txt
@@ -115,6 +115,7 @@ aria-valuemin
 aria-valuenow
 aria-valuetext
 article
+as
 ascent
 aside
 async


### PR DESCRIPTION
While playing around the `<link>` element in Servo, I noticed that the "as" IDL attribute doesn't play nice because the name is not included in `local_names`.

https://html.spec.whatwg.org/multipage/semantics.html#dom-link-as