### PR TITLE
Bump xml5ever, markup5ever and html5ever versions

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html5ever"
-version = "0.30.0"
+version = "0.31.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -18,7 +18,7 @@ trace_tokenizer = []
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.15", path = "../markup5ever" }
+markup5ever = { version = "0.16", path = "../markup5ever" }
 match_token = { workspace = true }
 
 [dev-dependencies]

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.15.0"
+version = "0.16.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -16,9 +16,9 @@ path = "lib.rs"
 
 [dependencies]
 tendril = "0.4"
-html5ever = { version = "0.30", path = "../html5ever" }
-markup5ever = { version = "0.15", path = "../markup5ever" }
-xml5ever = { version = "0.21", path = "../xml5ever" }
+html5ever = { version = "0.31", path = "../html5ever" }
+markup5ever = { version = "0.16", path = "../markup5ever" }
+xml5ever = { version = "0.22", path = "../xml5ever" }
 
 [dev-dependencies]
 libtest-mimic = "0.8.1"

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml5ever"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["The xml5ever project developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"
@@ -20,7 +20,7 @@ trace_tokenizer = []
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.15", path = "../markup5ever" }
+markup5ever = { version = "0.16", path = "../markup5ever" }
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
This should have been done as part of https://github.com/servo/html5ever/pull/591. I forgot that servo depends on the crates.io version of html5ever, not the git repository. So to upgrade in servo we need to release new versions of all three crates.

All three crates have received breaking changes since the last PR.

cc @mrobinson since I think you have permission to create new releases?