### PR TITLE
docs(html5ever): Add `Cargo.toml` keywords

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -8,6 +8,7 @@ description = "High-performance browser-grade HTML5 parser"
 documentation = "https://docs.rs/html5ever"
 build = "build.rs"
 categories = [ "parser-implementations", "web-programming" ]
+keywords = ["html", "html5", "parser", "parsing"]
 edition = "2021"
 readme = "../README.md"
 


### PR DESCRIPTION
crates.io seems wholly unconvinced that [`html5ever` is an "html parser" when sorting by 'Relevance'](https://crates.io/search?q=html%20parser). Hopefully this will clear up the confusion for it