### PR TITLE
Remove mutability from parser/tokenizer APIs.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install stable toolchain
         run: |
           rustup set profile minimal
-          rustup override set 1.61.0
+          rustup override set 1.65.0
 
       - run: cargo check --lib --all-features
 

--- a/html5ever/benches/html5ever.rs
+++ b/html5ever/benches/html5ever.rs
@@ -15,7 +15,7 @@ struct Sink;
 impl TokenSink for Sink {
     type Handle = ();
 
-    fn process_token(&mut self, token: Token, _line_number: u64) -> TokenSinkResult<()> {
+    fn process_token(&self, token: Token, _line_number: u64) -> TokenSinkResult<()> {
         // Don't use the token, but make sure we don't get
         // optimized out entirely.
         black_box(token);
@@ -53,7 +53,7 @@ fn run_bench(c: &mut Criterion, name: &str) {
 
     c.bench_function(&test_name, move |b| {
         b.iter(|| {
-            let mut tok = Tokenizer::new(Sink, Default::default());
+            let tok = Tokenizer::new(Sink, Default::default());
             let buffer = BufferQueue::default();
             // We are doing clone inside the bench function, this is not ideal, but possibly
             // necessary since our iterator consumes the underlying buffer.

--- a/html5ever/examples/noop-tokenize.rs
+++ b/html5ever/examples/noop-tokenize.rs
@@ -11,20 +11,21 @@
 
 extern crate html5ever;
 
+use std::cell::RefCell;
 use std::io;
 
 use html5ever::tendril::*;
 use html5ever::tokenizer::{BufferQueue, Token, TokenSink, TokenSinkResult, Tokenizer};
 
 /// In our case, our sink only contains a tokens vector
-struct Sink(Vec<Token>);
+struct Sink(RefCell<Vec<Token>>);
 
 impl TokenSink for Sink {
     type Handle = ();
 
     /// Each processed token will be handled by this method
-    fn process_token(&mut self, token: Token, _line_number: u64) -> TokenSinkResult<()> {
-        self.0.push(token);
+    fn process_token(&self, token: Token, _line_number: u64) -> TokenSinkResult<()> {
+        self.0.borrow_mut().push(token);
         TokenSinkResult::Continue
     }
 }
@@ -39,7 +40,7 @@ fn main() {
     let input = BufferQueue::default();
     input.push_back(chunk.try_reinterpret().unwrap());
 
-    let mut tok = Tokenizer::new(Sink(Vec::new()), Default::default());
+    let tok = Tokenizer::new(Sink(RefCell::new(Vec::new())), Default::default());
     let _ = tok.feed(&input);
     assert!(input.is_empty());
     tok.end();

--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -51,7 +51,8 @@ impl TreeSink for Sink {
     }
 
     fn get_template_contents(&self, target: &usize) -> usize {
-        if let Some(expanded_name!(html "template")) = self.names.borrow().get(target).map(|n| n.expanded())
+        if let Some(expanded_name!(html "template")) =
+            self.names.borrow().get(target).map(|n| n.expanded())
         {
             target + 1
         } else {
@@ -68,7 +69,12 @@ impl TreeSink for Sink {
     }
 
     fn elem_name(&self, target: &usize) -> ExpandedName {
-        self.names.borrow().get(target).cloned().expect("not an element").expanded()
+        self.names
+            .borrow()
+            .get(target)
+            .cloned()
+            .expect("not an element")
+            .expanded()
     }
 
     fn create_element(&self, name: QualName, _: Vec<Attribute>, _: ElementFlags) -> usize {
@@ -78,7 +84,9 @@ impl TreeSink for Sink {
         //      of this example code. A real implementation would either want to use a real
         //      real DOM tree implentation, or else use an arena as the backing store for
         //      memory used by the parser.
-        self.names.borrow_mut().insert(id, Box::leak(Box::new(name)));
+        self.names
+            .borrow_mut()
+            .insert(id, Box::leak(Box::new(name)));
         id
     }
 

--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -11,6 +11,7 @@
 extern crate html5ever;
 
 use std::borrow::Cow;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::io;
 
@@ -22,14 +23,14 @@ use html5ever::tree_builder::{
 use html5ever::{Attribute, ExpandedName, QualName};
 
 struct Sink {
-    next_id: usize,
-    names: HashMap<usize, QualName>,
+    next_id: Cell<usize>,
+    names: RefCell<HashMap<usize, QualName>>,
 }
 
 impl Sink {
-    fn get_id(&mut self) -> usize {
-        let id = self.next_id;
-        self.next_id += 2;
+    fn get_id(&self) -> usize {
+        let id = self.next_id.get();
+        self.next_id.set(id + 2);
         id
     }
 }
@@ -41,16 +42,16 @@ impl TreeSink for Sink {
         self
     }
 
-    fn parse_error(&mut self, msg: Cow<'static, str>) {
+    fn parse_error(&self, msg: Cow<'static, str>) {
         println!("Parse error: {}", msg);
     }
 
-    fn get_document(&mut self) -> usize {
+    fn get_document(&self) -> usize {
         0
     }
 
-    fn get_template_contents(&mut self, target: &usize) -> usize {
-        if let Some(expanded_name!(html "template")) = self.names.get(target).map(|n| n.expanded())
+    fn get_template_contents(&self, target: &usize) -> usize {
+        if let Some(expanded_name!(html "template")) = self.names.borrow().get(target).map(|n| n.expanded())
         {
             target + 1
         } else {
@@ -58,7 +59,7 @@ impl TreeSink for Sink {
         }
     }
 
-    fn set_quirks_mode(&mut self, mode: QuirksMode) {
+    fn set_quirks_mode(&self, mode: QuirksMode) {
         println!("Set quirks mode to {:?}", mode);
     }
 
@@ -66,36 +67,38 @@ impl TreeSink for Sink {
         x == y
     }
 
-    fn elem_name(&self, target: &usize) -> ExpandedName {
-        self.names.get(target).expect("not an element").expanded()
+    fn elem_name(&self, _target: &usize) -> ExpandedName {
+        //XXX(jdm)
+        //self.names.borrow().get(target).cloned().expect("not an element").expanded()
+        todo!()
     }
 
-    fn create_element(&mut self, name: QualName, _: Vec<Attribute>, _: ElementFlags) -> usize {
+    fn create_element(&self, name: QualName, _: Vec<Attribute>, _: ElementFlags) -> usize {
         let id = self.get_id();
         println!("Created {:?} as {}", name, id);
-        self.names.insert(id, name);
+        //self.names.borrow_mut().insert(id, name);
         id
     }
 
-    fn create_comment(&mut self, text: StrTendril) -> usize {
+    fn create_comment(&self, text: StrTendril) -> usize {
         let id = self.get_id();
         println!("Created comment \"{}\" as {}", text.escape_default(), id);
         id
     }
 
     #[allow(unused_variables)]
-    fn create_pi(&mut self, target: StrTendril, value: StrTendril) -> usize {
+    fn create_pi(&self, target: StrTendril, value: StrTendril) -> usize {
         unimplemented!()
     }
 
-    fn append(&mut self, parent: &usize, child: NodeOrText<usize>) {
+    fn append(&self, parent: &usize, child: NodeOrText<usize>) {
         match child {
             AppendNode(n) => println!("Append node {} to {}", n, parent),
             AppendText(t) => println!("Append text to {}: \"{}\"", parent, t.escape_default()),
         }
     }
 
-    fn append_before_sibling(&mut self, sibling: &usize, new_node: NodeOrText<usize>) {
+    fn append_before_sibling(&self, sibling: &usize, new_node: NodeOrText<usize>) {
         match new_node {
             AppendNode(n) => println!("Append node {} before {}", n, sibling),
             AppendText(t) => println!("Append text before {}: \"{}\"", sibling, t.escape_default()),
@@ -103,7 +106,7 @@ impl TreeSink for Sink {
     }
 
     fn append_based_on_parent_node(
-        &mut self,
+        &self,
         element: &Self::Handle,
         _prev_element: &Self::Handle,
         child: NodeOrText<Self::Handle>,
@@ -112,7 +115,7 @@ impl TreeSink for Sink {
     }
 
     fn append_doctype_to_document(
-        &mut self,
+        &self,
         name: StrTendril,
         public_id: StrTendril,
         system_id: StrTendril,
@@ -120,8 +123,8 @@ impl TreeSink for Sink {
         println!("Append doctype: {} {} {}", name, public_id, system_id);
     }
 
-    fn add_attrs_if_missing(&mut self, target: &usize, attrs: Vec<Attribute>) {
-        assert!(self.names.contains_key(target), "not an element");
+    fn add_attrs_if_missing(&self, target: &usize, attrs: Vec<Attribute>) {
+        assert!(self.names.borrow().contains_key(target), "not an element");
         println!("Add missing attributes to {}:", target);
         for attr in attrs.into_iter() {
             println!("    {:?} = {}", attr.name, attr.value);
@@ -129,7 +132,7 @@ impl TreeSink for Sink {
     }
 
     fn associate_with_form(
-        &mut self,
+        &self,
         _target: &usize,
         _form: &usize,
         _nodes: (&usize, Option<&usize>),
@@ -137,23 +140,23 @@ impl TreeSink for Sink {
         // No form owner support.
     }
 
-    fn remove_from_parent(&mut self, target: &usize) {
+    fn remove_from_parent(&self, target: &usize) {
         println!("Remove {} from parent", target);
     }
 
-    fn reparent_children(&mut self, node: &usize, new_parent: &usize) {
+    fn reparent_children(&self, node: &usize, new_parent: &usize) {
         println!("Move children from {} to {}", node, new_parent);
     }
 
-    fn mark_script_already_started(&mut self, node: &usize) {
+    fn mark_script_already_started(&self, node: &usize) {
         println!("Mark script {} as already started", node);
     }
 
-    fn set_current_line(&mut self, line_number: u64) {
+    fn set_current_line(&self, line_number: u64) {
         println!("Set current line to {}", line_number);
     }
 
-    fn pop(&mut self, elem: &usize) {
+    fn pop(&self, elem: &usize) {
         println!("Popped element {}", elem);
     }
 }
@@ -163,8 +166,8 @@ impl TreeSink for Sink {
 /// called.
 fn main() {
     let sink = Sink {
-        next_id: 1,
-        names: HashMap::new(),
+        next_id: Cell::new(1),
+        names: RefCell::new(HashMap::new()),
     };
     let stdin = io::stdin();
     parse_document(sink, Default::default())

--- a/html5ever/examples/tokenize.rs
+++ b/html5ever/examples/tokenize.rs
@@ -85,7 +85,9 @@ impl TokenSink for TokenPrinter {
 /// In this example we implement the TokenSink trait in such a way that each token is printed.
 /// If a there's an error while processing a token it is printed as well.
 fn main() {
-    let sink = TokenPrinter { in_char_run: Cell::new(false) };
+    let sink = TokenPrinter {
+        in_char_run: Cell::new(false),
+    };
 
     // Read HTML from standard input
     let mut chunk = ByteTendril::new();

--- a/html5ever/src/driver.rs
+++ b/html5ever/src/driver.rs
@@ -57,7 +57,7 @@ where
 ///
 /// If your input is bytes, use `Parser::from_utf8`.
 pub fn parse_fragment<Sink>(
-    mut sink: Sink,
+    sink: Sink,
     opts: ParseOpts,
     context_name: QualName,
     context_attrs: Vec<Attribute>,
@@ -65,7 +65,7 @@ pub fn parse_fragment<Sink>(
 where
     Sink: TreeSink,
 {
-    let context_elem = create_element(&mut sink, context_name, context_attrs);
+    let context_elem = create_element(&sink, context_name, context_attrs);
     parse_fragment_for_element(sink, opts, context_elem, None)
 }
 

--- a/html5ever/src/driver.rs
+++ b/html5ever/src/driver.rs
@@ -116,7 +116,7 @@ impl<Sink: TreeSink> TendrilSink<tendril::fmt::UTF8> for Parser<Sink> {
 
     type Output = Sink::Output;
 
-    fn finish(mut self) -> Self::Output {
+    fn finish(self) -> Self::Output {
         // FIXME: Properly support </script> somehow.
         while let TokenizerResult::Script(_) = self.tokenizer.feed(&self.input_buffer) {}
         assert!(self.input_buffer.is_empty());

--- a/html5ever/src/macros.rs
+++ b/html5ever/src/macros.rs
@@ -8,12 +8,10 @@
 // except according to those terms.
 
 macro_rules! unwrap_or_else {
-    ($opt:expr, $else_block:block) => {
-        {
-            let Some(x) = $opt else { $else_block };
-            x
-        }
-    };
+    ($opt:expr, $else_block:block) => {{
+        let Some(x) = $opt else { $else_block };
+        x
+    }};
 }
 
 macro_rules! unwrap_or_return {

--- a/html5ever/src/macros.rs
+++ b/html5ever/src/macros.rs
@@ -9,9 +9,9 @@
 
 macro_rules! unwrap_or_else {
     ($opt:expr, $else_block:block) => {
-        match $opt {
-            None => $else_block,
-            Some(x) => x,
+        {
+            let Some(x) = $opt else { $else_block };
+            x
         }
     };
 }

--- a/html5ever/src/tokenizer/char_ref/mod.rs
+++ b/html5ever/src/tokenizer/char_ref/mod.rs
@@ -114,7 +114,7 @@ impl CharRefTokenizer {
 impl CharRefTokenizer {
     pub(super) fn step<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         if self.result.is_some() {
@@ -134,7 +134,7 @@ impl CharRefTokenizer {
 
     fn do_begin<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         match unwrap_or_return!(tokenizer.peek(input), Stuck) {
@@ -155,7 +155,7 @@ impl CharRefTokenizer {
 
     fn do_octothorpe<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         let c = unwrap_or_return!(tokenizer.peek(input), Stuck);
@@ -176,7 +176,7 @@ impl CharRefTokenizer {
 
     fn do_numeric<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
         base: u32,
     ) -> Status {
@@ -206,7 +206,7 @@ impl CharRefTokenizer {
 
     fn do_numeric_semicolon<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         match unwrap_or_return!(tokenizer.peek(input), Stuck) {
@@ -220,7 +220,7 @@ impl CharRefTokenizer {
 
     fn unconsume_numeric<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         let mut unconsume = StrTendril::from_char('#');
@@ -233,7 +233,7 @@ impl CharRefTokenizer {
         self.finish_none()
     }
 
-    fn finish_numeric<Sink: TokenSink>(&mut self, tokenizer: &mut Tokenizer<Sink>) -> Status {
+    fn finish_numeric<Sink: TokenSink>(&mut self, tokenizer: &Tokenizer<Sink>) -> Status {
         fn conv(n: u32) -> char {
             from_u32(n).expect("invalid char missed by error handling cases")
         }
@@ -269,7 +269,7 @@ impl CharRefTokenizer {
 
     fn do_named<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         // peek + discard skips over newline normalization, therefore making it easier to
@@ -294,7 +294,7 @@ impl CharRefTokenizer {
         }
     }
 
-    fn emit_name_error<Sink: TokenSink>(&mut self, tokenizer: &mut Tokenizer<Sink>) {
+    fn emit_name_error<Sink: TokenSink>(&mut self, tokenizer: &Tokenizer<Sink>) {
         let msg = format_if!(
             tokenizer.opts.exact_errors,
             "Invalid character reference",
@@ -310,7 +310,7 @@ impl CharRefTokenizer {
 
     fn finish_named<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
         end_char: Option<char>,
     ) -> Status {
@@ -381,7 +381,7 @@ impl CharRefTokenizer {
                     self.finish_none()
                 } else {
                     input.push_front(StrTendril::from_slice(&self.name_buf()[name_len..]));
-                    tokenizer.ignore_lf = false;
+                    tokenizer.ignore_lf.set(false);
                     self.result = Some(CharRef {
                         chars: [from_u32(c1).unwrap(), from_u32(c2).unwrap()],
                         num_chars: if c2 == 0 { 1 } else { 2 },
@@ -394,7 +394,7 @@ impl CharRefTokenizer {
 
     fn do_bogus_name<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         // peek + discard skips over newline normalization, therefore making it easier to
@@ -413,7 +413,7 @@ impl CharRefTokenizer {
 
     pub(super) fn end_of_file<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut Tokenizer<Sink>,
+        tokenizer: &Tokenizer<Sink>,
         input: &BufferQueue,
     ) {
         while self.result.is_none() {

--- a/html5ever/src/tokenizer/interface.rs
+++ b/html5ever/src/tokenizer/interface.rs
@@ -84,10 +84,10 @@ pub trait TokenSink {
     type Handle;
 
     /// Process a token.
-    fn process_token(&mut self, token: Token, line_number: u64) -> TokenSinkResult<Self::Handle>;
+    fn process_token(&self, token: Token, line_number: u64) -> TokenSinkResult<Self::Handle>;
 
     // Signal sink that tokenization reached the end.
-    fn end(&mut self) {}
+    fn end(&self) {}
 
     /// Used in the markup declaration open state. By default, this always
     /// returns false and thus all CDATA sections are tokenized as bogus

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -288,7 +288,6 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         if self.reconsume.get() {
             self.reconsume.set(false);
             Some(self.current_char.get())
-
         } else {
             input
                 .next()
@@ -321,12 +320,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
     // BufferQueue::eat.
     //
     // NB: this doesn't set the current input character.
-    fn eat(
-        &self,
-        input: &BufferQueue,
-        pat: &str,
-        eq: fn(&u8, &u8) -> bool,
-    ) -> Option<bool> {
+    fn eat(&self, input: &BufferQueue, pat: &str, eq: fn(&u8, &u8) -> bool) -> Option<bool> {
         if self.ignore_lf.get() {
             self.ignore_lf.set(false);
             if self.peek(input) == Some('\n') {
@@ -491,7 +485,10 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
     fn have_appropriate_end_tag(&self) -> bool {
         match self.last_start_tag_name.borrow().as_ref() {
-            Some(last) => (self.current_tag_kind.get() == EndTag) && (**self.current_tag_name.borrow() == **last),
+            Some(last) => {
+                (self.current_tag_kind.get() == EndTag)
+                    && (**self.current_tag_name.borrow() == **last)
+            },
             None => false,
         }
     }
@@ -1469,8 +1466,12 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
     }
 
     fn dump_profile(&self) {
-        let mut results: Vec<(states::State, u64)> =
-            self.state_profile.borrow().iter().map(|(s, t)| (*s, *t)).collect();
+        let mut results: Vec<(states::State, u64)> = self
+            .state_profile
+            .borrow()
+            .iter()
+            .map(|(s, t)| (*s, *t))
+            .collect();
         results.sort_by(|&(_, x), &(_, y)| y.cmp(&x));
 
         let total: u64 = results
@@ -1478,7 +1479,10 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
             .map(|&(_, t)| t)
             .fold(0, ::std::ops::Add::add);
         println!("\nTokenizer profile, in nanoseconds");
-        println!("\n{:12}         total in token sink", self.time_in_sink.get());
+        println!(
+            "\n{:12}         total in token sink",
+            self.time_in_sink.get()
+        );
         println!("\n{:12}         total in tokenizer", total);
 
         for (k, v) in results.into_iter() {
@@ -1629,11 +1633,7 @@ mod test {
     impl TokenSink for LinesMatch {
         type Handle = ();
 
-        fn process_token(
-            &self,
-            token: Token,
-            line_number: u64,
-        ) -> TokenSinkResult<Self::Handle> {
+        fn process_token(&self, token: Token, line_number: u64) -> TokenSinkResult<Self::Handle> {
             match token {
                 CharacterTokens(b) => {
                     self.current_str.borrow_mut().push_slice(&b);

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -253,7 +253,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
         if self.ignore_lf.get() {
             self.ignore_lf.set(false);
             if c == '\n' {
-                c = unwrap_or_return!(input.next(), None);
+                c = input.next()?;
             }
         }
 

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -25,6 +25,7 @@ use crate::tokenizer::states as tok_state;
 use crate::tokenizer::{Doctype, EndTag, StartTag, Tag, TokenSink, TokenSinkResult};
 
 use std::borrow::Cow::Borrowed;
+use std::cell::{Cell, RefCell, Ref, RefMut};
 use std::collections::VecDeque;
 use std::iter::{Enumerate, Rev};
 use std::mem;
@@ -92,51 +93,51 @@ pub struct TreeBuilder<Handle, Sink> {
     pub sink: Sink,
 
     /// Insertion mode.
-    mode: InsertionMode,
+    mode: Cell<InsertionMode>,
 
     /// Original insertion mode, used by Text and InTableText modes.
-    orig_mode: Option<InsertionMode>,
+    orig_mode: Cell<Option<InsertionMode>>,
 
     /// Stack of template insertion modes.
-    template_modes: Vec<InsertionMode>,
+    template_modes: RefCell<Vec<InsertionMode>>,
 
     /// Pending table character tokens.
-    pending_table_text: Vec<(SplitStatus, StrTendril)>,
+    pending_table_text: RefCell<Vec<(SplitStatus, StrTendril)>>,
 
     /// Quirks mode as set by the parser.
     /// FIXME: can scripts etc. change this?
-    quirks_mode: QuirksMode,
+    quirks_mode: Cell<QuirksMode>,
 
     /// The document node, which is created by the sink.
     doc_handle: Handle,
 
     /// Stack of open elements, most recently added at end.
-    open_elems: Vec<Handle>,
+    open_elems: RefCell<Vec<Handle>>,
 
     /// List of active formatting elements.
-    active_formatting: Vec<FormatEntry<Handle>>,
+    active_formatting: RefCell<Vec<FormatEntry<Handle>>>,
 
     //§ the-element-pointers
     /// Head element pointer.
-    head_elem: Option<Handle>,
+    head_elem: RefCell<Option<Handle>>,
 
     /// Form element pointer.
-    form_elem: Option<Handle>,
+    form_elem: RefCell<Option<Handle>>,
     //§ END
     /// Frameset-ok flag.
-    frameset_ok: bool,
+    frameset_ok: Cell<bool>,
 
     /// Ignore a following U+000A LINE FEED?
-    ignore_lf: bool,
+    ignore_lf: Cell<bool>,
 
     /// Is foster parenting enabled?
-    foster_parenting: bool,
+    foster_parenting: Cell<bool>,
 
     /// The context element for the fragment parsing algorithm.
-    context_elem: Option<Handle>,
+    context_elem: RefCell<Option<Handle>>,
 
     /// Track current line
-    current_line: u64,
+    current_line: Cell<u64>,
     // WARNING: If you add new fields that contain Handles, you
     // must add them to trace_handles() below to preserve memory
     // safety!
@@ -157,21 +158,21 @@ where
         TreeBuilder {
             opts: opts,
             sink: sink,
-            mode: Initial,
-            orig_mode: None,
-            template_modes: vec![],
-            pending_table_text: vec![],
-            quirks_mode: opts.quirks_mode,
+            mode: Cell::new(Initial),
+            orig_mode: Cell::new(None),
+            template_modes: Default::default(),
+            pending_table_text: Default::default(),
+            quirks_mode: Cell::new(opts.quirks_mode),
             doc_handle: doc_handle,
-            open_elems: vec![],
-            active_formatting: vec![],
-            head_elem: None,
-            form_elem: None,
-            frameset_ok: true,
-            ignore_lf: false,
-            foster_parenting: false,
-            context_elem: None,
-            current_line: 1,
+            open_elems: Default::default(),
+            active_formatting: Default::default(),
+            head_elem: Default::default(),
+            form_elem: Default::default(),
+            frameset_ok: Cell::new(true),
+            ignore_lf: Default::default(),
+            foster_parenting: Default::default(),
+            context_elem: Default::default(),
+            current_line: Cell::new(1),
         }
     }
 
@@ -190,25 +191,25 @@ where
         let mut tb = TreeBuilder {
             opts: opts,
             sink: sink,
-            mode: Initial,
-            orig_mode: None,
-            template_modes: if context_is_template {
+            mode: Cell::new(Initial),
+            orig_mode: Cell::new(None),
+            template_modes: RefCell::new(if context_is_template {
                 vec![InTemplate]
             } else {
                 vec![]
-            },
-            pending_table_text: vec![],
-            quirks_mode: opts.quirks_mode,
+            }),
+            pending_table_text: Default::default(),
+            quirks_mode: Cell::new(opts.quirks_mode),
             doc_handle: doc_handle,
-            open_elems: vec![],
-            active_formatting: vec![],
-            head_elem: None,
-            form_elem: form_elem,
-            frameset_ok: true,
-            ignore_lf: false,
-            foster_parenting: false,
-            context_elem: Some(context_elem),
-            current_line: 1,
+            open_elems: Default::default(),
+            active_formatting: Default::default(),
+            head_elem: Default::default(),
+            form_elem: RefCell::new(form_elem),
+            frameset_ok: Cell::new(true),
+            ignore_lf: Default::default(),
+            foster_parenting: Default::default(),
+            context_elem: RefCell::new(Some(context_elem)),
+            current_line: Cell::new(1),
         };
 
         // https://html.spec.whatwg.org/multipage/#parsing-html-fragments
@@ -217,7 +218,8 @@ where
         // 7. Set up the parser's stack of open elements so that it contains just the single element root.
         tb.create_root(vec![]);
         // 10. Reset the parser's insertion mode appropriately.
-        tb.mode = tb.reset_insertion_mode();
+        let old_insertion_mode = tb.reset_insertion_mode();
+        tb.mode.set(old_insertion_mode);
 
         tb
     }
@@ -225,7 +227,8 @@ where
     // https://html.spec.whatwg.org/multipage/#concept-frag-parse-context
     // Step 4. Set the state of the HTML parser's tokenization stage as follows:
     pub fn tokenizer_state_for_context_elem(&self) -> tok_state::State {
-        let elem = self.context_elem.as_ref().expect("no context element");
+        let context_elem = self.context_elem.borrow();
+        let elem = context_elem.as_ref().expect("no context element");
         let name = match self.sink.elem_name(elem) {
             ExpandedName {
                 ns: &ns!(html),
@@ -262,25 +265,25 @@ where
     /// internal state.  This is intended to support garbage-collected DOMs.
     pub fn trace_handles(&self, tracer: &dyn Tracer<Handle = Handle>) {
         tracer.trace_handle(&self.doc_handle);
-        for e in &self.open_elems {
+        for e in &*self.open_elems.borrow() {
             tracer.trace_handle(e);
         }
-        for e in &self.active_formatting {
+        for e in &*self.active_formatting.borrow() {
             match e {
                 &Element(ref h, _) => tracer.trace_handle(h),
                 _ => (),
             }
         }
-        self.head_elem.as_ref().map(|h| tracer.trace_handle(h));
-        self.form_elem.as_ref().map(|h| tracer.trace_handle(h));
-        self.context_elem.as_ref().map(|h| tracer.trace_handle(h));
+        self.head_elem.borrow().as_ref().map(|h| tracer.trace_handle(h));
+        self.form_elem.borrow().as_ref().map(|h| tracer.trace_handle(h));
+        self.context_elem.borrow().as_ref().map(|h| tracer.trace_handle(h));
     }
 
     #[allow(dead_code)]
     fn dump_state(&self, label: String) {
         println!("dump_state on {}", label);
         print!("    open_elems:");
-        for node in self.open_elems.iter() {
+        for node in self.open_elems.borrow().iter() {
             let name = self.sink.elem_name(node);
             match *name.ns {
                 ns!(html) => print!(" {}", name.local),
@@ -289,7 +292,7 @@ where
         }
         println!("");
         print!("    active_formatting:");
-        for entry in self.active_formatting.iter() {
+        for entry in self.active_formatting.borrow().iter() {
             match entry {
                 &Marker => print!(" Marker"),
                 &Element(ref h, _) => {
@@ -314,7 +317,7 @@ where
         }
     }
 
-    fn process_to_completion(&mut self, mut token: Token) -> TokenSinkResult<Handle> {
+    fn process_to_completion(&self, mut token: Token) -> TokenSinkResult<Handle> {
         // Queue of additional tokens yet to be processed.
         // This stays empty in the common case where we don't split whitespace.
         let mut more_tokens = VecDeque::new();
@@ -331,7 +334,7 @@ where
             let result = if self.is_foreign(&token) {
                 self.step_foreign(token)
             } else {
-                let mode = self.mode;
+                let mode = self.mode.get();
                 self.step(mode, token)
             };
             match result {
@@ -352,7 +355,7 @@ where
                     );
                 },
                 Reprocess(m, t) => {
-                    self.mode = m;
+                    self.mode.set(m);
                     token = t;
                 },
                 ReprocessForeign(t) => {
@@ -386,19 +389,19 @@ where
 
     /// Are we parsing a HTML fragment?
     pub fn is_fragment(&self) -> bool {
-        self.context_elem.is_some()
+        self.context_elem.borrow().is_some()
     }
 
     /// https://html.spec.whatwg.org/multipage/#appropriate-place-for-inserting-a-node
     fn appropriate_place_for_insertion(
-        &mut self,
+        &self,
         override_target: Option<Handle>,
     ) -> InsertionPoint<Handle> {
         use self::tag_sets::*;
 
         declare_tag_set!(foster_target = "table" "tbody" "tfoot" "thead" "tr");
         let target = override_target.unwrap_or_else(|| self.current_node().clone());
-        if !(self.foster_parenting && self.elem_in(&target, foster_target)) {
+        if !(self.foster_parenting.get() && self.elem_in(&target, foster_target)) {
             if self.html_elem_named(&target, local_name!("template")) {
                 // No foster parenting (inside template).
                 let contents = self.sink.get_template_contents(&target);
@@ -410,7 +413,8 @@ where
         }
 
         // Foster parenting
-        let mut iter = self.open_elems.iter().rev().peekable();
+        let open_elems = self.open_elems.borrow();
+        let mut iter = open_elems.iter().rev().peekable();
         while let Some(elem) = iter.next() {
             if self.html_elem_named(&elem, local_name!("template")) {
                 let contents = self.sink.get_template_contents(&elem);
@@ -426,7 +430,7 @@ where
         LastChild(html_elem.clone())
     }
 
-    fn insert_at(&mut self, insertion_point: InsertionPoint<Handle>, child: NodeOrText<Handle>) {
+    fn insert_at(&self, insertion_point: InsertionPoint<Handle>, child: NodeOrText<Handle>) {
         match insertion_point {
             LastChild(parent) => self.sink.append(&parent, child),
             BeforeSibling(sibling) => self.sink.append_before_sibling(&sibling, child),
@@ -448,14 +452,14 @@ where
     type Handle = Handle;
 
     fn process_token(
-        &mut self,
+        &self,
         token: tokenizer::Token,
         line_number: u64,
     ) -> TokenSinkResult<Handle> {
-        if line_number != self.current_line {
+        if line_number != self.current_line.get() {
             self.sink.set_current_line(line_number);
         }
-        let ignore_lf = mem::take(&mut self.ignore_lf);
+        let ignore_lf = self.ignore_lf.take();
 
         // Handle `ParseError` and `DoctypeToken`; convert everything else to the local `Token` type.
         let token = match token {
@@ -465,7 +469,7 @@ where
             },
 
             tokenizer::DoctypeToken(dt) => {
-                if self.mode == Initial {
+                if self.mode.get() == Initial {
                     let (err, quirk) = data::doctype_error_and_quirks(&dt, self.opts.iframe_srcdoc);
                     if err {
                         self.sink.parse_error(format_if!(
@@ -490,14 +494,14 @@ where
                     }
                     self.set_quirks_mode(quirk);
 
-                    self.mode = BeforeHtml;
+                    self.mode.set(BeforeHtml);
                     return tokenizer::TokenSinkResult::Continue;
                 } else {
                     self.sink.parse_error(format_if!(
                         self.opts.exact_errors,
                         "DOCTYPE in body",
                         "DOCTYPE in insertion mode {:?}",
-                        self.mode
+                        self.mode.get()
                     ));
                     return tokenizer::TokenSinkResult::Continue;
                 }
@@ -522,20 +526,32 @@ where
         self.process_to_completion(token)
     }
 
-    fn end(&mut self) {
-        for elem in self.open_elems.drain(..).rev() {
+    fn end(&self) {
+        for elem in self.open_elems.borrow_mut().drain(..).rev() {
             self.sink.pop(&elem);
         }
     }
 
     fn adjusted_current_node_present_but_not_in_html_namespace(&self) -> bool {
-        !self.open_elems.is_empty()
-            && self.sink.elem_name(self.adjusted_current_node()).ns != &ns!(html)
+        !self.open_elems.borrow().is_empty()
+            && self.sink.elem_name(&self.adjusted_current_node()).ns != &ns!(html)
     }
 }
 
 pub fn html_elem<Handle>(open_elems: &[Handle]) -> &Handle {
     &open_elems[0]
+}
+
+struct ActiveFormattingView<'a, Handle: 'a> {
+    data: Ref<'a, Vec<FormatEntry<Handle>>>,
+}
+
+impl <'a, Handle: 'a> ActiveFormattingView<'a, Handle> {
+    fn iter(&'a self) -> impl Iterator<Item = (usize, &'a Handle, &'a Tag)> + 'a {
+        ActiveFormattingIter {
+            iter: self.data.iter().enumerate().rev()
+        }
+    }
 }
 
 pub struct ActiveFormattingIter<'a, Handle: 'a> {
@@ -585,42 +601,42 @@ where
     Handle: Clone,
     Sink: TreeSink<Handle = Handle>,
 {
-    fn unexpected<T: fmt::Debug>(&mut self, _thing: &T) -> ProcessResult<Handle> {
+    fn unexpected<T: fmt::Debug>(&self, _thing: &T) -> ProcessResult<Handle> {
         self.sink.parse_error(format_if!(
             self.opts.exact_errors,
             "Unexpected token",
             "Unexpected token {} in insertion mode {:?}",
             to_escaped_string(_thing),
-            self.mode
+            self.mode.get()
         ));
         Done
     }
 
-    fn assert_named(&mut self, node: &Handle, name: LocalName) {
+    fn assert_named(&self, node: &Handle, name: LocalName) {
         assert!(self.html_elem_named(&node, name));
     }
 
     /// Iterate over the active formatting elements (with index in the list) from the end
     /// to the last marker, or the beginning if there are no markers.
-    fn active_formatting_end_to_marker<'a>(&'a self) -> ActiveFormattingIter<'a, Handle> {
-        ActiveFormattingIter {
-            iter: self.active_formatting.iter().enumerate().rev(),
+    fn active_formatting_end_to_marker<'a>(&'a self) -> ActiveFormattingView<'a, Handle> {
+        ActiveFormattingView {
+            data: Ref::map(self.active_formatting.borrow(), |a| &*a),
         }
     }
 
     fn position_in_active_formatting(&self, element: &Handle) -> Option<usize> {
-        self.active_formatting.iter().position(|n| match n {
+        self.active_formatting.borrow().iter().position(|n| match n {
             &Marker => false,
             &Element(ref handle, _) => self.sink.same_node(handle, element),
         })
     }
 
-    fn set_quirks_mode(&mut self, mode: QuirksMode) {
-        self.quirks_mode = mode;
+    fn set_quirks_mode(&self, mode: QuirksMode) {
+        self.quirks_mode.set(mode);
         self.sink.set_quirks_mode(mode);
     }
 
-    fn stop_parsing(&mut self) -> ProcessResult<Handle> {
+    fn stop_parsing(&self) -> ProcessResult<Handle> {
         Done
     }
 
@@ -629,26 +645,28 @@ where
     // switch the tokenizer to a raw-data state.
     // The latter only takes effect after the current / next
     // `process_token` of a start tag returns!
-    fn to_raw_text_mode(&mut self, k: RawKind) -> ProcessResult<Handle> {
-        self.orig_mode = Some(self.mode);
-        self.mode = Text;
+    fn to_raw_text_mode(&self, k: RawKind) -> ProcessResult<Handle> {
+        self.orig_mode.set(Some(self.mode.get()));
+        self.mode.set(Text);
         ToRawData(k)
     }
 
     // The generic raw text / RCDATA parsing algorithm.
-    fn parse_raw_data(&mut self, tag: Tag, k: RawKind) -> ProcessResult<Handle> {
+    fn parse_raw_data(&self, tag: Tag, k: RawKind) -> ProcessResult<Handle> {
         self.insert_element_for(tag);
         self.to_raw_text_mode(k)
     }
     //§ END
 
-    fn current_node(&self) -> &Handle {
-        self.open_elems.last().expect("no current element")
+    fn current_node(&self) -> Ref<Handle> {
+        Ref::map(self.open_elems.borrow(), |elems| elems.last().expect("no current element"))
     }
 
-    fn adjusted_current_node(&self) -> &Handle {
-        if self.open_elems.len() == 1 {
-            if let Some(ctx) = self.context_elem.as_ref() {
+    fn adjusted_current_node(&self) -> Ref<Handle> {
+        if self.open_elems.borrow().len() == 1 {
+            let context_elem = self.context_elem.borrow();
+            let ctx = Ref::filter_map(context_elem, |e| e.as_ref());
+            if let Ok(ctx) = ctx {
                 return ctx;
             }
         }
@@ -659,20 +677,20 @@ where
     where
         TagSet: Fn(ExpandedName) -> bool,
     {
-        set(self.sink.elem_name(self.current_node()))
+        set(self.sink.elem_name(&self.current_node()))
     }
 
     // Insert at the "appropriate place for inserting a node".
-    fn insert_appropriately(&mut self, child: NodeOrText<Handle>, override_target: Option<Handle>) {
+    fn insert_appropriately(&self, child: NodeOrText<Handle>, override_target: Option<Handle>) {
         let insertion_point = self.appropriate_place_for_insertion(override_target);
         self.insert_at(insertion_point, child);
     }
 
-    fn adoption_agency(&mut self, subject: LocalName) {
+    fn adoption_agency(&self, subject: LocalName) {
         // 1.
         if self.current_node_named(subject.clone()) {
             if self
-                .position_in_active_formatting(self.current_node())
+                .position_in_active_formatting(&self.current_node())
                 .is_none()
             {
                 self.pop();
@@ -686,6 +704,7 @@ where
             let (fmt_elem_index, fmt_elem, fmt_elem_tag) = unwrap_or_return!(
                 // We clone the Handle and Tag so they don't cause an immutable borrow of self.
                 self.active_formatting_end_to_marker()
+                    .iter()
                     .filter(|&(_, _, tag)| tag.name == subject)
                     .next()
                     .map(|(i, h, t)| (i, h.clone(), t.clone())),
@@ -701,12 +720,13 @@ where
 
             let fmt_elem_stack_index = unwrap_or_return!(
                 self.open_elems
+                    .borrow()
                     .iter()
                     .rposition(|n| self.sink.same_node(n, &fmt_elem)),
                 {
                     self.sink
                         .parse_error(Borrowed("Formatting element not open"));
-                    self.active_formatting.remove(fmt_elem_index);
+                    self.active_formatting.borrow_mut().remove(fmt_elem_index);
                 }
             );
 
@@ -718,7 +738,7 @@ where
             }
 
             // 8.
-            if !self.sink.same_node(self.current_node(), &fmt_elem) {
+            if !self.sink.same_node(&self.current_node(), &fmt_elem) {
                 self.sink
                     .parse_error(Borrowed("Formatting element not current node"));
             }
@@ -726,6 +746,7 @@ where
             // 9.
             let (furthest_block_index, furthest_block) = unwrap_or_return!(
                 self.open_elems
+                    .borrow()
                     .iter()
                     .enumerate()
                     .skip(fmt_elem_stack_index)
@@ -734,13 +755,13 @@ where
                     .map(|(i, h)| (i, h.clone())),
                 // 10.
                 {
-                    self.open_elems.truncate(fmt_elem_stack_index);
-                    self.active_formatting.remove(fmt_elem_index);
+                    self.open_elems.borrow_mut().truncate(fmt_elem_stack_index);
+                    self.active_formatting.borrow_mut().remove(fmt_elem_index);
                 }
             );
 
             // 11.
-            let common_ancestor = self.open_elems[fmt_elem_stack_index - 1].clone();
+            let common_ancestor = self.open_elems.borrow()[fmt_elem_stack_index - 1].clone();
 
             // 12.
             let mut bookmark = Bookmark::Replace(fmt_elem.clone());
@@ -758,7 +779,7 @@ where
 
                 // 13.3.
                 node_index -= 1;
-                node = self.open_elems[node_index].clone();
+                node = self.open_elems.borrow()[node_index].clone();
 
                 // 13.4.
                 if self.sink.same_node(&node, &fmt_elem) {
@@ -768,8 +789,8 @@ where
                 // 13.5.
                 if inner_counter > 3 {
                     self.position_in_active_formatting(&node)
-                        .map(|position| self.active_formatting.remove(position));
-                    self.open_elems.remove(node_index);
+                        .map(|position| self.active_formatting.borrow_mut().remove(position));
+                    self.open_elems.borrow_mut().remove(node_index);
                     continue;
                 }
 
@@ -777,13 +798,13 @@ where
                     self.position_in_active_formatting(&node),
                     // 13.6.
                     {
-                        self.open_elems.remove(node_index);
+                        self.open_elems.borrow_mut().remove(node_index);
                         continue;
                     }
                 );
 
                 // 13.7.
-                let tag = match self.active_formatting[node_formatting_index] {
+                let tag = match self.active_formatting.borrow()[node_formatting_index] {
                     Element(ref h, ref t) => {
                         assert!(self.sink.same_node(h, &node));
                         t.clone()
@@ -793,12 +814,12 @@ where
                 // FIXME: Is there a way to avoid cloning the attributes twice here (once on their
                 // own, once as part of t.clone() above)?
                 let new_element = create_element(
-                    &mut self.sink,
+                    &self.sink,
                     QualName::new(None, ns!(html), tag.name.clone()),
                     tag.attrs.clone(),
                 );
-                self.open_elems[node_index] = new_element.clone();
-                self.active_formatting[node_formatting_index] = Element(new_element.clone(), tag);
+                self.open_elems.borrow_mut()[node_index] = new_element.clone();
+                self.active_formatting.borrow_mut()[node_formatting_index] = Element(new_element.clone(), tag);
                 node = new_element;
 
                 // 13.8.
@@ -824,7 +845,7 @@ where
             // FIXME: Is there a way to avoid cloning the attributes twice here (once on their own,
             // once as part of t.clone() above)?
             let new_element = create_element(
-                &mut self.sink,
+                &self.sink,
                 QualName::new(None, ns!(html), fmt_elem_tag.name.clone()),
                 fmt_elem_tag.attrs.clone(),
             );
@@ -845,18 +866,18 @@ where
                     let index = self
                         .position_in_active_formatting(&to_replace)
                         .expect("bookmark not found in active formatting elements");
-                    self.active_formatting[index] = new_entry;
+                    self.active_formatting.borrow_mut()[index] = new_entry;
                 },
                 Bookmark::InsertAfter(previous) => {
                     let index = self
                         .position_in_active_formatting(&previous)
                         .expect("bookmark not found in active formatting elements")
                         + 1;
-                    self.active_formatting.insert(index, new_entry);
+                    self.active_formatting.borrow_mut().insert(index, new_entry);
                     let old_index = self
                         .position_in_active_formatting(&fmt_elem)
                         .expect("formatting element not found in active formatting elements");
-                    self.active_formatting.remove(old_index);
+                    self.active_formatting.borrow_mut().remove(old_index);
                 },
             }
 
@@ -864,35 +885,37 @@ where
             self.remove_from_stack(&fmt_elem);
             let new_furthest_block_index = self
                 .open_elems
+                .borrow()
                 .iter()
                 .position(|n| self.sink.same_node(n, &furthest_block))
                 .expect("furthest block missing from open element stack");
             self.open_elems
+                .borrow_mut()
                 .insert(new_furthest_block_index + 1, new_element);
 
             // 20.
         }
     }
 
-    fn push(&mut self, elem: &Handle) {
-        self.open_elems.push(elem.clone());
+    fn push(&self, elem: &Handle) {
+        self.open_elems.borrow_mut().push(elem.clone());
     }
 
-    fn pop(&mut self) -> Handle {
-        let elem = self.open_elems.pop().expect("no current element");
+    fn pop(&self) -> Handle {
+        let elem = self.open_elems.borrow_mut().pop().expect("no current element");
         self.sink.pop(&elem);
         elem
     }
 
-    fn remove_from_stack(&mut self, elem: &Handle) {
-        let sink = &mut self.sink;
+    fn remove_from_stack(&self, elem: &Handle) {
         let position = self
             .open_elems
+            .borrow()
             .iter()
-            .rposition(|x| sink.same_node(elem, &x));
+            .rposition(|x| self.sink.same_node(elem, &x));
         if let Some(position) = position {
-            self.open_elems.remove(position);
-            sink.pop(elem);
+            self.open_elems.borrow_mut().remove(position);
+            self.sink.pop(elem);
         }
     }
 
@@ -901,6 +924,7 @@ where
             Marker => true,
             Element(ref node, _) => self
                 .open_elems
+                .borrow()
                 .iter()
                 .rev()
                 .any(|n| self.sink.same_node(&n, &node)),
@@ -908,28 +932,29 @@ where
     }
 
     /// Reconstruct the active formatting elements.
-    fn reconstruct_formatting(&mut self) {
+    fn reconstruct_formatting(&self) {
         {
-            let last = unwrap_or_return!(self.active_formatting.last(), ());
+            let active_formatting = self.active_formatting.borrow();
+            let last = unwrap_or_return!(active_formatting.last(), ());
             if self.is_marker_or_open(last) {
                 return;
             }
         }
 
-        let mut entry_index = self.active_formatting.len() - 1;
+        let mut entry_index = self.active_formatting.borrow().len() - 1;
         loop {
             if entry_index == 0 {
                 break;
             }
             entry_index -= 1;
-            if self.is_marker_or_open(&self.active_formatting[entry_index]) {
+            if self.is_marker_or_open(&self.active_formatting.borrow()[entry_index]) {
                 entry_index += 1;
                 break;
             }
         }
 
         loop {
-            let tag = match self.active_formatting[entry_index] {
+            let tag = match self.active_formatting.borrow()[entry_index] {
                 Element(_, ref t) => t.clone(),
                 Marker => panic!("Found marker during formatting element reconstruction"),
             };
@@ -938,8 +963,8 @@ where
             // once as part of t.clone() above)?
             let new_element =
                 self.insert_element(Push, ns!(html), tag.name.clone(), tag.attrs.clone());
-            self.active_formatting[entry_index] = Element(new_element, tag);
-            if entry_index == self.active_formatting.len() - 1 {
+            self.active_formatting.borrow_mut()[entry_index] = Element(new_element, tag);
+            if entry_index == self.active_formatting.borrow().len() - 1 {
                 break;
             }
             entry_index += 1;
@@ -947,18 +972,18 @@ where
     }
 
     /// Get the first element on the stack, which will be the <html> element.
-    fn html_elem(&self) -> &Handle {
-        &self.open_elems[0]
+    fn html_elem(&self) -> Ref<Handle> {
+        Ref::map(self.open_elems.borrow(), |elems| &elems[0])
     }
 
     /// Get the second element on the stack, if it's a HTML body element.
-    fn body_elem(&self) -> Option<&Handle> {
-        if self.open_elems.len() <= 1 {
+    fn body_elem(&self) -> Option<Ref<Handle>> {
+        if self.open_elems.borrow().len() <= 1 {
             return None;
         }
 
-        let node = &self.open_elems[1];
-        if self.html_elem_named(node, local_name!("body")) {
+        let node = Ref::map(self.open_elems.borrow(), |elems| &elems[1]);
+        if self.html_elem_named(&node, local_name!("body")) {
             Some(node)
         } else {
             None
@@ -967,12 +992,12 @@ where
 
     /// Signal an error depending on the state of the stack of open elements at
     /// the end of the body.
-    fn check_body_end(&mut self) {
+    fn check_body_end(&self) {
         declare_tag_set!(body_end_ok =
             "dd" "dt" "li" "optgroup" "option" "p" "rp" "rt" "tbody" "td" "tfoot" "th"
             "thead" "tr" "body" "html");
 
-        for elem in self.open_elems.iter() {
+        for elem in self.open_elems.borrow().iter() {
             let error;
             {
                 let name = self.sink.elem_name(elem);
@@ -998,7 +1023,7 @@ where
         TagSet: Fn(ExpandedName) -> bool,
         Pred: Fn(Handle) -> bool,
     {
-        for node in self.open_elems.iter().rev() {
+        for node in self.open_elems.borrow().iter().rev() {
             if pred(node.clone()) {
                 return true;
             }
@@ -1026,12 +1051,13 @@ where
 
     fn in_html_elem_named(&self, name: LocalName) -> bool {
         self.open_elems
+            .borrow()
             .iter()
             .any(|elem| self.html_elem_named(elem, name.clone()))
     }
 
     fn current_node_named(&self, name: LocalName) -> bool {
-        self.html_elem_named(self.current_node(), name)
+        self.html_elem_named(&self.current_node(), name)
     }
 
     fn in_scope_named<TagSet>(&self, scope: TagSet, name: LocalName) -> bool
@@ -1042,13 +1068,14 @@ where
     }
 
     //§ closing-elements-that-have-implied-end-tags
-    fn generate_implied_end<TagSet>(&mut self, set: TagSet)
+    fn generate_implied_end<TagSet>(&self, set: TagSet)
     where
         TagSet: Fn(ExpandedName) -> bool,
     {
         loop {
             {
-                let elem = unwrap_or_return!(self.open_elems.last(), ());
+                let open_elems = self.open_elems.borrow();
+                let elem = unwrap_or_return!(open_elems.last(), ());
                 let nsname = self.sink.elem_name(elem);
                 if !set(nsname) {
                     return;
@@ -1058,7 +1085,7 @@ where
         }
     }
 
-    fn generate_implied_end_except(&mut self, except: LocalName) {
+    fn generate_implied_end_except(&self, except: LocalName) {
         self.generate_implied_end(|p| {
             if *p.ns == ns!(html) && *p.local == except {
                 false
@@ -1070,7 +1097,7 @@ where
     //§ END
 
     // Pop elements until the current element is in the set.
-    fn pop_until_current<TagSet>(&mut self, pred: TagSet)
+    fn pop_until_current<TagSet>(&self, pred: TagSet)
     where
         TagSet: Fn(ExpandedName) -> bool,
     {
@@ -1078,20 +1105,20 @@ where
             if self.current_node_in(|x| pred(x)) {
                 break;
             }
-            self.open_elems.pop();
+            self.open_elems.borrow_mut().pop();
         }
     }
 
     // Pop elements until an element from the set has been popped.  Returns the
     // number of elements popped.
-    fn pop_until<P>(&mut self, pred: P) -> usize
+    fn pop_until<P>(&self, pred: P) -> usize
     where
         P: Fn(ExpandedName) -> bool,
     {
         let mut n = 0;
         loop {
             n += 1;
-            match self.open_elems.pop() {
+            match self.open_elems.borrow_mut().pop() {
                 None => break,
                 Some(elem) => {
                     if pred(self.sink.elem_name(&elem)) {
@@ -1103,13 +1130,13 @@ where
         n
     }
 
-    fn pop_until_named(&mut self, name: LocalName) -> usize {
+    fn pop_until_named(&self, name: LocalName) -> usize {
         self.pop_until(|p| *p.ns == ns!(html) && *p.local == name)
     }
 
     // Pop elements until one with the specified name has been popped.
     // Signal an error if it was not the first one.
-    fn expect_to_close(&mut self, name: LocalName) {
+    fn expect_to_close(&self, name: LocalName) {
         if self.pop_until_named(name.clone()) != 1 {
             self.sink.parse_error(format_if!(
                 self.opts.exact_errors,
@@ -1120,13 +1147,13 @@ where
         }
     }
 
-    fn close_p_element(&mut self) {
+    fn close_p_element(&self) {
         declare_tag_set!(implied = [cursory_implied_end] - "p");
         self.generate_implied_end(implied);
         self.expect_to_close(local_name!("p"));
     }
 
-    fn close_p_element_in_button_scope(&mut self) {
+    fn close_p_element_in_button_scope(&self) {
         if self.in_scope_named(button_scope, local_name!("p")) {
             self.close_p_element();
         }
@@ -1144,20 +1171,20 @@ where
         }
     }
 
-    fn foster_parent_in_body(&mut self, token: Token) -> ProcessResult<Handle> {
+    fn foster_parent_in_body(&self, token: Token) -> ProcessResult<Handle> {
         warn!("foster parenting not implemented");
-        self.foster_parenting = true;
+        self.foster_parenting.set(true);
         let res = self.step(InBody, token);
         // FIXME: what if res is Reprocess?
-        self.foster_parenting = false;
+        self.foster_parenting.set(false);
         res
     }
 
-    fn process_chars_in_table(&mut self, token: Token) -> ProcessResult<Handle> {
+    fn process_chars_in_table(&self, token: Token) -> ProcessResult<Handle> {
         declare_tag_set!(table_outer = "table" "tbody" "tfoot" "thead" "tr");
         if self.current_node_in(table_outer) {
-            assert!(self.pending_table_text.is_empty());
-            self.orig_mode = Some(self.mode);
+            assert!(self.pending_table_text.borrow().is_empty());
+            self.orig_mode.set(Some(self.mode.get()));
             Reprocess(InTableText, token)
         } else {
             self.sink.parse_error(format_if!(
@@ -1171,10 +1198,12 @@ where
     }
 
     // https://html.spec.whatwg.org/multipage/#reset-the-insertion-mode-appropriately
-    fn reset_insertion_mode(&mut self) -> InsertionMode {
-        for (i, mut node) in self.open_elems.iter().enumerate().rev() {
+    fn reset_insertion_mode(&self) -> InsertionMode {
+        let open_elems = self.open_elems.borrow();
+        for (i, mut node) in open_elems.iter().enumerate().rev() {
             let last = i == 0usize;
-            if let (true, Some(ctx)) = (last, self.context_elem.as_ref()) {
+            let context_elem = self.context_elem.borrow();
+            if let (true, Some(ctx)) = (last, context_elem.as_ref()) {
                 node = ctx;
             }
             let name = match self.sink.elem_name(node) {
@@ -1186,7 +1215,7 @@ where
             };
             match *name {
                 local_name!("select") => {
-                    for ancestor in self.open_elems[0..i].iter().rev() {
+                    for ancestor in self.open_elems.borrow()[0..i].iter().rev() {
                         if self.html_elem_named(ancestor, local_name!("template")) {
                             return InSelect;
                         } else if self.html_elem_named(ancestor, local_name!("table")) {
@@ -1207,7 +1236,7 @@ where
                 local_name!("caption") => return InCaption,
                 local_name!("colgroup") => return InColumnGroup,
                 local_name!("table") => return InTable,
-                local_name!("template") => return *self.template_modes.last().unwrap(),
+                local_name!("template") => return *self.template_modes.borrow().last().unwrap(),
                 local_name!("head") => {
                     if !last {
                         return InHead;
@@ -1215,7 +1244,7 @@ where
                 },
                 local_name!("body") => return InBody,
                 local_name!("frameset") => return InFrameset,
-                local_name!("html") => match self.head_elem {
+                local_name!("html") => match *self.head_elem.borrow() {
                     None => return BeforeHead,
                     Some(_) => return AfterHead,
                 },
@@ -1226,7 +1255,7 @@ where
         InBody
     }
 
-    fn close_the_cell(&mut self) {
+    fn close_the_cell(&self) {
         self.generate_implied_end(cursory_implied_end);
         if self.pop_until(td_th) != 1 {
             self.sink
@@ -1235,34 +1264,35 @@ where
         self.clear_active_formatting_to_marker();
     }
 
-    fn append_text(&mut self, text: StrTendril) -> ProcessResult<Handle> {
+    fn append_text(&self, text: StrTendril) -> ProcessResult<Handle> {
         self.insert_appropriately(AppendText(text), None);
         Done
     }
 
-    fn append_comment(&mut self, text: StrTendril) -> ProcessResult<Handle> {
+    fn append_comment(&self, text: StrTendril) -> ProcessResult<Handle> {
         let comment = self.sink.create_comment(text);
         self.insert_appropriately(AppendNode(comment), None);
         Done
     }
 
-    fn append_comment_to_doc(&mut self, text: StrTendril) -> ProcessResult<Handle> {
+    fn append_comment_to_doc(&self, text: StrTendril) -> ProcessResult<Handle> {
         let comment = self.sink.create_comment(text);
         self.sink.append(&self.doc_handle, AppendNode(comment));
         Done
     }
 
-    fn append_comment_to_html(&mut self, text: StrTendril) -> ProcessResult<Handle> {
-        let target = html_elem(&self.open_elems);
+    fn append_comment_to_html(&self, text: StrTendril) -> ProcessResult<Handle> {
+        let open_elems = self.open_elems.borrow();
+        let target = html_elem(&*open_elems);
         let comment = self.sink.create_comment(text);
         self.sink.append(target, AppendNode(comment));
         Done
     }
 
     //§ creating-and-inserting-nodes
-    fn create_root(&mut self, attrs: Vec<Attribute>) {
+    fn create_root(&self, attrs: Vec<Attribute>) {
         let elem = create_element(
-            &mut self.sink,
+            &self.sink,
             QualName::new(None, ns!(html), local_name!("html")),
             attrs,
         );
@@ -1273,7 +1303,7 @@ where
 
     // https://html.spec.whatwg.org/multipage/#create-an-element-for-the-token
     fn insert_element(
-        &mut self,
+        &self,
         push: PushFlag,
         ns: Namespace,
         name: LocalName,
@@ -1287,7 +1317,7 @@ where
 
         // Step 7.
         let qname = QualName::new(None, ns, name);
-        let elem = create_element(&mut self.sink, qname.clone(), attrs.clone());
+        let elem = create_element(&self.sink, qname.clone(), attrs.clone());
 
         let insertion_point = self.appropriate_place_for_insertion(None);
         let (node1, node2) = match insertion_point {
@@ -1300,14 +1330,14 @@ where
 
         // Step 12.
         if form_associatable(qname.expanded())
-            && self.form_elem.is_some()
+            && self.form_elem.borrow().is_some()
             && !self.in_html_elem_named(local_name!("template"))
             && !(listed(qname.expanded())
                 && attrs
                     .iter()
                     .any(|a| a.name.expanded() == expanded_name!("", "form")))
         {
-            let form = self.form_elem.as_ref().unwrap().clone();
+            let form = self.form_elem.borrow().as_ref().unwrap().clone();
             let node2 = match node2 {
                 Some(ref n) => Some(n),
                 None => None,
@@ -1325,24 +1355,24 @@ where
         elem
     }
 
-    fn insert_element_for(&mut self, tag: Tag) -> Handle {
+    fn insert_element_for(&self, tag: Tag) -> Handle {
         self.insert_element(Push, ns!(html), tag.name, tag.attrs)
     }
 
-    fn insert_and_pop_element_for(&mut self, tag: Tag) -> Handle {
+    fn insert_and_pop_element_for(&self, tag: Tag) -> Handle {
         self.insert_element(NoPush, ns!(html), tag.name, tag.attrs)
     }
 
-    fn insert_phantom(&mut self, name: LocalName) -> Handle {
+    fn insert_phantom(&self, name: LocalName) -> Handle {
         self.insert_element(Push, ns!(html), name, vec![])
     }
     //§ END
 
-    fn create_formatting_element_for(&mut self, tag: Tag) -> Handle {
+    fn create_formatting_element_for(&self, tag: Tag) -> Handle {
         // FIXME: This really wants unit tests.
         let mut first_match = None;
         let mut matches = 0usize;
-        for (i, _, old_tag) in self.active_formatting_end_to_marker() {
+        for (i, _, old_tag) in self.active_formatting_end_to_marker().iter() {
             if tag.equiv_modulo_attr_order(old_tag) {
                 first_match = Some(i);
                 matches += 1;
@@ -1351,27 +1381,28 @@ where
 
         if matches >= 3 {
             self.active_formatting
+                .borrow_mut()
                 .remove(first_match.expect("matches with no index"));
         }
 
         let elem = self.insert_element(Push, ns!(html), tag.name.clone(), tag.attrs.clone());
-        self.active_formatting.push(Element(elem.clone(), tag));
+        self.active_formatting.borrow_mut().push(Element(elem.clone(), tag));
         elem
     }
 
-    fn clear_active_formatting_to_marker(&mut self) {
+    fn clear_active_formatting_to_marker(&self) {
         loop {
-            match self.active_formatting.pop() {
+            match self.active_formatting.borrow_mut().pop() {
                 None | Some(Marker) => break,
                 _ => (),
             }
         }
     }
 
-    fn process_end_tag_in_body(&mut self, tag: Tag) {
+    fn process_end_tag_in_body(&self, tag: Tag) {
         // Look back for a matching open element.
         let mut match_idx = None;
-        for (i, elem) in self.open_elems.iter().enumerate().rev() {
+        for (i, elem) in self.open_elems.borrow().iter().enumerate().rev() {
             if self.html_elem_named(elem, tag.name.clone()) {
                 match_idx = Some(i);
                 break;
@@ -1397,16 +1428,17 @@ where
 
         self.generate_implied_end_except(tag.name.clone());
 
-        if match_idx != self.open_elems.len() - 1 {
+        if match_idx != self.open_elems.borrow().len() - 1 {
             // mis-nested tags
             self.unexpected(&tag);
         }
-        self.open_elems.truncate(match_idx);
+        self.open_elems.borrow_mut().truncate(match_idx);
     }
 
-    fn handle_misnested_a_tags(&mut self, tag: &Tag) {
+    fn handle_misnested_a_tags(&self, tag: &Tag) {
         let node = unwrap_or_return!(
             self.active_formatting_end_to_marker()
+                .iter()
                 .filter(|&(_, n, _)| self.html_elem_named(n, local_name!("a")))
                 .next()
                 .map(|(_, n, _)| n.clone()),
@@ -1416,21 +1448,22 @@ where
         self.unexpected(tag);
         self.adoption_agency(local_name!("a"));
         self.position_in_active_formatting(&node)
-            .map(|index| self.active_formatting.remove(index));
+            .map(|index| self.active_formatting.borrow_mut().remove(index));
         self.remove_from_stack(&node);
     }
 
     //§ tree-construction
-    fn is_foreign(&mut self, token: &Token) -> bool {
+    fn is_foreign(&self, token: &Token) -> bool {
         if let EOFToken = *token {
             return false;
         }
 
-        if self.open_elems.is_empty() {
+        if self.open_elems.borrow().is_empty() {
             return false;
         }
 
-        let name = self.sink.elem_name(self.adjusted_current_node());
+        let current = self.adjusted_current_node();
+        let name = self.sink.elem_name(&current);
         if let ns!(html) = *name.ns {
             return false;
         }
@@ -1467,7 +1500,7 @@ where
                 CharacterTokens(..) | NullCharacterToken | TagToken(Tag { kind: StartTag, .. }) => {
                     return !self
                         .sink
-                        .is_mathml_annotation_xml_integration_point(self.adjusted_current_node());
+                        .is_mathml_annotation_xml_integration_point(&self.adjusted_current_node());
                 },
                 _ => {},
             };
@@ -1477,7 +1510,7 @@ where
     }
     //§ END
 
-    fn enter_foreign(&mut self, mut tag: Tag, ns: Namespace) -> ProcessResult<Handle> {
+    fn enter_foreign(&self, mut tag: Tag, ns: Namespace) -> ProcessResult<Handle> {
         match ns {
             ns!(mathml) => self.adjust_mathml_attributes(&mut tag),
             ns!(svg) => self.adjust_svg_attributes(&mut tag),
@@ -1494,7 +1527,7 @@ where
         }
     }
 
-    fn adjust_svg_tag_name(&mut self, tag: &mut Tag) {
+    fn adjust_svg_tag_name(&self, tag: &mut Tag) {
         let Tag { ref mut name, .. } = *tag;
         match *name {
             local_name!("altglyph") => *name = local_name!("altGlyph"),
@@ -1538,7 +1571,7 @@ where
         }
     }
 
-    fn adjust_attributes<F>(&mut self, tag: &mut Tag, mut map: F)
+    fn adjust_attributes<F>(&self, tag: &mut Tag, mut map: F)
     where
         F: FnMut(LocalName) -> Option<QualName>,
     {
@@ -1549,7 +1582,7 @@ where
         }
     }
 
-    fn adjust_svg_attributes(&mut self, tag: &mut Tag) {
+    fn adjust_svg_attributes(&self, tag: &mut Tag) {
         self.adjust_attributes(tag, |k| match k {
             local_name!("attributename") => Some(qualname!("", "attributeName")),
             local_name!("attributetype") => Some(qualname!("", "attributeType")),
@@ -1613,14 +1646,14 @@ where
         });
     }
 
-    fn adjust_mathml_attributes(&mut self, tag: &mut Tag) {
+    fn adjust_mathml_attributes(&self, tag: &mut Tag) {
         self.adjust_attributes(tag, |k| match k {
             local_name!("definitionurl") => Some(qualname!("", "definitionURL")),
             _ => None,
         });
     }
 
-    fn adjust_foreign_attributes(&mut self, tag: &mut Tag) {
+    fn adjust_foreign_attributes(&self, tag: &mut Tag) {
         self.adjust_attributes(tag, |k| match k {
             local_name!("xlink:actuate") => Some(qualname!("xlink" xlink "actuate")),
             local_name!("xlink:arcrole") => Some(qualname!("xlink" xlink "arcrole")),
@@ -1637,8 +1670,8 @@ where
         });
     }
 
-    fn foreign_start_tag(&mut self, mut tag: Tag) -> ProcessResult<Handle> {
-        let current_ns = self.sink.elem_name(self.adjusted_current_node()).ns.clone();
+    fn foreign_start_tag(&self, mut tag: Tag) -> ProcessResult<Handle> {
+        let current_ns = self.sink.elem_name(&self.adjusted_current_node()).ns.clone();
         match current_ns {
             ns!(mathml) => self.adjust_mathml_attributes(&mut tag),
             ns!(svg) => {
@@ -1658,13 +1691,13 @@ where
         }
     }
 
-    fn unexpected_start_tag_in_foreign_content(&mut self, tag: Tag) -> ProcessResult<Handle> {
+    fn unexpected_start_tag_in_foreign_content(&self, tag: Tag) -> ProcessResult<Handle> {
         self.unexpected(&tag);
         while !self.current_node_in(|n| {
             *n.ns == ns!(html) || mathml_text_integration_point(n) || svg_html_integration_point(n)
         }) {
             self.pop();
         }
-        self.step(self.mode, TagToken(tag))
+        self.step(self.mode.get(), TagToken(tag))
     }
 }

--- a/markup5ever/interface/mod.rs
+++ b/markup5ever/interface/mod.rs
@@ -19,16 +19,10 @@ use super::{LocalName, Namespace, Prefix};
 /// An [expanded name], containing the tag and the namespace.
 ///
 /// [expanded name]: https://www.w3.org/TR/REC-xml-names/#dt-expname
-#[derive(Copy, Clone, Eq, Hash)]
+#[derive(Copy, Clone, Eq, Hash, PartialEq)]
 pub struct ExpandedName<'a> {
     pub ns: &'a Namespace,
     pub local: &'a LocalName,
-}
-
-impl<'a, 'b> PartialEq<ExpandedName<'a>> for ExpandedName<'b> {
-    fn eq(&self, other: &ExpandedName<'a>) -> bool {
-        self.ns == other.ns && self.local == other.local
-    }
 }
 
 impl<'a> fmt::Debug for ExpandedName<'a> {

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -78,7 +78,7 @@ pub struct ElementFlags {
 /// # Examples
 ///
 /// Create an element like `<div class="test-class-name"></div>`:
-pub fn create_element<Sink>(sink: &mut Sink, name: QualName, attrs: Vec<Attribute>) -> Sink::Handle
+pub fn create_element<Sink>(sink: &Sink, name: QualName, attrs: Vec<Attribute>) -> Sink::Handle
 where
     Sink: TreeSink,
 {
@@ -121,10 +121,10 @@ pub trait TreeSink {
     fn finish(self) -> Self::Output;
 
     /// Signal a parse error.
-    fn parse_error(&mut self, msg: Cow<'static, str>);
+    fn parse_error(&self, msg: Cow<'static, str>);
 
     /// Get a handle to the `Document` node.
-    fn get_document(&mut self) -> Self::Handle;
+    fn get_document(&self) -> Self::Handle;
 
     /// What is the name of this element?
     ///
@@ -142,30 +142,30 @@ pub trait TreeSink {
     ///
     /// [whatwg template]: https://html.spec.whatwg.org/multipage/#the-template-element
     fn create_element(
-        &mut self,
+        &self,
         name: QualName,
         attrs: Vec<Attribute>,
         flags: ElementFlags,
     ) -> Self::Handle;
 
     /// Create a comment node.
-    fn create_comment(&mut self, text: StrTendril) -> Self::Handle;
+    fn create_comment(&self, text: StrTendril) -> Self::Handle;
 
     /// Create a Processing Instruction node.
-    fn create_pi(&mut self, target: StrTendril, data: StrTendril) -> Self::Handle;
+    fn create_pi(&self, target: StrTendril, data: StrTendril) -> Self::Handle;
 
     /// Append a node as the last child of the given node.  If this would
     /// produce adjacent sibling text nodes, it should concatenate the text
     /// instead.
     ///
     /// The child node will not already have a parent.
-    fn append(&mut self, parent: &Self::Handle, child: NodeOrText<Self::Handle>);
+    fn append(&self, parent: &Self::Handle, child: NodeOrText<Self::Handle>);
 
     /// When the insertion point is decided by the existence of a parent node of the
     /// element, we consider both possibilities and send the element which will be used
     /// if a parent node exists, along with the element to be used if there isn't one.
     fn append_based_on_parent_node(
-        &mut self,
+        &self,
         element: &Self::Handle,
         prev_element: &Self::Handle,
         child: NodeOrText<Self::Handle>,
@@ -173,28 +173,28 @@ pub trait TreeSink {
 
     /// Append a `DOCTYPE` element to the `Document` node.
     fn append_doctype_to_document(
-        &mut self,
+        &self,
         name: StrTendril,
         public_id: StrTendril,
         system_id: StrTendril,
     );
 
     /// Mark a HTML `<script>` as "already started".
-    fn mark_script_already_started(&mut self, _node: &Self::Handle) {}
+    fn mark_script_already_started(&self, _node: &Self::Handle) {}
 
     /// Indicate that a node was popped off the stack of open elements.
-    fn pop(&mut self, _node: &Self::Handle) {}
+    fn pop(&self, _node: &Self::Handle) {}
 
     /// Get a handle to a template's template contents. The tree builder
     /// promises this will never be called with something else than
     /// a template element.
-    fn get_template_contents(&mut self, target: &Self::Handle) -> Self::Handle;
+    fn get_template_contents(&self, target: &Self::Handle) -> Self::Handle;
 
     /// Do two handles refer to the same node?
     fn same_node(&self, x: &Self::Handle, y: &Self::Handle) -> bool;
 
     /// Set the document's quirks mode.
-    fn set_quirks_mode(&mut self, mode: QuirksMode);
+    fn set_quirks_mode(&self, mode: QuirksMode);
 
     /// Append a node as the sibling immediately before the given node.
     ///
@@ -204,16 +204,16 @@ pub trait TreeSink {
     /// be merged, as in the behavior of `append`.
     ///
     /// NB: `new_node` may have an old parent, from which it should be removed.
-    fn append_before_sibling(&mut self, sibling: &Self::Handle, new_node: NodeOrText<Self::Handle>);
+    fn append_before_sibling(&self, sibling: &Self::Handle, new_node: NodeOrText<Self::Handle>);
 
     /// Add each attribute to the given element, if no attribute with that name
     /// already exists. The tree builder promises this will never be called
     /// with something else than an element.
-    fn add_attrs_if_missing(&mut self, target: &Self::Handle, attrs: Vec<Attribute>);
+    fn add_attrs_if_missing(&self, target: &Self::Handle, attrs: Vec<Attribute>);
 
     /// Associate the given form-associatable element with the form element
     fn associate_with_form(
-        &mut self,
+        &self,
         _target: &Self::Handle,
         _form: &Self::Handle,
         _nodes: (&Self::Handle, Option<&Self::Handle>),
@@ -221,10 +221,10 @@ pub trait TreeSink {
     }
 
     /// Detach the given node from its parent.
-    fn remove_from_parent(&mut self, target: &Self::Handle);
+    fn remove_from_parent(&self, target: &Self::Handle);
 
     /// Remove all the children from node and append them to new_parent.
-    fn reparent_children(&mut self, node: &Self::Handle, new_parent: &Self::Handle);
+    fn reparent_children(&self, node: &Self::Handle, new_parent: &Self::Handle);
 
     /// Returns true if the adjusted current node is an HTML integration point
     /// and the token is a start tag.
@@ -233,10 +233,10 @@ pub trait TreeSink {
     }
 
     /// Called whenever the line number changes.
-    fn set_current_line(&mut self, _line_number: u64) {}
+    fn set_current_line(&self, _line_number: u64) {}
 
     /// Indicate that a `script` element is complete.
-    fn complete_script(&mut self, _node: &Self::Handle) -> NextParserState {
+    fn complete_script(&self, _node: &Self::Handle) -> NextParserState {
         NextParserState::Continue
     }
 }

--- a/markup5ever/lib.rs
+++ b/markup5ever/lib.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unexpected_cfgs)]
+
 pub use tendril;
 
 /// Create a [`SmallCharSet`], with each space-separated number stored in the set.

--- a/markup5ever/util/buffer_queue.rs
+++ b/markup5ever/util/buffer_queue.rs
@@ -18,7 +18,7 @@
 //!
 //! [`BufferQueue`]: struct.BufferQueue.html
 
-use std::{cell::RefCell, collections::VecDeque};
+use std::{cell::RefCell, collections::VecDeque, mem};
 
 use tendril::StrTendril;
 
@@ -234,6 +234,14 @@ impl BufferQueue {
         }
 
         result
+    }
+
+    pub fn replace_with(&self, other: BufferQueue) {
+        let _ = mem::replace(&mut *self.buffers.borrow_mut(), other.buffers.take());
+    }
+
+    pub fn swap_with(&self, other: &BufferQueue) {
+        mem::swap(&mut *self.buffers.borrow_mut(), &mut *other.buffers.borrow_mut());
     }
 }
 

--- a/markup5ever/util/buffer_queue.rs
+++ b/markup5ever/util/buffer_queue.rs
@@ -241,7 +241,10 @@ impl BufferQueue {
     }
 
     pub fn swap_with(&self, other: &BufferQueue) {
-        mem::swap(&mut *self.buffers.borrow_mut(), &mut *other.buffers.borrow_mut());
+        mem::swap(
+            &mut *self.buffers.borrow_mut(),
+            &mut *other.buffers.borrow_mut(),
+        );
     }
 }
 

--- a/rcdom/examples/print-rcdom.rs
+++ b/rcdom/examples/print-rcdom.rs
@@ -69,9 +69,9 @@ fn main() {
         .unwrap();
     walk(0, &dom.document);
 
-    if !dom.errors.is_empty() {
+    if !dom.errors.borrow().is_empty() {
         println!("\nParse errors:");
-        for err in dom.errors.iter() {
+        for err in dom.errors.borrow().iter() {
             println!("    {}", err);
         }
     }

--- a/rcdom/lib.rs
+++ b/rcdom/lib.rs
@@ -264,12 +264,7 @@ impl TreeSink for RcDom {
         };
     }
 
-    fn create_element(
-        &self,
-        name: QualName,
-        attrs: Vec<Attribute>,
-        flags: ElementFlags,
-    ) -> Handle {
+    fn create_element(&self, name: QualName, attrs: Vec<Attribute>, flags: ElementFlags) -> Handle {
         Node::new(NodeData::Element {
             name,
             attrs: RefCell::new(attrs),

--- a/rcdom/tests/html-tree-sink.rs
+++ b/rcdom/tests/html-tree-sink.rs
@@ -48,13 +48,10 @@ impl TreeSink for LineCountingDOM {
         self.rcdom.elem_name(target)
     }
 
-    fn create_element(
-        &self,
-        name: QualName,
-        attrs: Vec<Attribute>,
-        flags: ElementFlags,
-    ) -> Handle {
-        self.line_vec.borrow_mut().push((name.clone(), self.current_line.get()));
+    fn create_element(&self, name: QualName, attrs: Vec<Attribute>, flags: ElementFlags) -> Handle {
+        self.line_vec
+            .borrow_mut()
+            .push((name.clone(), self.current_line.get()));
         self.rcdom.create_element(name, attrs, flags)
     }
 

--- a/rcdom/tests/html-tree-sink.rs
+++ b/rcdom/tests/html-tree-sink.rs
@@ -7,10 +7,11 @@ use markup5ever::interface::{ElementFlags, NodeOrText, QuirksMode, TreeSink};
 use markup5ever::{local_name, namespace_url, ns, Attribute};
 use markup5ever_rcdom::{Handle, RcDom};
 use std::borrow::Cow;
+use std::cell::{Cell, RefCell};
 
 pub struct LineCountingDOM {
-    pub line_vec: Vec<(QualName, u64)>,
-    pub current_line: u64,
+    pub line_vec: RefCell<Vec<(QualName, u64)>>,
+    pub current_line: Cell<u64>,
     pub rcdom: RcDom,
 }
 
@@ -23,19 +24,19 @@ impl TreeSink for LineCountingDOM {
 
     type Handle = Handle;
 
-    fn parse_error(&mut self, msg: Cow<'static, str>) {
+    fn parse_error(&self, msg: Cow<'static, str>) {
         self.rcdom.parse_error(msg);
     }
 
-    fn get_document(&mut self) -> Handle {
+    fn get_document(&self) -> Handle {
         self.rcdom.get_document()
     }
 
-    fn get_template_contents(&mut self, target: &Handle) -> Handle {
+    fn get_template_contents(&self, target: &Handle) -> Handle {
         self.rcdom.get_template_contents(target)
     }
 
-    fn set_quirks_mode(&mut self, mode: QuirksMode) {
+    fn set_quirks_mode(&self, mode: QuirksMode) {
         self.rcdom.set_quirks_mode(mode)
     }
 
@@ -48,33 +49,33 @@ impl TreeSink for LineCountingDOM {
     }
 
     fn create_element(
-        &mut self,
+        &self,
         name: QualName,
         attrs: Vec<Attribute>,
         flags: ElementFlags,
     ) -> Handle {
-        self.line_vec.push((name.clone(), self.current_line));
+        self.line_vec.borrow_mut().push((name.clone(), self.current_line.get()));
         self.rcdom.create_element(name, attrs, flags)
     }
 
-    fn create_comment(&mut self, text: StrTendril) -> Handle {
+    fn create_comment(&self, text: StrTendril) -> Handle {
         self.rcdom.create_comment(text)
     }
 
-    fn create_pi(&mut self, target: StrTendril, content: StrTendril) -> Handle {
+    fn create_pi(&self, target: StrTendril, content: StrTendril) -> Handle {
         self.rcdom.create_pi(target, content)
     }
 
-    fn append(&mut self, parent: &Handle, child: NodeOrText<Handle>) {
+    fn append(&self, parent: &Handle, child: NodeOrText<Handle>) {
         self.rcdom.append(parent, child)
     }
 
-    fn append_before_sibling(&mut self, sibling: &Handle, child: NodeOrText<Handle>) {
+    fn append_before_sibling(&self, sibling: &Handle, child: NodeOrText<Handle>) {
         self.rcdom.append_before_sibling(sibling, child)
     }
 
     fn append_based_on_parent_node(
-        &mut self,
+        &self,
         element: &Handle,
         prev_element: &Handle,
         child: NodeOrText<Handle>,
@@ -84,7 +85,7 @@ impl TreeSink for LineCountingDOM {
     }
 
     fn append_doctype_to_document(
-        &mut self,
+        &self,
         name: StrTendril,
         public_id: StrTendril,
         system_id: StrTendril,
@@ -93,24 +94,24 @@ impl TreeSink for LineCountingDOM {
             .append_doctype_to_document(name, public_id, system_id);
     }
 
-    fn add_attrs_if_missing(&mut self, target: &Handle, attrs: Vec<Attribute>) {
+    fn add_attrs_if_missing(&self, target: &Handle, attrs: Vec<Attribute>) {
         self.rcdom.add_attrs_if_missing(target, attrs);
     }
 
-    fn remove_from_parent(&mut self, target: &Handle) {
+    fn remove_from_parent(&self, target: &Handle) {
         self.rcdom.remove_from_parent(target);
     }
 
-    fn reparent_children(&mut self, node: &Handle, new_parent: &Handle) {
+    fn reparent_children(&self, node: &Handle, new_parent: &Handle) {
         self.rcdom.reparent_children(node, new_parent);
     }
 
-    fn mark_script_already_started(&mut self, target: &Handle) {
+    fn mark_script_already_started(&self, target: &Handle) {
         self.rcdom.mark_script_already_started(target);
     }
 
-    fn set_current_line(&mut self, line_number: u64) {
-        self.current_line = line_number;
+    fn set_current_line(&self, line_number: u64) {
+        self.current_line.set(line_number);
     }
 }
 
@@ -118,8 +119,8 @@ impl TreeSink for LineCountingDOM {
 fn check_four_lines() {
     // Input
     let sink = LineCountingDOM {
-        line_vec: vec![],
-        current_line: 1,
+        line_vec: RefCell::new(vec![]),
+        current_line: Cell::new(1),
         rcdom: RcDom::default(),
     };
     let mut result_tok = driver::parse_document(sink, Default::default());
@@ -138,5 +139,5 @@ fn check_four_lines() {
         (QualName::new(None, ns!(html), local_name!("b")), 3),
     ];
     // Assertion
-    assert_eq!(actual.line_vec, expected);
+    assert_eq!(*actual.line_vec.borrow(), expected);
 }

--- a/rcdom/tests/xml-tokenizer.rs
+++ b/rcdom/tests/xml-tokenizer.rs
@@ -10,10 +10,10 @@
 use serde_json::{Map, Value};
 use std::borrow::Cow::Borrowed;
 use std::cell::RefCell;
+use std::env;
 use std::ffi::OsStr;
 use std::io::Read;
 use std::path::Path;
-use std::env;
 
 use util::find_tests::foreach_xml5lib_test;
 use util::runner::Test;

--- a/xml5ever/benches/xml5ever.rs
+++ b/xml5ever/benches/xml5ever.rs
@@ -15,7 +15,7 @@ use xml5ever::tokenizer::{Token, TokenSink, XmlTokenizer};
 struct Sink;
 
 impl TokenSink for Sink {
-    fn process_token(&mut self, token: Token) {
+    fn process_token(&self, token: Token) {
         // Don't use the token, but make sure we don't get
         // optimized out entirely.
         black_box(token);
@@ -52,7 +52,7 @@ fn run_bench(c: &mut Criterion, name: &str) {
 
     c.bench_function(&test_name, move |b| {
         b.iter(|| {
-            let mut tok = XmlTokenizer::new(Sink, Default::default());
+            let tok = XmlTokenizer::new(Sink, Default::default());
             let buffer = BufferQueue::default();
             // We are doing clone inside the bench function, this is not ideal, but possibly
             // necessary since our iterator consumes the underlying buffer.

--- a/xml5ever/examples/simple_xml_tokenizer.rs
+++ b/xml5ever/examples/simple_xml_tokenizer.rs
@@ -24,7 +24,7 @@ use xml5ever::tokenizer::{ParseError, Token, TokenSink, XmlTokenizer};
 struct SimpleTokenPrinter;
 
 impl TokenSink for SimpleTokenPrinter {
-    fn process_token(&mut self, token: Token) {
+    fn process_token(&self, token: Token) {
         match token {
             CharacterTokens(b) => {
                 println!("TEXT: {}", &*b);
@@ -75,7 +75,7 @@ fn main() {
     let input_buffer = BufferQueue::default();
     input_buffer.push_back(input.try_reinterpret().unwrap());
     // Here we create and run tokenizer
-    let mut tok = XmlTokenizer::new(sink, Default::default());
+    let tok = XmlTokenizer::new(sink, Default::default());
     tok.feed(&input_buffer);
     tok.end();
 }

--- a/xml5ever/examples/xml_tokenizer.rs
+++ b/xml5ever/examples/xml_tokenizer.rs
@@ -12,6 +12,7 @@
 extern crate markup5ever;
 extern crate xml5ever;
 
+use std::cell::Cell;
 use std::io;
 
 use markup5ever::buffer_queue::BufferQueue;
@@ -21,29 +22,29 @@ use xml5ever::tokenizer::{EmptyTag, EndTag, ShortTag, StartTag};
 use xml5ever::tokenizer::{PIToken, Pi};
 use xml5ever::tokenizer::{ParseError, Token, TokenSink, XmlTokenizer, XmlTokenizerOpts};
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 struct TokenPrinter {
-    in_char_run: bool,
+    in_char_run: Cell<bool>,
 }
 
 impl TokenPrinter {
-    fn is_char(&mut self, is_char: bool) {
-        match (self.in_char_run, is_char) {
+    fn is_char(&self, is_char: bool) {
+        match (self.in_char_run.get(), is_char) {
             (false, true) => print!("CHAR : \""),
             (true, false) => println!("\""),
             _ => (),
         }
-        self.in_char_run = is_char;
+        self.in_char_run.set(is_char);
     }
 
-    fn do_char(&mut self, c: char) {
+    fn do_char(&self, c: char) {
         self.is_char(true);
         print!("{}", c.escape_default().collect::<String>());
     }
 }
 
 impl TokenSink for TokenPrinter {
-    fn process_token(&mut self, token: Token) {
+    fn process_token(&self, token: Token) {
         match token {
             CharacterTokens(b) => {
                 for c in b.chars() {
@@ -88,13 +89,13 @@ impl TokenSink for TokenPrinter {
 }
 
 fn main() {
-    let mut sink = TokenPrinter { in_char_run: false };
+    let sink = TokenPrinter { in_char_run: Cell::new(false) };
     let mut input = ByteTendril::new();
     io::stdin().read_to_tendril(&mut input).unwrap();
     let input_buffer = BufferQueue::default();
     input_buffer.push_back(input.try_reinterpret().unwrap());
 
-    let mut tok = XmlTokenizer::new(
+    let tok = XmlTokenizer::new(
         sink,
         XmlTokenizerOpts {
             profile: true,
@@ -104,5 +105,5 @@ fn main() {
     );
     tok.feed(&input_buffer);
     tok.end();
-    sink.is_char(false);
+    tok.sink.is_char(false);
 }

--- a/xml5ever/examples/xml_tokenizer.rs
+++ b/xml5ever/examples/xml_tokenizer.rs
@@ -89,7 +89,9 @@ impl TokenSink for TokenPrinter {
 }
 
 fn main() {
-    let sink = TokenPrinter { in_char_run: Cell::new(false) };
+    let sink = TokenPrinter {
+        in_char_run: Cell::new(false),
+    };
     let mut input = ByteTendril::new();
     io::stdin().read_to_tendril(&mut input).unwrap();
     let input_buffer = BufferQueue::default();

--- a/xml5ever/src/driver.rs
+++ b/xml5ever/src/driver.rs
@@ -71,7 +71,7 @@ impl<Sink: TreeSink> TendrilSink<tendril::fmt::UTF8> for XmlParser<Sink> {
         self.tokenizer.sink.sink.parse_error(desc)
     }
 
-    fn finish(mut self) -> Self::Output {
+    fn finish(self) -> Self::Output {
         self.tokenizer.end();
         self.tokenizer.sink.sink.finish()
     }

--- a/xml5ever/src/lib.rs
+++ b/xml5ever/src/lib.rs
@@ -30,6 +30,7 @@
 
 #![crate_name = "xml5ever"]
 #![crate_type = "dylib"]
+#![allow(unexpected_cfgs)]
 #![deny(missing_docs)]
 
 pub use markup5ever::*;

--- a/xml5ever/src/tokenizer/char_ref/mod.rs
+++ b/xml5ever/src/tokenizer/char_ref/mod.rs
@@ -115,7 +115,7 @@ impl CharRefTokenizer {
 impl CharRefTokenizer {
     pub fn step<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         if self.result.is_some() {
@@ -135,7 +135,7 @@ impl CharRefTokenizer {
 
     fn do_begin<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         match unwrap_or_return!(tokenizer.peek(input), Stuck) {
@@ -158,7 +158,7 @@ impl CharRefTokenizer {
 
     fn do_octothorpe<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         let c = unwrap_or_return!(tokenizer.peek(input), Stuck);
@@ -179,7 +179,7 @@ impl CharRefTokenizer {
 
     fn do_numeric<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         base: u32,
         input: &BufferQueue,
     ) -> Status {
@@ -209,7 +209,7 @@ impl CharRefTokenizer {
 
     fn do_numeric_semicolon<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         match unwrap_or_return!(tokenizer.peek(input), Stuck) {
@@ -223,7 +223,7 @@ impl CharRefTokenizer {
 
     fn unconsume_numeric<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         let mut unconsume = StrTendril::from_char('#');
@@ -236,7 +236,7 @@ impl CharRefTokenizer {
         self.finish_none()
     }
 
-    fn finish_numeric<Sink: TokenSink>(&mut self, tokenizer: &mut XmlTokenizer<Sink>) -> Status {
+    fn finish_numeric<Sink: TokenSink>(&mut self, tokenizer: &XmlTokenizer<Sink>) -> Status {
         fn conv(n: u32) -> char {
             from_u32(n).expect("invalid char missed by error handling cases")
         }
@@ -272,7 +272,7 @@ impl CharRefTokenizer {
 
     fn do_named<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         let c = unwrap_or_return!(tokenizer.get_char(input), Stuck);
@@ -294,7 +294,7 @@ impl CharRefTokenizer {
         }
     }
 
-    fn emit_name_error<Sink: TokenSink>(&mut self, tokenizer: &mut XmlTokenizer<Sink>) {
+    fn emit_name_error<Sink: TokenSink>(&mut self, tokenizer: &XmlTokenizer<Sink>) {
         let msg = format_if!(
             tokenizer.opts.exact_errors,
             "Invalid character reference",
@@ -306,7 +306,7 @@ impl CharRefTokenizer {
 
     fn unconsume_name<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         input: &BufferQueue,
     ) {
         tokenizer.unconsume(input, self.name_buf_opt.take().unwrap());
@@ -314,7 +314,7 @@ impl CharRefTokenizer {
 
     fn finish_named<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         end_char: Option<char>,
         input: &BufferQueue,
     ) -> Status {
@@ -403,7 +403,7 @@ impl CharRefTokenizer {
 
     fn do_bogus_name<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         input: &BufferQueue,
     ) -> Status {
         let c = unwrap_or_return!(tokenizer.get_char(input), Stuck);
@@ -419,7 +419,7 @@ impl CharRefTokenizer {
 
     pub fn end_of_file<Sink: TokenSink>(
         &mut self,
-        tokenizer: &mut XmlTokenizer<Sink>,
+        tokenizer: &XmlTokenizer<Sink>,
         input: &BufferQueue,
     ) {
         while self.result.is_none() {

--- a/xml5ever/src/tokenizer/interface.rs
+++ b/xml5ever/src/tokenizer/interface.rs
@@ -109,15 +109,15 @@ pub enum Token {
 /// Types which can receive tokens from the tokenizer.
 pub trait TokenSink {
     /// Process a token.
-    fn process_token(&mut self, token: Token);
+    fn process_token(&self, token: Token);
 
     /// Signal to the sink that parsing has ended.
-    fn end(&mut self) {}
+    fn end(&self) {}
 
     /// The tokenizer will call this after emitting any start tag.
     /// This allows the tree builder to change the tokenizer's state.
     /// By default no state changes occur.
-    fn query_state_change(&mut self) -> Option<states::XmlState> {
+    fn query_state_change(&self) -> Option<states::XmlState> {
         None
     }
 }

--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -417,7 +417,10 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
     fn emit_current_tag(&self) {
         self.finish_attribute();
 
-        let qname = process_qname(replace(&mut *self.current_tag_name.borrow_mut(), StrTendril::new()));
+        let qname = process_qname(replace(
+            &mut *self.current_tag_name.borrow_mut(),
+            StrTendril::new(),
+        ));
 
         match self.current_tag_kind.get() {
             StartTag | EmptyTag => {},
@@ -463,7 +466,8 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
     fn consume_char_ref(&self, addnl_allowed: Option<char>) {
         // NB: The char ref tokenizer assumes we have an additional allowed
         // character iff we're tokenizing in an attribute value.
-        *self.char_ref_tokenizer.borrow_mut() = Some(Box::new(CharRefTokenizer::new(addnl_allowed)));
+        *self.char_ref_tokenizer.borrow_mut() =
+            Some(Box::new(CharRefTokenizer::new(addnl_allowed)));
     }
 
     fn emit_eof(&self) {
@@ -1116,8 +1120,12 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
 
     #[cfg(not(for_c))]
     fn dump_profile(&self) {
-        let mut results: Vec<(states::XmlState, u64)> =
-            self.state_profile.borrow().iter().map(|(s, t)| (*s, *t)).collect();
+        let mut results: Vec<(states::XmlState, u64)> = self
+            .state_profile
+            .borrow()
+            .iter()
+            .map(|(s, t)| (*s, *t))
+            .collect();
         results.sort_by(|&(_, x), &(_, y)| y.cmp(&x));
 
         let total: u64 = results
@@ -1125,7 +1133,10 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
             .map(|&(_, t)| t)
             .fold(0, ::std::ops::Add::add);
         debug!("\nTokenizer profile, in nanoseconds");
-        debug!("\n{:12}         total in token sink", self.time_in_sink.get());
+        debug!(
+            "\n{:12}         total in token sink",
+            self.time_in_sink.get()
+        );
         debug!("\n{:12}         total in tokenizer", total);
 
         for (k, v) in results.into_iter() {
@@ -1249,7 +1260,10 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
             self.current_attr_name.borrow_mut().clear();
             self.current_attr_value.borrow_mut().clear();
         } else {
-            let qname = process_qname(replace(&mut self.current_attr_name.borrow_mut(), StrTendril::new()));
+            let qname = process_qname(replace(
+                &mut self.current_attr_name.borrow_mut(),
+                StrTendril::new(),
+            ));
             let attr = Attribute {
                 name: qname.clone(),
                 value: replace(&mut self.current_attr_value.borrow_mut(), StrTendril::new()),

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -14,7 +14,7 @@ use mac::unwrap_or_return;
 use markup5ever::{local_name, namespace_prefix, namespace_url, ns};
 use std::borrow::Cow;
 use std::borrow::Cow::Borrowed;
-use std::cell::{Cell, RefCell, Ref};
+use std::cell::{Cell, Ref, RefCell};
 use std::collections::btree_map::Iter;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::fmt::{Debug, Error, Formatter};
@@ -362,7 +362,10 @@ where
         self.bind_qname(&mut tag.name);
 
         // Finally, we dump current namespace if its unneeded.
-        let x = mem::replace(&mut *self.current_namespace.borrow_mut(), NamespaceMap::empty());
+        let x = mem::replace(
+            &mut *self.current_namespace.borrow_mut(),
+            NamespaceMap::empty(),
+        );
 
         // Only start tag doesn't dump current namespace. However, <script /> is treated
         // differently than every other empty tag, so it needs to retain the current
@@ -442,7 +445,9 @@ where
     Sink: TreeSink<Handle = Handle>,
 {
     fn current_node(&self) -> Ref<Handle> {
-        Ref::map(self.open_elems.borrow(), |elems| elems.last().expect("no current element"))
+        Ref::map(self.open_elems.borrow(), |elems| {
+            elems.last().expect("no current element")
+        })
     }
 
     fn insert_appropriately(&self, child: NodeOrText<Handle>) {
@@ -583,7 +588,11 @@ where
 
     fn pop(&self) -> Handle {
         self.namespace_stack.borrow_mut().pop();
-        let node = self.open_elems.borrow_mut().pop().expect("no current element");
+        let node = self
+            .open_elems
+            .borrow_mut()
+            .pop()
+            .expect("no current element");
         self.sink.pop(&node);
         node
     }


### PR DESCRIPTION
This is incompatible with a re-entrant parsing algorithm which is required by the web platform's document.write API.