### PR TITLE
Publish html5ever 0.29.1 and markup5ever 0.14.1.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install stable toolchain
         run: |
           rustup set profile minimal
-          rustup override set 1.65.0
+          rustup override set 1.70.0
 
       - run: cargo check --lib --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ members = [
 
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.70.0"
+
 [workspace.dependencies]
 match_token = { path = "match_token" }
 

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -10,6 +10,7 @@ categories = [ "parser-implementations", "web-programming" ]
 keywords = ["html", "html5", "parser", "parsing"]
 edition = "2021"
 readme = "../README.md"
+rust-version.workspace = true
 
 [features]
 trace_tokenizer = []

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html5ever"
-version = "0.29.0"
+version = "0.29.1"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/markup5ever"
 build = "build.rs"
 categories = [ "parser-implementations", "web-programming" ]
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.14.0"
+version = "0.14.1"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/rcdom/tests/html-tokenizer.rs
+++ b/rcdom/tests/html-tokenizer.rs
@@ -377,7 +377,7 @@ fn mk_tests(tests: &mut Vec<Test>, filename: &str, js: &Value) {
     // the input and output.
     if obj
         .get(&"doubleEscaped".to_string())
-        .map_or(false, |j| j.get_bool())
+        .is_some_and(|j| j.get_bool())
     {
         match unescape(&input) {
             None => return,

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["xml", "xml5", "parser", "parsing"]
 exclude = ["xml5lib-tests/*"]
 categories = ["parser-implementations", "web-programming"]
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 trace_tokenizer = []

--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -62,7 +62,7 @@ fn process_qname(tag_name: StrTendril) -> QualName {
     //     a:b
     // Since StrTendril are UTF-8, we know that minimal size in bytes must be
     // three bytes minimum.
-    let split = if (*tag_name).as_bytes().len() < 3 {
+    let split = if (*tag_name).len() < 3 {
         None
     } else {
         QualNameTokenizer::new((*tag_name).as_bytes()).run()
@@ -71,7 +71,7 @@ fn process_qname(tag_name: StrTendril) -> QualName {
     match split {
         None => QualName::new(None, ns!(), LocalName::from(&*tag_name)),
         Some(col) => {
-            let len = (*tag_name).as_bytes().len() as u32;
+            let len = (*tag_name).len() as u32;
             let prefix = tag_name.subtendril(0, col);
             let local = tag_name.subtendril(col + 1, len - col - 1);
             let ns = ns!(); // Actual namespace URL set in XmlTreeBuilder::bind_qname


### PR DESCRIPTION
#568 added new methods to a public trait, but they have default implementations so this can be treated as a minor version bump (https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-default-item).