### PR TITLE
Bump version numbers (html:0.29, xml:0.20, markup:0.14)

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html5ever"
-version = "0.28.0"
+version = "0.29.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -17,7 +17,7 @@ trace_tokenizer = []
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.13", path = "../markup5ever" }
+markup5ever = { version = "0.14", path = "../markup5ever" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.13.0"
+version = "0.14.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -16,9 +16,9 @@ path = "lib.rs"
 
 [dependencies]
 tendril = "0.4"
-html5ever = { version = "0.28", path = "../html5ever" }
-markup5ever = { version = "0.13", path = "../markup5ever" }
-xml5ever = { version = "0.19", path = "../xml5ever" }
+html5ever = { version = "0.29", path = "../html5ever" }
+markup5ever = { version = "0.14", path = "../markup5ever" }
+xml5ever = { version = "0.20", path = "../xml5ever" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml5ever"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["The xml5ever project developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -19,7 +19,7 @@ trace_tokenizer = []
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.13", path = "../markup5ever" }
+markup5ever = { version = "0.14", path = "../markup5ever" }
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
@jdm Any chance of a new release with the changes in [#553](https://github.com/servo/html5ever/pull/553)?