### PR TITLE
Bump `string_cache_codegen` to `0.5.4`

### DIFF
--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.14.1"
+version = "0.14.2"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -21,5 +21,5 @@ tendril = "0.4"
 log = "0.4"
 
 [build-dependencies]
-string_cache_codegen = "0.5.1"
+string_cache_codegen = "0.5.4"
 phf_codegen = "0.11"


### PR DESCRIPTION
Bumping version of string cache codegen to `0.5.4` to stabilize `generated_rs` atom's write order.

I assume `html5ever` and `xml5ever` will auto-update their dependencies and pickup latest `markup5ever`.

Fix #573 