### PR TITLE
Make return type of `TreeSink::elem_name` an associated type.

### DIFF
--- a/html5ever/examples/arena.rs
+++ b/html5ever/examples/arena.rs
@@ -12,7 +12,7 @@ extern crate typed_arena;
 
 use html5ever::interface::tree_builder::{ElementFlags, NodeOrText, QuirksMode, TreeSink};
 use html5ever::tendril::{StrTendril, TendrilSink};
-use html5ever::{parse_document, Attribute, ExpandedName, QualName};
+use html5ever::{parse_document, Attribute, QualName};
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
@@ -183,6 +183,7 @@ impl<'arena> Sink<'arena> {
 impl<'arena> TreeSink for Sink<'arena> {
     type Handle = Ref<'arena>;
     type Output = Ref<'arena>;
+    type ElemName<'a> = &'a QualName where Self : 'a;
 
     fn finish(self) -> Ref<'arena> {
         self.document
@@ -202,9 +203,9 @@ impl<'arena> TreeSink for Sink<'arena> {
         ptr::eq::<Node>(*x, *y)
     }
 
-    fn elem_name<'a>(&self, target: &'a Ref<'arena>) -> ExpandedName<'a> {
+    fn elem_name(&self, target: &Ref<'arena>) -> Self::ElemName<'_> {
         match target.data {
-            NodeData::Element { ref name, .. } => name.expanded(),
+            NodeData::Element { ref name, .. } => name,
             _ => panic!("not an element!"),
         }
     }

--- a/html5ever/examples/noop-tree-builder.rs
+++ b/html5ever/examples/noop-tree-builder.rs
@@ -40,6 +40,7 @@ impl Sink {
 impl TreeSink for Sink {
     type Handle = usize;
     type Output = Self;
+    type ElemName<'a> = ExpandedName<'a>;
     fn finish(self) -> Self {
         self
     }

--- a/html5ever/examples/print-tree-actions.rs
+++ b/html5ever/examples/print-tree-actions.rs
@@ -11,7 +11,7 @@
 extern crate html5ever;
 
 use std::borrow::Cow;
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 use std::collections::HashMap;
 use std::io;
 
@@ -20,7 +20,7 @@ use html5ever::tendril::*;
 use html5ever::tree_builder::{
     AppendNode, AppendText, ElementFlags, NodeOrText, QuirksMode, TreeSink,
 };
-use html5ever::{Attribute, ExpandedName, QualName};
+use html5ever::{Attribute, QualName};
 
 struct Sink {
     next_id: Cell<usize>,
@@ -38,6 +38,7 @@ impl Sink {
 impl TreeSink for Sink {
     type Handle = usize;
     type Output = Self;
+    type ElemName<'a> = Ref<'a, QualName>;
     fn finish(self) -> Self {
         self
     }
@@ -68,13 +69,10 @@ impl TreeSink for Sink {
         x == y
     }
 
-    fn elem_name(&self, target: &usize) -> ExpandedName {
-        self.names
-            .borrow()
-            .get(target)
-            .cloned()
-            .expect("not an element")
-            .expanded()
+    fn elem_name(&self, target: &usize) -> Self::ElemName<'_> {
+        Ref::map(self.names.borrow(), |map| {
+            *map.get(target).expect("not an element")
+        })
     }
 
     fn create_element(&self, name: QualName, _: Vec<Attribute>, _: ElementFlags) -> usize {

--- a/html5ever/src/tree_builder/rules.rs
+++ b/html5ever/src/tree_builder/rules.rs
@@ -9,15 +9,18 @@
 
 // The tree builder rules, as a single, enormous nested match expression.
 
-use markup5ever::{expanded_name, local_name, namespace_prefix, namespace_url, ns};
+use crate::interface::Quirks;
 use crate::tokenizer::states::{Plaintext, Rawtext, Rcdata, ScriptData};
+use crate::tokenizer::TagKind::{EndTag, StartTag};
 use crate::tree_builder::tag_sets::*;
 use crate::tree_builder::types::*;
+use crate::tree_builder::{
+    create_element, html_elem, ElemName, NodeOrText::AppendNode, StrTendril, Tag, TreeBuilder,
+    TreeSink,
+};
 use crate::QualName;
-use crate::tree_builder::{create_element, html_elem, TreeSink, Tag, NodeOrText::AppendNode, StrTendril, TreeBuilder};
-use crate::tokenizer::TagKind::{StartTag, EndTag};
+use markup5ever::{expanded_name, local_name, namespace_prefix, namespace_url, ns};
 use std::borrow::Cow::Borrowed;
-use crate::interface::Quirks;
 
 use std::borrow::ToOwned;
 
@@ -402,7 +405,8 @@ where
 
                     let mut to_close = None;
                     for node in self.open_elems.borrow().iter().rev() {
-                        let name = self.sink.elem_name(node);
+                        let elem_name = self.sink.elem_name(node);
+                        let name = elem_name.expanded();
                         let can_close = if list {
                             close_list(name)
                         } else {
@@ -1441,8 +1445,8 @@ where
                     {
                         let open_elems = self.open_elems.borrow();
                         let node_name = self.sink.elem_name(&open_elems[stack_idx]);
-                        html = *node_name.ns == ns!(html);
-                        eq = node_name.local.eq_ignore_ascii_case(&tag.name);
+                        html = *node_name.ns() == ns!(html);
+                        eq = node_name.local_name().eq_ignore_ascii_case(&tag.name);
                     }
                     if !first && html {
                         let mode = self.mode.get();

--- a/html5ever/src/tree_builder/types.rs
+++ b/html5ever/src/tree_builder/types.rs
@@ -58,6 +58,7 @@ pub(crate) enum SplitStatus {
 /// A subset/refinement of `tokenizer::Token`.  Everything else is handled
 /// specially at the beginning of `process_token`.
 #[derive(PartialEq, Eq, Clone, Debug)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum Token {
     TagToken(Tag),
     CommentToken(StrTendril),

--- a/markup5ever/interface/mod.rs
+++ b/markup5ever/interface/mod.rs
@@ -8,12 +8,13 @@
 // except according to those terms.
 //! Types for tag and attribute names, and tree-builder functionality.
 
+use std::cell::Ref;
 use std::fmt;
 use tendril::StrTendril;
 
 pub use self::tree_builder::{create_element, AppendNode, AppendText, ElementFlags, NodeOrText};
+pub use self::tree_builder::{ElemName, NextParserState, Tracer, TreeSink};
 pub use self::tree_builder::{LimitedQuirks, NoQuirks, Quirks, QuirksMode};
-pub use self::tree_builder::{NextParserState, Tracer, TreeSink};
 use super::{LocalName, Namespace, Prefix};
 
 /// An [expanded name], containing the tag and the namespace.
@@ -23,6 +24,30 @@ use super::{LocalName, Namespace, Prefix};
 pub struct ExpandedName<'a> {
     pub ns: &'a Namespace,
     pub local: &'a LocalName,
+}
+
+impl<'a> ElemName for ExpandedName<'a> {
+    #[inline(always)]
+    fn ns(&self) -> &Namespace {
+        self.ns
+    }
+
+    #[inline(always)]
+    fn local_name(&self) -> &LocalName {
+        self.local
+    }
+}
+
+impl<'a> ElemName for Ref<'a, ExpandedName<'a>> {
+    #[inline(always)]
+    fn ns(&self) -> &Namespace {
+        self.ns
+    }
+
+    #[inline(always)]
+    fn local_name(&self) -> &LocalName {
+        self.local
+    }
 }
 
 impl<'a> fmt::Debug for ExpandedName<'a> {
@@ -239,6 +264,30 @@ pub struct QualName {
     ///
     /// ```
     pub local: LocalName,
+}
+
+impl<'a> ElemName for Ref<'a, QualName> {
+    #[inline(always)]
+    fn ns(&self) -> &Namespace {
+        &self.ns
+    }
+
+    #[inline(always)]
+    fn local_name(&self) -> &LocalName {
+        &self.local
+    }
+}
+
+impl<'a> ElemName for &'a QualName {
+    #[inline(always)]
+    fn ns(&self) -> &Namespace {
+        &self.ns
+    }
+
+    #[inline(always)]
+    fn local_name(&self) -> &LocalName {
+        &self.local
+    }
 }
 
 impl QualName {

--- a/markup5ever/serialize.rs
+++ b/markup5ever/serialize.rs
@@ -6,7 +6,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-//! Traits for serializing elements. The serializer expects the data to be xml-like (with a name,
+//! Traits for serializing elements.
+//!
+//! The serializer expects the data to be xml-like (with a name,
 //! and optional children, attrs, text, comments, doctypes, and [processing instructions]). It uses
 //! the visitor pattern, where the serializer and the serializable objects are decoupled and
 //! implement their own traits.

--- a/rcdom/lib.rs
+++ b/rcdom/lib.rs
@@ -225,6 +225,8 @@ impl TreeSink for RcDom {
 
     type Handle = Handle;
 
+    type ElemName<'a> = ExpandedName<'a> where Self : 'a;
+
     fn parse_error(&self, msg: Cow<'static, str>) {
         self.errors.borrow_mut().push(msg);
     }

--- a/rcdom/tests/html-tree-sink.rs
+++ b/rcdom/tests/html-tree-sink.rs
@@ -17,6 +17,7 @@ pub struct LineCountingDOM {
 
 impl TreeSink for LineCountingDOM {
     type Output = Self;
+    type ElemName<'a> = ExpandedName<'a>;
 
     fn finish(self) -> Self {
         self

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -20,7 +20,7 @@ use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::fmt::{Debug, Error, Formatter};
 use std::mem;
 
-pub use self::interface::{NextParserState, NodeOrText, Tracer, TreeSink};
+pub use self::interface::{ElemName, NextParserState, NodeOrText, Tracer, TreeSink};
 use self::types::*;
 use crate::interface::{self, create_element, AppendNode, Attribute, QualName};
 use crate::interface::{AppendText, ExpandedName};
@@ -535,7 +535,7 @@ where
         self.open_elems
             .borrow()
             .iter()
-            .any(|a| self.sink.elem_name(a) == tag.name.expanded())
+            .any(|a| self.sink.elem_name(a).expanded() == tag.name.expanded())
     }
 
     // Pop elements until an element from the set has been popped.  Returns the
@@ -557,7 +557,7 @@ where
         TagSet: Fn(ExpandedName) -> bool,
     {
         // FIXME: take namespace into consideration:
-        set(self.sink.elem_name(&self.current_node()))
+        set(self.sink.elem_name(&self.current_node()).expanded())
     }
 
     fn close_tag(&self, tag: Tag) -> XmlProcessResult {
@@ -567,7 +567,7 @@ where
             &tag.name
         );
 
-        if *self.sink.elem_name(&self.current_node()).local != tag.name.local {
+        if *self.sink.elem_name(&self.current_node()).local_name() != tag.name.local {
             self.sink
                 .parse_error(Borrowed("Current node doesn't match tag"));
         }


### PR DESCRIPTION
Fixes #552

This allows this type to be owned or contain data protected by a RefCell or Mutex. It can also simply be `ExpandedName` - the type which was previously the return type of `TreeSink::elem_name`.

I have not yet had a chance to test this, but I believe this ought to fix my issue.