### PR TITLE
xml5ever: Bubble parser blocking scripts to the caller instead of the TreeSink

### DIFF
--- a/html5ever/src/driver.rs
+++ b/html5ever/src/driver.rs
@@ -10,10 +10,10 @@
 //! High-level interface to the parser.
 
 use crate::buffer_queue::BufferQueue;
-use crate::tokenizer::{Tokenizer, TokenizerOpts, TokenizerResult};
+use crate::tokenizer::{Tokenizer, TokenizerOpts};
 use crate::tree_builder::{create_element, TreeBuilder, TreeBuilderOpts, TreeSink};
 use crate::{Attribute, QualName};
-
+use markup5ever::TokenizerResult;
 use std::borrow::Cow;
 
 use crate::tendril;

--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -25,7 +25,7 @@ use crate::util::str::lower_ascii_letter;
 
 use log::{debug, trace};
 use mac::format_if;
-use markup5ever::{namespace_url, ns, small_char_set};
+use markup5ever::{namespace_url, ns, small_char_set, TokenizerResult};
 use std::borrow::Cow::{self, Borrowed};
 use std::cell::{Cell, RefCell, RefMut};
 use std::collections::BTreeMap;
@@ -42,13 +42,6 @@ pub mod states;
 pub enum ProcessResult<Handle> {
     Continue,
     Suspend,
-    Script(Handle),
-}
-
-#[must_use]
-#[derive(Debug)]
-pub enum TokenizerResult<Handle> {
-    Done,
     Script(Handle),
 }
 

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -9,9 +9,7 @@
 
 //! The HTML5 tree builder.
 
-pub use crate::interface::{
-    create_element, ElemName, ElementFlags, NextParserState, Tracer, TreeSink,
-};
+pub use crate::interface::{create_element, ElemName, ElementFlags, Tracer, TreeSink};
 pub use crate::interface::{AppendNode, AppendText, Attribute, NodeOrText};
 pub use crate::interface::{LimitedQuirks, NoQuirks, Quirks, QuirksMode};
 

--- a/markup5ever/interface/mod.rs
+++ b/markup5ever/interface/mod.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use tendril::StrTendril;
 
 pub use self::tree_builder::{create_element, AppendNode, AppendText, ElementFlags, NodeOrText};
-pub use self::tree_builder::{ElemName, NextParserState, Tracer, TreeSink};
+pub use self::tree_builder::{ElemName, Tracer, TreeSink};
 pub use self::tree_builder::{LimitedQuirks, NoQuirks, Quirks, QuirksMode};
 use super::{LocalName, Namespace, Prefix};
 
@@ -58,6 +58,13 @@ impl fmt::Debug for ExpandedName<'_> {
             write!(f, "{{{}}}:{}", self.ns, self.local)
         }
     }
+}
+
+#[must_use]
+#[derive(Debug)]
+pub enum TokenizerResult<Handle> {
+    Done,
+    Script(Handle),
 }
 
 /// Helper to quickly create an expanded name.

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -43,17 +43,6 @@ pub enum QuirksMode {
     NoQuirks,
 }
 
-/// Whether to interrupt further parsing of the current input until
-/// the next explicit resumption of the tokenizer, or continue without
-/// any interruption.
-#[derive(PartialEq, Eq, Copy, Clone, Hash, Debug)]
-pub enum NextParserState {
-    /// Stop further parsing.
-    Suspend,
-    /// Continue without interruptions.
-    Continue,
-}
-
 /// Special properties of an element, useful for tagging elements with this information.
 #[derive(Default)]
 #[non_exhaustive]
@@ -255,11 +244,6 @@ pub trait TreeSink {
 
     /// Called whenever the line number changes.
     fn set_current_line(&self, _line_number: u64) {}
-
-    /// Indicate that a `script` element is complete.
-    fn complete_script(&self, _node: &Self::Handle) -> NextParserState {
-        NextParserState::Continue
-    }
 
     fn allow_declarative_shadow_roots(&self, _intended_parent: &Self::Handle) -> bool {
         true

--- a/markup5ever/lib.rs
+++ b/markup5ever/lib.rs
@@ -45,6 +45,6 @@ mod util {
     pub mod smallcharset;
 }
 
-pub use interface::{Attribute, ExpandedName, QualName};
+pub use interface::{Attribute, ExpandedName, QualName, TokenizerResult};
 pub use util::smallcharset::SmallCharSet;
 pub use util::*;

--- a/xml5ever/benches/xml5ever.rs
+++ b/xml5ever/benches/xml5ever.rs
@@ -10,15 +10,18 @@ use criterion::{black_box, Criterion};
 
 use markup5ever::buffer_queue::BufferQueue;
 use xml5ever::tendril::*;
-use xml5ever::tokenizer::{Token, TokenSink, XmlTokenizer};
+use xml5ever::tokenizer::{ProcessResult, Token, TokenSink, XmlTokenizer};
 
 struct Sink;
 
 impl TokenSink for Sink {
-    fn process_token(&self, token: Token) {
+    type Handle = ();
+
+    fn process_token(&self, token: Token) -> ProcessResult<()> {
         // Don't use the token, but make sure we don't get
         // optimized out entirely.
         black_box(token);
+        ProcessResult::Continue
     }
 }
 
@@ -58,9 +61,9 @@ fn run_bench(c: &mut Criterion, name: &str) {
             // necessary since our iterator consumes the underlying buffer.
             for buf in input.clone().into_iter() {
                 buffer.push_back(buf);
-                tok.feed(&buffer);
+                let _ = tok.feed(&buffer);
             }
-            tok.feed(&buffer);
+            let _ = tok.feed(&buffer);
             tok.end();
         })
     });

--- a/xml5ever/examples/simple_xml_tokenizer.rs
+++ b/xml5ever/examples/simple_xml_tokenizer.rs
@@ -16,7 +16,7 @@ use std::io;
 
 use markup5ever::buffer_queue::BufferQueue;
 use xml5ever::tendril::{ByteTendril, ReadExt};
-use xml5ever::tokenizer::{CharacterTokens, NullCharacterToken, TagToken};
+use xml5ever::tokenizer::{CharacterTokens, NullCharacterToken, ProcessResult, TagToken};
 use xml5ever::tokenizer::{CommentToken, PIToken, Pi};
 use xml5ever::tokenizer::{Doctype, DoctypeToken, EOFToken};
 use xml5ever::tokenizer::{ParseError, Token, TokenSink, XmlTokenizer};
@@ -24,7 +24,9 @@ use xml5ever::tokenizer::{ParseError, Token, TokenSink, XmlTokenizer};
 struct SimpleTokenPrinter;
 
 impl TokenSink for SimpleTokenPrinter {
-    fn process_token(&self, token: Token) {
+    type Handle = ();
+
+    fn process_token(&self, token: Token) -> ProcessResult<()> {
         match token {
             CharacterTokens(b) => {
                 println!("TEXT: {}", &*b);
@@ -55,7 +57,8 @@ impl TokenSink for SimpleTokenPrinter {
             }) => {
                 println!("<!DOCTYPE {name:?} {public_id:?}>");
             },
-        }
+        };
+        ProcessResult::Continue
     }
 }
 
@@ -76,6 +79,6 @@ fn main() {
     input_buffer.push_back(input.try_reinterpret().unwrap());
     // Here we create and run tokenizer
     let tok = XmlTokenizer::new(sink, Default::default());
-    tok.feed(&input_buffer);
+    let _ = tok.feed(&input_buffer);
     tok.end();
 }

--- a/xml5ever/examples/xml_tokenizer.rs
+++ b/xml5ever/examples/xml_tokenizer.rs
@@ -17,7 +17,7 @@ use std::io;
 
 use markup5ever::buffer_queue::BufferQueue;
 use xml5ever::tendril::{ByteTendril, ReadExt};
-use xml5ever::tokenizer::{CharacterTokens, NullCharacterToken, TagToken};
+use xml5ever::tokenizer::{CharacterTokens, NullCharacterToken, ProcessResult, TagToken};
 use xml5ever::tokenizer::{EmptyTag, EndTag, ShortTag, StartTag};
 use xml5ever::tokenizer::{PIToken, Pi};
 use xml5ever::tokenizer::{ParseError, Token, TokenSink, XmlTokenizer, XmlTokenizerOpts};
@@ -44,7 +44,9 @@ impl TokenPrinter {
 }
 
 impl TokenSink for TokenPrinter {
-    fn process_token(&self, token: Token) {
+    type Handle = ();
+
+    fn process_token(&self, token: Token) -> ProcessResult<()> {
         match token {
             CharacterTokens(b) => {
                 for c in b.chars() {
@@ -84,7 +86,9 @@ impl TokenSink for TokenPrinter {
                 self.is_char(false);
                 println!("OTHER: {token:?}");
             },
-        }
+        };
+
+        ProcessResult::Continue
     }
 }
 
@@ -105,7 +109,7 @@ fn main() {
             ..Default::default()
         },
     );
-    tok.feed(&input_buffer);
+    let _ = tok.feed(&input_buffer);
     tok.end();
     tok.sink.is_char(false);
 }

--- a/xml5ever/src/driver.rs
+++ b/xml5ever/src/driver.rs
@@ -63,7 +63,8 @@ impl<Sink: TreeSink> TendrilSink<tendril::fmt::UTF8> for XmlParser<Sink> {
 
     fn process(&mut self, t: StrTendril) {
         self.input_buffer.push_back(t);
-        self.tokenizer.feed(&self.input_buffer);
+        // FIXME: Properly support </script> somehow.
+        let _ = self.tokenizer.feed(&self.input_buffer);
     }
 
     // FIXME: Is it too noisy to report every character decoding error?

--- a/xml5ever/src/tokenizer/interface.rs
+++ b/xml5ever/src/tokenizer/interface.rs
@@ -10,13 +10,12 @@
 use std::borrow::Cow;
 
 use crate::tendril::StrTendril;
+use crate::tokenizer::ProcessResult;
 use crate::{Attribute, QualName};
 
 pub use self::TagKind::{EmptyTag, EndTag, ShortTag, StartTag};
 pub use self::Token::{CharacterTokens, EOFToken, NullCharacterToken, ParseError};
 pub use self::Token::{CommentToken, DoctypeToken, PIToken, TagToken};
-
-use super::states;
 
 /// Tag kind denotes which kind of tag did we encounter.
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
@@ -108,16 +107,12 @@ pub enum Token {
 
 /// Types which can receive tokens from the tokenizer.
 pub trait TokenSink {
+    /// Handle to a DOM script element
+    type Handle;
+
     /// Process a token.
-    fn process_token(&self, token: Token);
+    fn process_token(&self, token: Token) -> ProcessResult<Self::Handle>;
 
     /// Signal to the sink that parsing has ended.
     fn end(&self) {}
-
-    /// The tokenizer will call this after emitting any start tag.
-    /// This allows the tree builder to change the tokenizer's state.
-    /// By default no state changes occur.
-    fn query_state_change(&self) -> Option<states::XmlState> {
-        None
-    }
 }

--- a/xml5ever/src/tree_builder/types.rs
+++ b/xml5ever/src/tree_builder/types.rs
@@ -34,7 +34,8 @@ pub enum Token {
     Eof,
 }
 
-pub enum XmlProcessResult {
+pub enum XmlProcessResult<Handle> {
     Done,
     Reprocess(XmlPhase, Token),
+    Script(Handle),
 }


### PR DESCRIPTION
This is the same approach used by html5ever, which will hopefully allow unifying their API a bit as part of the effort for encoding support.

This is a breaking change. The TreeSink::complete_script method (among other things) is removed.