### PR TITLE
nit: VS Code and Idea exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /data/bench/uncommitted
 target
+.idea
+.vscode
 Cargo.lock
 *.racertmp


### PR DESCRIPTION
Adds VSCode and Idea RustRover folder to .gitignore