### PR TITLE
Attempt of getting <pre> to not parse inner contents similar to <script>

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .vscode
 Cargo.lock
 *.racertmp
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,91 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
+        "path": "/nix/store/b309kyd5hrvrrf5z5xbqglmb1hhm8n6p-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1736320768,
+        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1737685583,
+        "narHash": "sha256-p+NVABRpGi+pT+xxf9HcLcFVxG6L+vEEy+NwzB9T0f8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "eb64cbcc8eee0fa87ebded92805280d2ec97415a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+# please read flake introduction here:
+# https://fasterthanli.me/series/building-a-rust-service-with-nix/part-10#a-flake-with-a-dev-shell
+{
+  description = "The fairsync importer prototype flake";
+  inputs = {
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs =
+  { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          platform_packages =
+            if pkgs.stdenv.isLinux then
+              with pkgs; [ ]
+            else if pkgs.stdenv.isDarwin then
+              with pkgs.darwin.apple_sdk.frameworks; [
+                CoreFoundation
+                Security
+                SystemConfiguration
+              ]
+            else
+              throw "unsupported platform";
+        in
+        with pkgs;
+        rec {
+          trunk = pkgs.callPackage ./trunk.nix {
+            inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
+          };
+          #leptosfmt = pkgs.callPackage ./leptosfmt.nix {};
+
+          devShells.default = mkShell {
+            buildInputs = [
+              rust
+              wasm-pack
+              firefox
+              trunk                    # required to bundle the frontend
+              binaryen                 # required to minify WASM files with wasm-opt
+              git
+              pkg-config
+              just                     # task runner
+              #nodejs                   # required to install tailwind plugins
+            ];
+          };
+        }
+      );
+}

--- a/html5ever/src/tokenizer/interface.rs
+++ b/html5ever/src/tokenizer/interface.rs
@@ -75,6 +75,7 @@ pub enum Token {
 pub enum TokenSinkResult<Handle> {
     Continue,
     Script(Handle),
+    PreData(Handle),
     Plaintext,
     RawData(states::RawKind),
 }

--- a/html5ever/src/tokenizer/states.rs
+++ b/html5ever/src/tokenizer/states.rs
@@ -35,6 +35,7 @@ pub enum RawKind {
     Rcdata,
     Rawtext,
     ScriptData,
+    PreData,
     ScriptDataEscaped(ScriptEscapeKind),
 }
 

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -394,7 +394,6 @@ where
                 },
                 PreData(pre_data) => {
                     println!("here1 PreData(node)");
-                    todo!();
                     assert!(more_tokens.is_empty());
                     return tokenizer::TokenSinkResult::PreData(pre_data);
                 }

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -31,12 +31,12 @@ use std::iter::{Enumerate, Rev};
 use std::{fmt, slice};
 
 use crate::tokenizer::states::RawKind;
+use crate::tokenizer::TagKind;
 use crate::tree_builder::tag_sets::*;
 use crate::util::str::to_escaped_string;
 use log::{debug, log_enabled, warn, Level};
 use mac::format_if;
 use markup5ever::{expanded_name, local_name, namespace_prefix, namespace_url, ns};
-use crate::tokenizer::TagKind;
 
 pub use self::PushFlag::*;
 
@@ -82,7 +82,7 @@ impl Default for TreeBuilderOpts {
             drop_doctype: false,
             ignore_missing_rules: false,
             quirks_mode: NoQuirks,
-            parse_pre: false,
+            parse_pre: true,
         }
     }
 }
@@ -326,10 +326,10 @@ where
 
     fn debug_step(&self, mode: InsertionMode, token: &Token) {
         println!(
-                "processing {} in insertion mode {:?}",
-                to_escaped_string(token),
-                mode
-            );
+            "processing {} in insertion mode {:?}",
+            to_escaped_string(token),
+            mode
+        );
     }
 
     fn process_to_completion(&self, mut token: Token) -> TokenSinkResult<Handle> {
@@ -396,7 +396,7 @@ where
                     println!("here1 PreData(node)");
                     assert!(more_tokens.is_empty());
                     return tokenizer::TokenSinkResult::PreData(pre_data);
-                }
+                },
                 ToPlaintext => {
                     assert!(more_tokens.is_empty());
                     return tokenizer::TokenSinkResult::Plaintext;
@@ -524,15 +524,15 @@ where
                     return tokenizer::TokenSinkResult::Continue;
                 }
             },
-// qknight
+            // qknight
             tokenizer::TagToken(x) => {
                 println!("TagToken: {}", x.name);
                 if *x.name == *"pre" {
-                    if x.kind == TagKind::StartTag { 
+                    if x.kind == TagKind::StartTag {
                         println!("start tag pre");
                         // Read everything until </pre> as raw text
                         // let mut pre_content = String::new();
-                        
+
                         // while let Some(token) = self.sink.next() {
                         //     match token {
                         //         Token::TagToken(ref tag) if tag.kind == TagKind::End && tag.name == local_name!("pre") => {

--- a/html5ever/src/tree_builder/rules.rs
+++ b/html5ever/src/tree_builder/rules.rs
@@ -41,6 +41,7 @@ where
     Sink: TreeSink<Handle = Handle>,
 {
     pub(crate) fn step(&self, mode: InsertionMode, token: Token) -> ProcessResult<Handle> {
+        println!("step");
         self.debug_step(mode, &token);
 
         match mode {
@@ -402,11 +403,6 @@ where
                 }
 
                 tag @ <pre> => {
-                    // self.close_p_element_in_button_scope();
-                    // self.insert_element_for(tag);
-                    // self.ignore_lf.set(true);
-                    // self.frameset_ok.set(false);
-                    // self.to_raw_text_mode(PreData)
                     let elem = create_element(
                         &self.sink, QualName::new(None, ns!(html), local_name!("pre")),
                         tag.attrs);
@@ -416,7 +412,6 @@ where
                     self.insert_appropriately(AppendNode(elem.clone()), None);
                     self.open_elems.borrow_mut().push(elem);
                     self.to_raw_text_mode(PreData)
-
                 }
 
                 tag @ <form> => {
@@ -796,10 +791,9 @@ where
                     if tag.name == local_name!("script") {
                         return Script(node);
                     }
-                    // if tag.name == local_name!("pre") {
-                    //     println!("here be pre");
-                    //     return PreData(node);
-                    // }
+                    if tag.name == local_name!("pre") {
+                        return ProcessResult::PreData(node);
+                    }
                     Done
                 }
 
@@ -1438,6 +1432,7 @@ where
     }
 
     pub(crate) fn step_foreign(&self, token: Token) -> ProcessResult<Handle> {
+        println!("step_foreign");
         match_token!(token {
             NullCharacterToken => {
                 self.unexpected(&token);

--- a/html5ever/src/tree_builder/types.rs
+++ b/html5ever/src/tree_builder/types.rs
@@ -75,6 +75,7 @@ pub(crate) enum ProcessResult<Handle> {
     #[allow(dead_code)] // FIXME
     ReprocessForeign(Token),
     Script(Handle),
+    PreData(Handle),
     ToPlaintext,
     ToRawData(RawKind),
 }

--- a/rcdom/examples/hello_xml.rs
+++ b/rcdom/examples/hello_xml.rs
@@ -19,7 +19,7 @@ use xml5ever::tree_builder::TreeSink;
 fn main() {
     // To parse a string into a tree of nodes, we need to invoke
     // `parse_document` and supply it with a TreeSink implementation (RcDom).
-    let dom: RcDom = parse_document(RcDom::default(), Default::default()).one("<hello>XML</hello>");
+    let dom: RcDom = parse_document(RcDom::default(), Default::default()).one("<hello>XML</hello><pre>asdf</pre>");
 
     // Do some processing
     let doc = &dom.document;

--- a/rcdom/examples/hello_xml.rs
+++ b/rcdom/examples/hello_xml.rs
@@ -19,7 +19,8 @@ use xml5ever::tree_builder::TreeSink;
 fn main() {
     // To parse a string into a tree of nodes, we need to invoke
     // `parse_document` and supply it with a TreeSink implementation (RcDom).
-    let dom: RcDom = parse_document(RcDom::default(), Default::default()).one("<hello>XML</hello><pre>asdf</pre>");
+    let dom: RcDom = parse_document(RcDom::default(), Default::default())
+        .one("<hello>XML</hello><pre>asdf</pre>");
 
     // Do some processing
     let doc = &dom.document;

--- a/rcdom/examples/html2html.rs
+++ b/rcdom/examples/html2html.rs
@@ -34,11 +34,18 @@ fn main() {
         },
         ..Default::default()
     };
-    let stdin = io::stdin();
+
+    let input = "<hello>XML</hello><pre>\n<bad> </bad>text-in  pre</pre><p>asdf</p><script>script</html> magic string</script>";
+    println!("-------- {} ----------", input);
     let dom = parse_document(RcDom::default(), opts)
-        .from_utf8()
-        .read_from(&mut stdin.lock())
-        .unwrap();
+    .one(input);
+
+    // let stdin = io::stdin();
+    // let dom = parse_document(RcDom::default(), opts)
+    //     .from_utf8()
+    //     .read_from(&mut stdin.lock())
+    //     .unwrap();
+
 
     // The validator.nu HTML2HTML always prints a doctype at the very beginning.
     io::stdout()

--- a/rcdom/examples/html2html.rs
+++ b/rcdom/examples/html2html.rs
@@ -30,6 +30,7 @@ fn main() {
     let opts = ParseOpts {
         tree_builder: TreeBuilderOpts {
             drop_doctype: true,
+            parse_pre: false,
             ..Default::default()
         },
         ..Default::default()
@@ -37,15 +38,13 @@ fn main() {
 
     let input = "<hello>XML</hello><pre>\n<bad> </bad>text-in  pre</pre><p>asdf</p><script>script</html> magic string</script>";
     println!("-------- {} ----------", input);
-    let dom = parse_document(RcDom::default(), opts)
-    .one(input);
+    let dom = parse_document(RcDom::default(), opts).one(input);
 
     // let stdin = io::stdin();
     // let dom = parse_document(RcDom::default(), opts)
     //     .from_utf8()
     //     .read_from(&mut stdin.lock())
     //     .unwrap();
-
 
     // The validator.nu HTML2HTML always prints a doctype at the very beginning.
     io::stdout()

--- a/rcdom/examples/print-rcdom.rs
+++ b/rcdom/examples/print-rcdom.rs
@@ -34,7 +34,7 @@ fn walk(indent: usize, handle: &Handle) {
         } => println!("<!DOCTYPE {name} \"{public_id}\" \"{system_id}\">"),
 
         NodeData::Text { ref contents } => {
-            println!("#text: {}", contents.borrow().escape_default())
+            print!("{}", contents.borrow().escape_default())
         },
 
         NodeData::Comment { ref contents } => println!("<!-- {} -->", contents.escape_default()),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+channel = "stable"
+targets = [
+  "x86_64-unknown-linux-musl", # used for the backend
+  "wasm32-unknown-unknown"     # used for the frontend
+]

--- a/trunk.nix
+++ b/trunk.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, openssl, libiconv,
+  CoreServices, Security, SystemConfiguration
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "trunk";
+  version = "0.21.4";
+
+  src = fetchFromGitHub {
+    owner = "trunk-rs";
+    repo = "trunk";
+    rev = "v${version}";
+    sha256 = "sha256-tU0Xob0dS1+rrfRVitwOe0K1AG05LHlGPHhFL0yOjxM=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = if stdenv.isDarwin
+    then [ libiconv CoreServices Security SystemConfiguration]
+    else [ openssl ];
+
+  # requires network
+  checkFlags = [ "--skip=tools::tests::download_and_install_binaries" ];
+
+  cargoHash = "sha256-iuxACtr91qWzojKWaieAd6kk/q9j5JSD1Fa50oCKogA=";
+
+  postConfigure = ''
+    cargo metadata --offline
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/trunk-rs/trunk";
+    description = "Build, bundle & ship your Rust WASM application to the web";
+    maintainers = with maintainers; [ freezeboy flosse ];
+    license = with licenses; [ asl20 ];
+  };
+}


### PR DESCRIPTION
This branch is used to implement the fix required to the issue: https://github.com/servo/html5ever/issues/580

# Motivation

With the current implementation the parser will evaluate arbitraty html tags inside a `<pre>...</pre>` and with this patch, `<pre>` will behave more like `<script>`.

This behaviour should be optional as sometimes it also makes sense to parse tags inside a `<pre>`, for instance for styling but most often the content inside a `<pre>` should be pretty much ignored and copied 1:1 from the source document into the generated output document and not reformatted (removing spaces, newlines or tabs) or should the parsed content have any influence on the overal consistenty of the document. 

That said: 

* `<html><pre></html>test   foo</pre></html>` should not be fixed into 
* `<html><pre>test foo</pre></html>`

# Status

branch: **servo_issue_580** with hash: **2094a85f5260b23397c4a89fbf50dcba883219e6**

This evaluates: 

`<hello>XML</hello><pre>\n<bad> </bad>text-in  pre</pre><p>asdf</p><script>script</html> magic string</script>`

into

`<html><head></head><body><hello>XML</hello><pre>\n&lt;bad&gt; &lt;/bad&gt;text-in  pre</pre><p>asdf</p><script>script</html> magic string</script></body></html>`

This shows that the content inside the `<pre>...</pre>` is grabbed and not parsed already. Yet the result should be no HTML escaped string but rather a 1:1 copy of the original tags.

This can be evaluated by running:

`clear && cargo run --example html2html`

# Todo

* [x] Figure out why: `process_to_completion` is called for `<script>` but not for `<pre>`
* [x] Implement an option to the parser to include parsing of `<pre>...</pre>` content or not
* [ ] Write the PreData as String and not HTML escaped.
* [x] Write a bunch of tests so make sure it works