### PR TITLE
Store xml namespace attributes for later serialization

### DIFF
--- a/rcdom/tests/xml-driver.rs
+++ b/rcdom/tests/xml-driver.rs
@@ -99,3 +99,39 @@ fn assert_serialization(text: &'static str, dom: RcDom) {
     serialize::serialize(&mut serialized, &document, Default::default()).unwrap();
     assert_eq!(String::from_utf8(serialized).unwrap(), text);
 }
+
+#[test]
+fn xmlns_on_root() {
+    assert_serialization(
+       r##"<svg xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg">
+    <sodipodi:namedview>
+        ...
+    </sodipodi:namedview>
+
+    <path d="..." sodipodi:nodetypes="cccc"></path>
+</svg>"##,
+        driver::parse_document(RcDom::default(), Default::default())
+            .from_utf8()
+            .one(r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
+    <sodipodi:namedview>
+        ...
+    </sodipodi:namedview>
+
+    <path d="..." sodipodi:nodetypes="cccc"/>
+</svg>"##.as_bytes()),
+    );
+}
+
+#[test]
+fn xmlns_applies_to_attr() {
+    assert_serialization(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
+    <path d="..." sodipodi:nodetypes="cccc"></path>
+</svg>"##,
+        driver::parse_document(RcDom::default(), Default::default())
+            .from_utf8()
+            .one(r##"<svg xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg">
+    <path d="..." sodipodi:nodetypes="cccc"/>
+</svg>"##.as_bytes()),
+    );
+}

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -149,24 +149,6 @@ impl<Wr: Write> Serializer for XmlSerializer<Wr> {
 
         self.writer.write_all(b"<")?;
         self.qual_name(&name)?;
-        if let Some(current_namespace) = self.namespace_stack.0.last() {
-            for (prefix, url_opt) in current_namespace.get_scope_iter() {
-                self.writer.write_all(b" xmlns")?;
-                if let Some(ref p) = *prefix {
-                    self.writer.write_all(b":")?;
-                    self.writer.write_all(p.as_bytes())?;
-                }
-
-                self.writer.write_all(b"=\"")?;
-                let url = if let Some(ref a) = *url_opt {
-                    a.as_bytes()
-                } else {
-                    b""
-                };
-                self.writer.write_all(url)?;
-                self.writer.write_all(b"\"")?;
-            }
-        }
         for (name, value) in attrs {
             self.writer.write_all(b" ")?;
             self.qual_attr_name(name)?;


### PR DESCRIPTION
Fixes #569

This is @jdm's `xmlns-attrs` branch posted in #569, plus an update to `xml5lib-tests` by @Ygg01 (https://github.com/servo/html5ever/issues/569#issuecomment-2661417199)