### PR TITLE
Bump xml5ever version to 0.20.1

### DIFF
--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml5ever"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["The xml5ever project developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"


### PR DESCRIPTION
Extend to https://github.com/servo/html5ever/pull/581
Bump xml5ever version to 0.20.1