### PR TITLE
Add libtest-mimic

### DIFF
--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -21,6 +21,7 @@ markup5ever = { version = "0.14", path = "../markup5ever" }
 xml5ever = { version = "0.20", path = "../xml5ever" }
 
 [dev-dependencies]
+libtest-mimic = "0.8.1"
 serde_json = "1.0"
 
 [[test]]

--- a/rcdom/tests/html-tokenizer.rs
+++ b/rcdom/tests/html-tokenizer.rs
@@ -28,7 +28,7 @@ use std::io::Read;
 use std::path::Path;
 use std::{char, env};
 
-use util::runner::Test;
+use util::runner::{run_all, Test};
 
 mod util {
     pub mod runner;
@@ -481,7 +481,5 @@ fn tests(src_dir: &Path) -> Vec<Test> {
 }
 
 fn main() {
-    for test in tests(Path::new(env!("CARGO_MANIFEST_DIR"))) {
-        test.run();
-    }
+    run_all(tests(Path::new(env!("CARGO_MANIFEST_DIR"))));
 }

--- a/rcdom/tests/html-tree-builder.rs
+++ b/rcdom/tests/html-tree-builder.rs
@@ -24,7 +24,7 @@ use html5ever::tendril::{StrTendril, TendrilSink};
 use html5ever::{parse_document, parse_fragment, ParseOpts};
 use html5ever::{LocalName, QualName};
 use rcdom::{Handle, NodeData, RcDom};
-use util::runner::Test;
+use util::runner::{run_all, Test};
 
 mod util {
     pub mod runner;
@@ -297,7 +297,5 @@ fn main() {
         }
     }
 
-    for test in tests(src_dir, &ignores) {
-        test.run();
-    }
+    run_all(tests(src_dir, &ignores));
 }

--- a/rcdom/tests/util/runner.rs
+++ b/rcdom/tests/util/runner.rs
@@ -7,11 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use libtest_mimic::{Arguments, Trial};
+
 /// Simple container for storing tests for later execution
 pub struct Test {
     pub name: String,
     pub skip: bool,
-    pub test: Box<dyn Fn()>,
+    pub test: Box<dyn Fn() + Send + Sync>,
 }
 
 impl Test {
@@ -29,4 +31,15 @@ impl Test {
             println!(" ok");
         }
     }
+}
+
+pub fn run_all(tests: Vec<Test>) {
+    let mut harness_tests = Vec::new();
+
+    for test in tests {
+        let harness_test = Trial::test(test.name.clone(), move || Ok(test.run()));
+        harness_tests.push(harness_test);
+    }
+    let args = Arguments::from_args();
+    libtest_mimic::run(&args, harness_tests).exit();
 }

--- a/rcdom/tests/util/runner.rs
+++ b/rcdom/tests/util/runner.rs
@@ -37,7 +37,10 @@ pub fn run_all(tests: Vec<Test>) {
     let mut harness_tests = Vec::new();
 
     for test in tests {
-        let harness_test = Trial::test(test.name.clone(), move || Ok(test.run()));
+        let harness_test = Trial::test(test.name.clone(), move || {
+            test.run();
+            Ok(())
+        });
         harness_tests.push(harness_test);
     }
     let args = Arguments::from_args();

--- a/rcdom/tests/xml-tokenizer.rs
+++ b/rcdom/tests/xml-tokenizer.rs
@@ -16,7 +16,7 @@ use std::io::Read;
 use std::path::Path;
 
 use util::find_tests::foreach_xml5lib_test;
-use util::runner::Test;
+use util::runner::{run_all, Test};
 
 use markup5ever::buffer_queue::BufferQueue;
 use xml5ever::tendril::{SliceExt, StrTendril};
@@ -372,7 +372,5 @@ fn tests(src_dir: &Path) -> Vec<Test> {
 }
 
 fn main() {
-    for test in tests(Path::new(env!("CARGO_MANIFEST_DIR"))) {
-        test.run();
-    }
+    run_all(tests(Path::new(env!("CARGO_MANIFEST_DIR"))));
 }

--- a/rcdom/tests/xml-tree-builder.rs
+++ b/rcdom/tests/xml-tree-builder.rs
@@ -15,7 +15,7 @@ use std::io::BufRead;
 use std::path::Path;
 use std::{env, fs, io, iter, mem};
 use util::find_tests::foreach_xml5lib_test;
-use util::runner::Test;
+use util::runner::{run_all, Test};
 use xml5ever::driver::parse_document;
 use xml5ever::tendril::TendrilSink;
 
@@ -236,7 +236,5 @@ fn main() {
         }
     }
 
-    for test in tests(src_dir, &ignores) {
-        test.run();
-    }
+    run_all(tests(src_dir, &ignores));
 }


### PR DESCRIPTION
https://github.com/servo/html5ever/pull/528 regressed the DX
significantly, add a lighter and more maintained test harness to get
basic functionality like "run one test" back.
