### PR TITLE
Publish html5ever 0.29.2 and markup5ever 0.15.0

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html5ever"
-version = "0.29.1"
+version = "0.29.2"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -18,7 +18,7 @@ trace_tokenizer = []
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.14", path = "../markup5ever" }
+markup5ever = { version = "0.15", path = "../markup5ever" }
 match_token = { workspace = true }
 
 [dev-dependencies]

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.14.2"
+version = "0.15.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 [dependencies]
 tendril = "0.4"
 html5ever = { version = "0.29", path = "../html5ever" }
-markup5ever = { version = "0.14", path = "../markup5ever" }
+markup5ever = { version = "0.15", path = "../markup5ever" }
 xml5ever = { version = "0.20", path = "../xml5ever" }
 
 [dev-dependencies]

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -20,7 +20,7 @@ trace_tokenizer = []
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.14", path = "../markup5ever" }
+markup5ever = { version = "0.15", path = "../markup5ever" }
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
https://github.com/servo/html5ever/pull/578 made a breaking change to markup5ever: [any change to trait item signatures](https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature)
