### PR TITLE
Don't import enum variants into the global namespace in html5ever

### DIFF
--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -35,8 +35,6 @@ use log::{debug, log_enabled, warn, Level};
 use mac::format_if;
 use markup5ever::{expanded_name, local_name, namespace_prefix, namespace_url, ns};
 
-pub use self::PushFlag::*;
-
 #[macro_use]
 mod tag_sets;
 
@@ -154,7 +152,7 @@ where
         TreeBuilder {
             opts,
             sink,
-            mode: Cell::new(Initial),
+            mode: Cell::new(InsertionMode::Initial),
             orig_mode: Cell::new(None),
             template_modes: Default::default(),
             pending_table_text: Default::default(),
@@ -186,7 +184,7 @@ where
         let context_is_template =
             sink.elem_name(&context_elem).expanded() == expanded_name!(html "template");
         let template_modes = if context_is_template {
-            RefCell::new(vec![InTemplate])
+            RefCell::new(vec![InsertionMode::InTemplate])
         } else {
             RefCell::new(vec![])
         };
@@ -194,7 +192,7 @@ where
         let tb = TreeBuilder {
             opts,
             sink,
-            mode: Cell::new(Initial),
+            mode: Cell::new(InsertionMode::Initial),
             orig_mode: Cell::new(None),
             template_modes,
             pending_table_text: Default::default(),
@@ -303,8 +301,8 @@ where
         print!("    active_formatting:");
         for entry in self.active_formatting.borrow().iter() {
             match entry {
-                &Marker => print!(" Marker"),
-                Element(h, _) => {
+                &FormatEntry::Marker => print!(" Marker"),
+                FormatEntry::Element(h, _) => {
                     let name = self.sink.elem_name(h);
                     match *name.ns() {
                         ns!(html) => print!(" {}", name.local_name()),
@@ -334,7 +332,7 @@ where
         loop {
             let should_have_acknowledged_self_closing_flag = matches!(
                 token,
-                TagToken(Tag {
+                Token::Tag(Tag {
                     self_closing: true,
                     kind: StartTag,
                     ..
@@ -347,7 +345,7 @@ where
                 self.step(mode, token)
             };
             match result {
-                Done => {
+                ProcessResult::Done => {
                     if should_have_acknowledged_self_closing_flag {
                         self.sink
                             .parse_error(Borrowed("Unacknowledged self-closing tag"));
@@ -357,38 +355,42 @@ where
                         tokenizer::TokenSinkResult::Continue
                     );
                 },
-                DoneAckSelfClosing => {
+                ProcessResult::DoneAckSelfClosing => {
                     token = unwrap_or_return!(
                         more_tokens.pop_front(),
                         tokenizer::TokenSinkResult::Continue
                     );
                 },
-                Reprocess(m, t) => {
+                ProcessResult::Reprocess(m, t) => {
                     self.mode.set(m);
                     token = t;
                 },
-                ReprocessForeign(t) => {
+                ProcessResult::ReprocessForeign(t) => {
                     token = t;
                 },
-                SplitWhitespace(mut buf) => {
+                ProcessResult::SplitWhitespace(mut buf) => {
                     let p = buf.pop_front_char_run(|c| c.is_ascii_whitespace());
                     let (first, is_ws) = unwrap_or_return!(p, tokenizer::TokenSinkResult::Continue);
-                    let status = if is_ws { Whitespace } else { NotWhitespace };
-                    token = CharacterTokens(status, first);
+                    let status = if is_ws {
+                        SplitStatus::Whitespace
+                    } else {
+                        SplitStatus::NotWhitespace
+                    };
+                    token = Token::Characters(status, first);
 
                     if buf.len32() > 0 {
-                        more_tokens.push_back(CharacterTokens(NotSplit, buf));
+                        more_tokens.push_back(Token::Characters(SplitStatus::NotSplit, buf));
                     }
                 },
-                Script(node) => {
+                ProcessResult::Script(node) => {
                     assert!(more_tokens.is_empty());
                     return tokenizer::TokenSinkResult::Script(node);
                 },
-                ToPlaintext => {
+                ProcessResult::ToPlaintext => {
                     assert!(more_tokens.is_empty());
                     return tokenizer::TokenSinkResult::Plaintext;
                 },
-                ToRawData(k) => {
+                ProcessResult::ToRawData(k) => {
                     assert!(more_tokens.is_empty());
                     return tokenizer::TokenSinkResult::RawData(k);
                 },
@@ -414,10 +416,10 @@ where
             if self.html_elem_named(&target, local_name!("template")) {
                 // No foster parenting (inside template).
                 let contents = self.sink.get_template_contents(&target);
-                return LastChild(contents);
+                return InsertionPoint::LastChild(contents);
             } else {
                 // No foster parenting (the common case).
-                return LastChild(target);
+                return InsertionPoint::LastChild(target);
             }
         }
 
@@ -427,23 +429,25 @@ where
         while let Some(elem) = iter.next() {
             if self.html_elem_named(elem, local_name!("template")) {
                 let contents = self.sink.get_template_contents(elem);
-                return LastChild(contents);
+                return InsertionPoint::LastChild(contents);
             } else if self.html_elem_named(elem, local_name!("table")) {
-                return TableFosterParenting {
+                return InsertionPoint::TableFosterParenting {
                     element: elem.clone(),
                     prev_element: (*iter.peek().unwrap()).clone(),
                 };
             }
         }
         let html_elem = self.html_elem();
-        LastChild(html_elem.clone())
+        InsertionPoint::LastChild(html_elem.clone())
     }
 
     fn insert_at(&self, insertion_point: InsertionPoint<Handle>, child: NodeOrText<Handle>) {
         match insertion_point {
-            LastChild(parent) => self.sink.append(&parent, child),
-            BeforeSibling(sibling) => self.sink.append_before_sibling(&sibling, child),
-            TableFosterParenting {
+            InsertionPoint::LastChild(parent) => self.sink.append(&parent, child),
+            InsertionPoint::BeforeSibling(sibling) => {
+                self.sink.append_before_sibling(&sibling, child)
+            },
+            InsertionPoint::TableFosterParenting {
                 element,
                 prev_element,
             } => self
@@ -474,7 +478,7 @@ where
             },
 
             tokenizer::DoctypeToken(dt) => {
-                if self.mode.get() == Initial {
+                if self.mode.get() == InsertionMode::Initial {
                     let (err, quirk) = data::doctype_error_and_quirks(&dt, self.opts.iframe_srcdoc);
                     if err {
                         self.sink.parse_error(format_if!(
@@ -499,7 +503,7 @@ where
                     }
                     self.set_quirks_mode(quirk);
 
-                    self.mode.set(BeforeHtml);
+                    self.mode.set(InsertionMode::BeforeHtml);
                     return tokenizer::TokenSinkResult::Continue;
                 } else {
                     self.sink.parse_error(format_if!(
@@ -512,10 +516,10 @@ where
                 }
             },
 
-            tokenizer::TagToken(x) => TagToken(x),
-            tokenizer::CommentToken(x) => CommentToken(x),
-            tokenizer::NullCharacterToken => NullCharacterToken,
-            tokenizer::EOFToken => EOFToken,
+            tokenizer::TagToken(x) => Token::Tag(x),
+            tokenizer::CommentToken(x) => Token::Comment(x),
+            tokenizer::NullCharacterToken => Token::NullCharacter,
+            tokenizer::EOFToken => Token::Eof,
 
             tokenizer::CharacterTokens(mut x) => {
                 if ignore_lf && x.starts_with("\n") {
@@ -524,7 +528,7 @@ where
                 if x.is_empty() {
                     return tokenizer::TokenSinkResult::Continue;
                 }
-                CharacterTokens(NotSplit, x)
+                Token::Characters(SplitStatus::NotSplit, x)
             },
         };
 
@@ -567,8 +571,8 @@ impl<'a, Handle> Iterator for ActiveFormattingIter<'a, Handle> {
     type Item = (usize, &'a Handle, &'a Tag);
     fn next(&mut self) -> Option<(usize, &'a Handle, &'a Tag)> {
         match self.iter.next() {
-            None | Some((_, &Marker)) => None,
-            Some((i, Element(h, t))) => Some((i, h, t)),
+            None | Some((_, &FormatEntry::Marker)) => None,
+            Some((i, FormatEntry::Element(h, t))) => Some((i, h, t)),
         }
     }
 }
@@ -614,7 +618,7 @@ where
             to_escaped_string(_thing),
             self.mode.get()
         ));
-        Done
+        ProcessResult::Done
     }
 
     fn assert_named(&self, node: &Handle, name: LocalName) {
@@ -645,7 +649,7 @@ where
     }
 
     fn stop_parsing(&self) -> ProcessResult<Handle> {
-        Done
+        ProcessResult::Done
     }
 
     //§ parsing-elements-that-contain-only-text
@@ -655,8 +659,8 @@ where
     // `process_token` of a start tag returns!
     fn to_raw_text_mode(&self, k: RawKind) -> ProcessResult<Handle> {
         self.orig_mode.set(Some(self.mode.get()));
-        self.mode.set(Text);
-        ToRawData(k)
+        self.mode.set(InsertionMode::Text);
+        ProcessResult::ToRawData(k)
     }
 
     // The generic raw text / RCDATA parsing algorithm.
@@ -812,11 +816,11 @@ where
 
                 // 13.7.
                 let tag = match self.active_formatting.borrow()[node_formatting_index] {
-                    Element(ref h, ref t) => {
+                    FormatEntry::Element(ref h, ref t) => {
                         assert!(self.sink.same_node(h, &node));
                         t.clone()
                     },
-                    Marker => panic!("Found marker during adoption agency"),
+                    FormatEntry::Marker => panic!("Found marker during adoption agency"),
                 };
                 // FIXME: Is there a way to avoid cloning the attributes twice here (once on their
                 // own, once as part of t.clone() above)?
@@ -827,7 +831,7 @@ where
                 );
                 self.open_elems.borrow_mut()[node_index] = new_element.clone();
                 self.active_formatting.borrow_mut()[node_formatting_index] =
-                    Element(new_element.clone(), tag);
+                    FormatEntry::Element(new_element.clone(), tag);
                 node = new_element;
 
                 // 13.8.
@@ -857,7 +861,7 @@ where
                 QualName::new(None, ns!(html), fmt_elem_tag.name.clone()),
                 fmt_elem_tag.attrs.clone(),
             );
-            let new_entry = Element(new_element.clone(), fmt_elem_tag);
+            let new_entry = FormatEntry::Element(new_element.clone(), fmt_elem_tag);
 
             // 16.
             self.sink.reparent_children(&furthest_block, &new_element);
@@ -933,8 +937,8 @@ where
 
     fn is_marker_or_open(&self, entry: &FormatEntry<Handle>) -> bool {
         match *entry {
-            Marker => true,
-            Element(ref node, _) => self
+            FormatEntry::Marker => true,
+            FormatEntry::Element(ref node, _) => self
                 .open_elems
                 .borrow()
                 .iter()
@@ -967,15 +971,22 @@ where
 
         loop {
             let tag = match self.active_formatting.borrow()[entry_index] {
-                Element(_, ref t) => t.clone(),
-                Marker => panic!("Found marker during formatting element reconstruction"),
+                FormatEntry::Element(_, ref t) => t.clone(),
+                FormatEntry::Marker => {
+                    panic!("Found marker during formatting element reconstruction")
+                },
             };
 
             // FIXME: Is there a way to avoid cloning the attributes twice here (once on their own,
             // once as part of t.clone() above)?
-            let new_element =
-                self.insert_element(Push, ns!(html), tag.name.clone(), tag.attrs.clone());
-            self.active_formatting.borrow_mut()[entry_index] = Element(new_element, tag);
+            let new_element = self.insert_element(
+                PushFlag::Push,
+                ns!(html),
+                tag.name.clone(),
+                tag.attrs.clone(),
+            );
+            self.active_formatting.borrow_mut()[entry_index] =
+                FormatEntry::Element(new_element, tag);
             if entry_index == self.active_formatting.borrow().len() - 1 {
                 break;
             }
@@ -1184,7 +1195,7 @@ where
     fn foster_parent_in_body(&self, token: Token) -> ProcessResult<Handle> {
         warn!("foster parenting not implemented");
         self.foster_parenting.set(true);
-        let res = self.step(InBody, token);
+        let res = self.step(InsertionMode::InBody, token);
         // FIXME: what if res is Reprocess?
         self.foster_parenting.set(false);
         res
@@ -1195,7 +1206,7 @@ where
         if self.current_node_in(table_outer) {
             assert!(self.pending_table_text.borrow().is_empty());
             self.orig_mode.set(Some(self.mode.get()));
-            Reprocess(InTableText, token)
+            ProcessResult::Reprocess(InsertionMode::InTableText, token)
         } else {
             self.sink.parse_error(format_if!(
                 self.opts.exact_errors,
@@ -1228,42 +1239,42 @@ where
                 local_name!("select") => {
                     for ancestor in self.open_elems.borrow()[0..i].iter().rev() {
                         if self.html_elem_named(ancestor, local_name!("template")) {
-                            return InSelect;
+                            return InsertionMode::InSelect;
                         } else if self.html_elem_named(ancestor, local_name!("table")) {
-                            return InSelectInTable;
+                            return InsertionMode::InSelectInTable;
                         }
                     }
-                    return InSelect;
+                    return InsertionMode::InSelect;
                 },
                 local_name!("td") | local_name!("th") => {
                     if !last {
-                        return InCell;
+                        return InsertionMode::InCell;
                     }
                 },
-                local_name!("tr") => return InRow,
+                local_name!("tr") => return InsertionMode::InRow,
                 local_name!("tbody") | local_name!("thead") | local_name!("tfoot") => {
-                    return InTableBody;
+                    return InsertionMode::InTableBody;
                 },
-                local_name!("caption") => return InCaption,
-                local_name!("colgroup") => return InColumnGroup,
-                local_name!("table") => return InTable,
+                local_name!("caption") => return InsertionMode::InCaption,
+                local_name!("colgroup") => return InsertionMode::InColumnGroup,
+                local_name!("table") => return InsertionMode::InTable,
                 local_name!("template") => return *self.template_modes.borrow().last().unwrap(),
                 local_name!("head") => {
                     if !last {
-                        return InHead;
+                        return InsertionMode::InHead;
                     }
                 },
-                local_name!("body") => return InBody,
-                local_name!("frameset") => return InFrameset,
+                local_name!("body") => return InsertionMode::InBody,
+                local_name!("frameset") => return InsertionMode::InFrameset,
                 local_name!("html") => match *self.head_elem.borrow() {
-                    None => return BeforeHead,
-                    Some(_) => return AfterHead,
+                    None => return InsertionMode::BeforeHead,
+                    Some(_) => return InsertionMode::AfterHead,
                 },
 
                 _ => (),
             }
         }
-        InBody
+        InsertionMode::InBody
     }
 
     fn close_the_cell(&self) {
@@ -1277,19 +1288,19 @@ where
 
     fn append_text(&self, text: StrTendril) -> ProcessResult<Handle> {
         self.insert_appropriately(AppendText(text), None);
-        Done
+        ProcessResult::Done
     }
 
     fn append_comment(&self, text: StrTendril) -> ProcessResult<Handle> {
         let comment = self.sink.create_comment(text);
         self.insert_appropriately(AppendNode(comment), None);
-        Done
+        ProcessResult::Done
     }
 
     fn append_comment_to_doc(&self, text: StrTendril) -> ProcessResult<Handle> {
         let comment = self.sink.create_comment(text);
         self.sink.append(&self.doc_handle, AppendNode(comment));
-        Done
+        ProcessResult::Done
     }
 
     fn append_comment_to_html(&self, text: StrTendril) -> ProcessResult<Handle> {
@@ -1297,7 +1308,7 @@ where
         let target = html_elem(&open_elems);
         let comment = self.sink.create_comment(text);
         self.sink.append(target, AppendNode(comment));
-        Done
+        ProcessResult::Done
     }
 
     //§ creating-and-inserting-nodes
@@ -1332,8 +1343,10 @@ where
 
         let insertion_point = self.appropriate_place_for_insertion(None);
         let (node1, node2) = match insertion_point {
-            LastChild(ref p) | BeforeSibling(ref p) => (p.clone(), None),
-            TableFosterParenting {
+            InsertionPoint::LastChild(ref p) | InsertionPoint::BeforeSibling(ref p) => {
+                (p.clone(), None)
+            },
+            InsertionPoint::TableFosterParenting {
                 ref element,
                 ref prev_element,
             } => (element.clone(), Some(prev_element.clone())),
@@ -1356,23 +1369,23 @@ where
         self.insert_at(insertion_point, AppendNode(elem.clone()));
 
         match push {
-            Push => self.push(&elem),
-            NoPush => (),
+            PushFlag::Push => self.push(&elem),
+            PushFlag::NoPush => (),
         }
         // FIXME: Remove from the stack if we can't append?
         elem
     }
 
     fn insert_element_for(&self, tag: Tag) -> Handle {
-        self.insert_element(Push, ns!(html), tag.name, tag.attrs)
+        self.insert_element(PushFlag::Push, ns!(html), tag.name, tag.attrs)
     }
 
     fn insert_and_pop_element_for(&self, tag: Tag) -> Handle {
-        self.insert_element(NoPush, ns!(html), tag.name, tag.attrs)
+        self.insert_element(PushFlag::NoPush, ns!(html), tag.name, tag.attrs)
     }
 
     fn insert_phantom(&self, name: LocalName) -> Handle {
-        self.insert_element(Push, ns!(html), name, vec![])
+        self.insert_element(PushFlag::Push, ns!(html), name, vec![])
     }
 
     /// <https://html.spec.whatwg.org/multipage/parsing.html#insert-an-element-at-the-adjusted-insertion-location>
@@ -1403,8 +1416,10 @@ where
         let adjusted_insertion_location = self.appropriate_place_for_insertion(None);
 
         let (intended_parent, _node2) = match adjusted_insertion_location {
-            LastChild(ref p) | BeforeSibling(ref p) => (p.clone(), None),
-            TableFosterParenting {
+            InsertionPoint::LastChild(ref p) | InsertionPoint::BeforeSibling(ref p) => {
+                (p.clone(), None)
+            },
+            InsertionPoint::TableFosterParenting {
                 ref element,
                 ref prev_element,
             } => (element.clone(), Some(prev_element.clone())),
@@ -1467,17 +1482,22 @@ where
                 .remove(first_match.expect("matches with no index"));
         }
 
-        let elem = self.insert_element(Push, ns!(html), tag.name.clone(), tag.attrs.clone());
+        let elem = self.insert_element(
+            PushFlag::Push,
+            ns!(html),
+            tag.name.clone(),
+            tag.attrs.clone(),
+        );
         self.active_formatting
             .borrow_mut()
-            .push(Element(elem.clone(), tag));
+            .push(FormatEntry::Element(elem.clone(), tag));
         elem
     }
 
     fn clear_active_formatting_to_marker(&self) {
         loop {
             match self.active_formatting.borrow_mut().pop() {
-                None | Some(Marker) => break,
+                None | Some(FormatEntry::Marker) => break,
                 _ => (),
             }
         }
@@ -1535,7 +1555,7 @@ where
 
     //§ tree-construction
     fn is_foreign(&self, token: &Token) -> bool {
-        if let EOFToken = *token {
+        if let Token::Eof = *token {
             return false;
         }
 
@@ -1552,8 +1572,8 @@ where
 
         if mathml_text_integration_point(name) {
             match *token {
-                CharacterTokens(..) | NullCharacterToken => return false,
-                TagToken(Tag {
+                Token::Characters(..) | Token::NullCharacter => return false,
+                Token::Tag(Tag {
                     kind: StartTag,
                     ref name,
                     ..
@@ -1566,20 +1586,22 @@ where
 
         if svg_html_integration_point(name) {
             match *token {
-                CharacterTokens(..) | NullCharacterToken => return false,
-                TagToken(Tag { kind: StartTag, .. }) => return false,
+                Token::Characters(..) | Token::NullCharacter => return false,
+                Token::Tag(Tag { kind: StartTag, .. }) => return false,
                 _ => (),
             }
         }
 
         if let expanded_name!(mathml "annotation-xml") = name {
             match *token {
-                TagToken(Tag {
+                Token::Tag(Tag {
                     kind: StartTag,
                     name: local_name!("svg"),
                     ..
                 }) => return false,
-                CharacterTokens(..) | NullCharacterToken | TagToken(Tag { kind: StartTag, .. }) => {
+                Token::Characters(..)
+                | Token::NullCharacter
+                | Token::Tag(Tag { kind: StartTag, .. }) => {
                     return !self
                         .sink
                         .is_mathml_annotation_xml_integration_point(&self.adjusted_current_node());
@@ -1601,11 +1623,11 @@ where
         self.adjust_foreign_attributes(&mut tag);
 
         if tag.self_closing {
-            self.insert_element(NoPush, ns, tag.name, tag.attrs);
-            DoneAckSelfClosing
+            self.insert_element(PushFlag::NoPush, ns, tag.name, tag.attrs);
+            ProcessResult::DoneAckSelfClosing
         } else {
-            self.insert_element(Push, ns, tag.name, tag.attrs);
-            Done
+            self.insert_element(PushFlag::Push, ns, tag.name, tag.attrs);
+            ProcessResult::Done
         }
     }
 
@@ -1769,11 +1791,11 @@ where
         self.adjust_foreign_attributes(&mut tag);
         if tag.self_closing {
             // FIXME(#118): <script /> in SVG
-            self.insert_element(NoPush, current_ns, tag.name, tag.attrs);
-            DoneAckSelfClosing
+            self.insert_element(PushFlag::NoPush, current_ns, tag.name, tag.attrs);
+            ProcessResult::DoneAckSelfClosing
         } else {
-            self.insert_element(Push, current_ns, tag.name, tag.attrs);
-            Done
+            self.insert_element(PushFlag::Push, current_ns, tag.name, tag.attrs);
+            ProcessResult::Done
         }
     }
 
@@ -1784,6 +1806,6 @@ where
         }) {
             self.pop();
         }
-        self.step(self.mode.get(), TagToken(tag))
+        self.step(self.mode.get(), Token::Tag(tag))
     }
 }

--- a/html5ever/src/tree_builder/rules.rs
+++ b/html5ever/src/tree_builder/rules.rs
@@ -45,29 +45,29 @@ where
 
         match mode {
             //§ the-initial-insertion-mode
-            Initial => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, _) => Done,
-                CommentToken(text) => self.append_comment_to_doc(text),
+            InsertionMode::Initial => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, _) => ProcessResult::Done,
+                Token::Comment(text) => self.append_comment_to_doc(text),
                 token => {
                     if !self.opts.iframe_srcdoc {
                         self.unexpected(&token);
                         self.set_quirks_mode(Quirks);
                     }
-                    Reprocess(BeforeHtml, token)
+                    ProcessResult::Reprocess(InsertionMode::BeforeHtml, token)
                 }
             }),
 
             //§ the-before-html-insertion-mode
-            BeforeHtml => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, _) => Done,
-                CommentToken(text) => self.append_comment_to_doc(text),
+            InsertionMode::BeforeHtml => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, _) => ProcessResult::Done,
+                Token::Comment(text) => self.append_comment_to_doc(text),
 
                 tag @ <html> => {
                     self.create_root(tag.attrs);
-                    self.mode.set(BeforeHead);
-                    Done
+                    self.mode.set(InsertionMode::BeforeHead);
+                    ProcessResult::Done
                 }
 
                 </head> </body> </html> </br> => else,
@@ -76,22 +76,22 @@ where
 
                 token => {
                     self.create_root(vec!());
-                    Reprocess(BeforeHead, token)
+                    ProcessResult::Reprocess(InsertionMode::BeforeHead, token)
                 }
             }),
 
             //§ the-before-head-insertion-mode
-            BeforeHead => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, _) => Done,
-                CommentToken(text) => self.append_comment(text),
+            InsertionMode::BeforeHead => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, _) => ProcessResult::Done,
+                Token::Comment(text) => self.append_comment(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
                 tag @ <head> => {
                     *self.head_elem.borrow_mut() = Some(self.insert_element_for(tag));
-                    self.mode.set(InHead);
-                    Done
+                    self.mode.set(InsertionMode::InHead);
+                    ProcessResult::Done
                 }
 
                 </head> </body> </html> </br> => else,
@@ -100,23 +100,23 @@ where
 
                 token => {
                     *self.head_elem.borrow_mut() = Some(self.insert_phantom(local_name!("head")));
-                    Reprocess(InHead, token)
+                    ProcessResult::Reprocess(InsertionMode::InHead, token)
                 }
             }),
 
             //§ parsing-main-inhead
             // https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhead
-            InHead => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, text) => self.append_text(text),
-                CommentToken(text) => self.append_comment(text),
+            InsertionMode::InHead => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, text) => self.append_text(text),
+                Token::Comment(text) => self.append_comment(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
                 tag @ <base> <basefont> <bgsound> <link> <meta> => {
                     // FIXME: handle <meta charset=...> and <meta http-equiv="Content-Type">
                     self.insert_and_pop_element_for(tag);
-                    DoneAckSelfClosing
+                    ProcessResult::DoneAckSelfClosing
                 }
 
                 tag @ <title> => {
@@ -126,8 +126,8 @@ where
                 tag @ <noframes> <style> <noscript> => {
                     if (!self.opts.scripting_enabled) && (tag.name == local_name!("noscript")) {
                         self.insert_element_for(tag);
-                        self.mode.set(InHeadNoscript);
-                        Done
+                        self.mode.set(InsertionMode::InHeadNoscript);
+                        ProcessResult::Done
                     } else {
                         self.parse_raw_data(tag, Rawtext)
                     }
@@ -147,17 +147,17 @@ where
 
                 </head> => {
                     self.pop();
-                    self.mode.set(AfterHead);
-                    Done
+                    self.mode.set(InsertionMode::AfterHead);
+                    ProcessResult::Done
                 }
 
                 </body> </html> </br> => else,
 
                 tag @ <template> => {
-                    self.active_formatting.borrow_mut().push(Marker);
+                    self.active_formatting.borrow_mut().push(FormatEntry::Marker);
                     self.frameset_ok.set(false);
-                    self.mode.set(InTemplate);
-                    self.template_modes.borrow_mut().push(InTemplate);
+                    self.mode.set(InsertionMode::InTemplate);
+                    self.template_modes.borrow_mut().push(InsertionMode::InTemplate);
 
                     if (self.should_attach_declarative_shadow(&tag)) {
                         // Attach shadow path
@@ -183,7 +183,7 @@ where
                         self.insert_element_for(tag);
                     }
 
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ </template> => {
@@ -196,7 +196,7 @@ where
                         self.template_modes.borrow_mut().pop();
                         self.mode.set(self.reset_insertion_mode());
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 <head> => self.unexpected(&token),
@@ -204,27 +204,27 @@ where
 
                 token => {
                     self.pop();
-                    Reprocess(AfterHead, token)
+                    ProcessResult::Reprocess(InsertionMode::AfterHead, token)
                 }
             }),
 
             //§ parsing-main-inheadnoscript
-            InHeadNoscript => match_token!(token {
-                <html> => self.step(InBody, token),
+            InsertionMode::InHeadNoscript => match_token!(token {
+                <html> => self.step(InsertionMode::InBody, token),
 
                 </noscript> => {
                     self.pop();
-                    self.mode.set(InHead);
-                    Done
+                    self.mode.set(InsertionMode::InHead);
+                    ProcessResult::Done
                 },
 
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, _) => self.step(InHead, token),
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, _) => self.step(InsertionMode::InHead, token),
 
-                CommentToken(_) => self.step(InHead, token),
+                Token::Comment(_) => self.step(InsertionMode::InHead, token),
 
                 <basefont> <bgsound> <link> <meta> <noframes> <style>
-                    => self.step(InHead, token),
+                    => self.step(InsertionMode::InHead, token),
 
                 </br> => else,
 
@@ -234,29 +234,29 @@ where
                 token => {
                     self.unexpected(&token);
                     self.pop();
-                    Reprocess(InHead, token)
+                    ProcessResult::Reprocess(InsertionMode::InHead, token)
                 },
             }),
 
             //§ the-after-head-insertion-mode
-            AfterHead => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, text) => self.append_text(text),
-                CommentToken(text) => self.append_comment(text),
+            InsertionMode::AfterHead => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, text) => self.append_text(text),
+                Token::Comment(text) => self.append_comment(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
                 tag @ <body> => {
                     self.insert_element_for(tag);
                     self.frameset_ok.set(false);
-                    self.mode.set(InBody);
-                    Done
+                    self.mode.set(InsertionMode::InBody);
+                    ProcessResult::Done
                 }
 
                 tag @ <frameset> => {
                     self.insert_element_for(tag);
-                    self.mode.set(InFrameset);
-                    Done
+                    self.mode.set(InsertionMode::InFrameset);
+                    ProcessResult::Done
                 }
 
                 <base> <basefont> <bgsound> <link> <meta>
@@ -264,12 +264,12 @@ where
                     self.unexpected(&token);
                     let head = self.head_elem.borrow().as_ref().expect("no head element").clone();
                     self.push(&head);
-                    let result = self.step(InHead, token);
+                    let result = self.step(InsertionMode::InHead, token);
                     self.remove_from_stack(&head);
                     result
                 }
 
-                </template> => self.step(InHead, token),
+                </template> => self.step(InsertionMode::InHead, token),
 
                 </body> </html> </br> => else,
 
@@ -278,15 +278,15 @@ where
 
                 token => {
                     self.insert_phantom(local_name!("body"));
-                    Reprocess(InBody, token)
+                    ProcessResult::Reprocess(InsertionMode::InBody, token)
                 }
             }),
 
             //§ parsing-main-inbody
-            InBody => match_token!(token {
-                NullCharacterToken => self.unexpected(&token),
+            InsertionMode::InBody => match_token!(token {
+                Token::NullCharacter => self.unexpected(&token),
 
-                CharacterTokens(_, text) => {
+                Token::Characters(_, text) => {
                     self.reconstruct_formatting();
                     if any_not_whitespace(&text) {
                         self.frameset_ok.set(false);
@@ -294,7 +294,7 @@ where
                     self.append_text(text)
                 }
 
-                CommentToken(text) => self.append_comment(text),
+                Token::Comment(text) => self.append_comment(text),
 
                 tag @ <html> => {
                     self.unexpected(&tag);
@@ -303,12 +303,12 @@ where
                         let top = html_elem(&open_elems);
                         self.sink.add_attrs_if_missing(top, tag.attrs);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 <base> <basefont> <bgsound> <link> <meta> <noframes>
                   <script> <style> <template> <title> </template> => {
-                    self.step(InHead, token)
+                    self.step(InsertionMode::InHead, token)
                 }
 
                 tag @ <body> => {
@@ -322,27 +322,27 @@ where
                         },
                         _ => {}
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <frameset> => {
                     self.unexpected(&tag);
-                    if !self.frameset_ok.get() { return Done; }
+                    if !self.frameset_ok.get() { return ProcessResult::Done; }
 
-                    let body = unwrap_or_return!(self.body_elem(), Done).clone();
+                    let body = unwrap_or_return!(self.body_elem(), ProcessResult::Done).clone();
                     self.sink.remove_from_parent(&body);
 
                     // FIXME: can we get here in the fragment case?
                     // What to do with the first element then?
                     self.open_elems.borrow_mut().truncate(1);
                     self.insert_element_for(tag);
-                    self.mode.set(InFrameset);
-                    Done
+                    self.mode.set(InsertionMode::InFrameset);
+                    ProcessResult::Done
                 }
 
-                EOFToken => {
+                Token::Eof => {
                     if !self.template_modes.borrow().is_empty() {
-                        self.step(InTemplate, token)
+                        self.step(InsertionMode::InTemplate, token)
                     } else {
                         self.check_body_end();
                         self.stop_parsing()
@@ -352,20 +352,20 @@ where
                 </body> => {
                     if self.in_scope_named(default_scope, local_name!("body")) {
                         self.check_body_end();
-                        self.mode.set(AfterBody);
+                        self.mode.set(InsertionMode::AfterBody);
                     } else {
                         self.sink.parse_error(Borrowed("</body> with no <body> in scope"));
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 </html> => {
                     if self.in_scope_named(default_scope, local_name!("body")) {
                         self.check_body_end();
-                        Reprocess(AfterBody, token)
+                        ProcessResult::Reprocess(InsertionMode::AfterBody, token)
                     } else {
                         self.sink.parse_error(Borrowed("</html> with no <body> in scope"));
-                        Done
+                        ProcessResult::Done
                     }
                 }
 
@@ -374,13 +374,13 @@ where
                   <hgroup> <main> <nav> <ol> <p> <search> <section> <summary> <ul> => {
                     self.close_p_element_in_button_scope();
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <menu> => {
                     self.close_p_element_in_button_scope();
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <h1> <h2> <h3> <h4> <h5> <h6> => {
@@ -390,7 +390,7 @@ where
                         self.pop();
                     }
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <pre> <listing> => {
@@ -398,7 +398,7 @@ where
                     self.insert_element_for(tag);
                     self.ignore_lf.set(true);
                     self.frameset_ok.set(false);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <form> => {
@@ -412,7 +412,7 @@ where
                             *self.form_elem.borrow_mut() = Some(elem);
                         }
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <li> <dd> <dt> => {
@@ -452,13 +452,13 @@ where
 
                     self.close_p_element_in_button_scope();
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <plaintext> => {
                     self.close_p_element_in_button_scope();
                     self.insert_element_for(tag);
-                    ToPlaintext
+                    ProcessResult::ToPlaintext
                 }
 
                 tag @ <button> => {
@@ -470,7 +470,7 @@ where
                     self.reconstruct_formatting();
                     self.insert_element_for(tag);
                     self.frameset_ok.set(false);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ </address> </article> </aside> </blockquote> </button> </center>
@@ -483,7 +483,7 @@ where
                         self.generate_implied_end(cursory_implied_end);
                         self.expect_to_close(tag.name);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 </form> => {
@@ -492,13 +492,13 @@ where
                         let node = match self.form_elem.take() {
                             None => {
                                 self.sink.parse_error(Borrowed("Null form element pointer on </form>"));
-                                return Done;
+                                return ProcessResult::Done;
                             }
                             Some(x) => x,
                         };
                         if !self.in_scope(default_scope, |n| self.sink.same_node(&node, &n)) {
                             self.sink.parse_error(Borrowed("Form element not in scope on </form>"));
-                            return Done;
+                            return ProcessResult::Done;
                         }
                         self.generate_implied_end(cursory_implied_end);
                         let current = self.current_node().clone();
@@ -509,7 +509,7 @@ where
                     } else {
                         if !self.in_scope_named(default_scope, local_name!("form")) {
                             self.sink.parse_error(Borrowed("Form element not in scope on </form>"));
-                            return Done;
+                            return ProcessResult::Done;
                         }
                         self.generate_implied_end(cursory_implied_end);
                         if !self.current_node_named(local_name!("form")) {
@@ -517,7 +517,7 @@ where
                         }
                         self.pop_until_named(local_name!("form"));
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 </p> => {
@@ -526,7 +526,7 @@ where
                         self.insert_phantom(local_name!("p"));
                     }
                     self.close_p_element();
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ </li> </dd> </dt> => {
@@ -541,7 +541,7 @@ where
                     } else {
                         self.sink.parse_error(Borrowed("No matching tag to close"));
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ </h1> </h2> </h3> </h4> </h5> </h6> => {
@@ -554,20 +554,20 @@ where
                     } else {
                         self.sink.parse_error(Borrowed("No heading tag to close"));
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <a> => {
                     self.handle_misnested_a_tags(&tag);
                     self.reconstruct_formatting();
                     self.create_formatting_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <b> <big> <code> <em> <font> <i> <s> <small> <strike> <strong> <tt> <u> => {
                     self.reconstruct_formatting();
                     self.create_formatting_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <nobr> => {
@@ -578,21 +578,21 @@ where
                         self.reconstruct_formatting();
                     }
                     self.create_formatting_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ </a> </b> </big> </code> </em> </font> </i> </nobr>
                   </s> </small> </strike> </strong> </tt> </u> => {
                     self.adoption_agency(tag.name);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <applet> <marquee> <object> => {
                     self.reconstruct_formatting();
                     self.insert_element_for(tag);
-                    self.active_formatting.borrow_mut().push(Marker);
+                    self.active_formatting.borrow_mut().push(FormatEntry::Marker);
                     self.frameset_ok.set(false);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ </applet> </marquee> </object> => {
@@ -603,7 +603,7 @@ where
                         self.expect_to_close(tag.name);
                         self.clear_active_formatting_to_marker();
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <table> => {
@@ -612,13 +612,13 @@ where
                     }
                     self.insert_element_for(tag);
                     self.frameset_ok.set(false);
-                    self.mode.set(InTable);
-                    Done
+                    self.mode.set(InsertionMode::InTable);
+                    ProcessResult::Done
                 }
 
                 tag @ </br> => {
                     self.unexpected(&tag);
-                    self.step(InBody, TagToken(Tag {
+                    self.step(InsertionMode::InBody, Token::Tag(Tag {
                         kind: StartTag,
                         attrs: vec!(),
                         ..tag
@@ -635,24 +635,24 @@ where
                     if !keep_frameset_ok {
                         self.frameset_ok.set(false);
                     }
-                    DoneAckSelfClosing
+                    ProcessResult::DoneAckSelfClosing
                 }
 
                 tag @ <param> <source> <track> => {
                     self.insert_and_pop_element_for(tag);
-                    DoneAckSelfClosing
+                    ProcessResult::DoneAckSelfClosing
                 }
 
                 tag @ <hr> => {
                     self.close_p_element_in_button_scope();
                     self.insert_and_pop_element_for(tag);
                     self.frameset_ok.set(false);
-                    DoneAckSelfClosing
+                    ProcessResult::DoneAckSelfClosing
                 }
 
                 tag @ <image> => {
                     self.unexpected(&tag);
-                    self.step(InBody, TagToken(Tag {
+                    self.step(InsertionMode::InBody, Token::Tag(Tag {
                         name: local_name!("img"),
                         ..tag
                     }))
@@ -689,11 +689,11 @@ where
                     // NB: mode == InBody but possibly self.mode != mode, if
                     // we're processing "as in the rules for InBody".
                     self.mode.set(match self.mode.get() {
-                        InTable | InCaption | InTableBody
-                            | InRow | InCell => InSelectInTable,
-                        _ => InSelect,
+                        InsertionMode::InTable | InsertionMode::InCaption | InsertionMode::InTableBody
+                            | InsertionMode::InRow | InsertionMode::InCell => InsertionMode::InSelectInTable,
+                        _ => InsertionMode::InSelect,
                     });
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <optgroup> <option> => {
@@ -702,7 +702,7 @@ where
                     }
                     self.reconstruct_formatting();
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <rb> <rtc> => {
@@ -713,7 +713,7 @@ where
                         self.unexpected(&tag);
                     }
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <rp> <rt> => {
@@ -724,7 +724,7 @@ where
                         self.unexpected(&tag);
                     }
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <math> => self.enter_foreign(tag, ns!(mathml)),
@@ -734,7 +734,7 @@ where
                 <caption> <col> <colgroup> <frame> <head>
                   <tbody> <td> <tfoot> <th> <thead> <tr> => {
                     self.unexpected(&token);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <_> => {
@@ -743,13 +743,13 @@ where
                     } else {
                         self.reconstruct_formatting();
                         self.insert_element_for(tag);
-                        Done
+                        ProcessResult::Done
                     }
                 }
 
                 tag @ </_> => {
                     self.process_end_tag_in_body(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 // FIXME: This should be unreachable, but match_token requires a
@@ -758,10 +758,10 @@ where
             }),
 
             //§ parsing-main-incdata
-            Text => match_token!(token {
-                CharacterTokens(_, text) => self.append_text(text),
+            InsertionMode::Text => match_token!(token {
+                Token::Characters(_, text) => self.append_text(text),
 
-                EOFToken => {
+                Token::Eof => {
                     self.unexpected(&token);
                     if self.current_node_named(local_name!("script")) {
                         let open_elems = self.open_elems.borrow();
@@ -769,16 +769,16 @@ where
                         self.sink.mark_script_already_started(current);
                     }
                     self.pop();
-                    Reprocess(self.orig_mode.take().unwrap(), token)
+                    ProcessResult::Reprocess(self.orig_mode.take().unwrap(), token)
                 }
 
                 tag @ </_> => {
                     let node = self.pop();
                     self.mode.set(self.orig_mode.take().unwrap());
                     if tag.name == local_name!("script") {
-                        return Script(node);
+                        return ProcessResult::Script(node);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 // The spec doesn't say what to do here.
@@ -787,55 +787,55 @@ where
             }),
 
             //§ parsing-main-intable
-            InTable => match_token!(token {
+            InsertionMode::InTable => match_token!(token {
                 // FIXME: hack, should implement pat | pat for match_token instead
-                NullCharacterToken => self.process_chars_in_table(token),
+                Token::NullCharacter => self.process_chars_in_table(token),
 
-                CharacterTokens(..) => self.process_chars_in_table(token),
+                Token::Characters(..) => self.process_chars_in_table(token),
 
-                CommentToken(text) => self.append_comment(text),
+                Token::Comment(text) => self.append_comment(text),
 
                 tag @ <caption> => {
                     self.pop_until_current(table_scope);
-                    self.active_formatting.borrow_mut().push(Marker);
+                    self.active_formatting.borrow_mut().push(FormatEntry::Marker);
                     self.insert_element_for(tag);
-                    self.mode.set(InCaption);
-                    Done
+                    self.mode.set(InsertionMode::InCaption);
+                    ProcessResult::Done
                 }
 
                 tag @ <colgroup> => {
                     self.pop_until_current(table_scope);
                     self.insert_element_for(tag);
-                    self.mode.set(InColumnGroup);
-                    Done
+                    self.mode.set(InsertionMode::InColumnGroup);
+                    ProcessResult::Done
                 }
 
                 <col> => {
                     self.pop_until_current(table_scope);
                     self.insert_phantom(local_name!("colgroup"));
-                    Reprocess(InColumnGroup, token)
+                    ProcessResult::Reprocess(InsertionMode::InColumnGroup, token)
                 }
 
                 tag @ <tbody> <tfoot> <thead> => {
                     self.pop_until_current(table_scope);
                     self.insert_element_for(tag);
-                    self.mode.set(InTableBody);
-                    Done
+                    self.mode.set(InsertionMode::InTableBody);
+                    ProcessResult::Done
                 }
 
                 <td> <th> <tr> => {
                     self.pop_until_current(table_scope);
                     self.insert_phantom(local_name!("tbody"));
-                    Reprocess(InTableBody, token)
+                    ProcessResult::Reprocess(InsertionMode::InTableBody, token)
                 }
 
                 <table> => {
                     self.unexpected(&token);
                     if self.in_scope_named(table_scope, local_name!("table")) {
                         self.pop_until_named(local_name!("table"));
-                        Reprocess(self.reset_insertion_mode(), token)
+                        ProcessResult::Reprocess(self.reset_insertion_mode(), token)
                     } else {
-                        Done
+                        ProcessResult::Done
                     }
                 }
 
@@ -846,7 +846,7 @@ where
                     } else {
                         self.unexpected(&token);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 </body> </caption> </col> </colgroup> </html>
@@ -854,15 +854,15 @@ where
                     self.unexpected(&token),
 
                 <style> <script> <template> </template>
-                    => self.step(InHead, token),
+                    => self.step(InsertionMode::InHead, token),
 
                 tag @ <input> => {
                     self.unexpected(&tag);
                     if self.is_type_hidden(&tag) {
                         self.insert_and_pop_element_for(tag);
-                        DoneAckSelfClosing
+                        ProcessResult::DoneAckSelfClosing
                     } else {
-                        self.foster_parent_in_body(TagToken(tag))
+                        self.foster_parent_in_body(Token::Tag(tag))
                     }
                 }
 
@@ -871,10 +871,10 @@ where
                     if !self.in_html_elem_named(local_name!("template")) && self.form_elem.borrow().is_none() {
                         *self.form_elem.borrow_mut() = Some(self.insert_and_pop_element_for(tag));
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
-                EOFToken => self.step(InBody, token),
+                Token::Eof => self.step(InsertionMode::InBody, token),
 
                 token => {
                     self.unexpected(&token);
@@ -883,29 +883,29 @@ where
             }),
 
             //§ parsing-main-intabletext
-            InTableText => match_token!(token {
-                NullCharacterToken => self.unexpected(&token),
+            InsertionMode::InTableText => match_token!(token {
+                Token::NullCharacter => self.unexpected(&token),
 
-                CharacterTokens(split, text) => {
+                Token::Characters(split, text) => {
                     self.pending_table_text.borrow_mut().push((split, text));
-                    Done
+                    ProcessResult::Done
                 }
 
                 token => {
                     let pending = self.pending_table_text.take();
                     let contains_nonspace = pending.iter().any(|&(split, ref text)| {
                         match split {
-                            Whitespace => false,
-                            NotWhitespace => true,
-                            NotSplit => any_not_whitespace(text),
+                            SplitStatus::Whitespace => false,
+                            SplitStatus::NotWhitespace => true,
+                            SplitStatus::NotSplit => any_not_whitespace(text),
                         }
                     });
 
                     if contains_nonspace {
                         self.sink.parse_error(Borrowed("Non-space table text"));
                         for (split, text) in pending.into_iter() {
-                            match self.foster_parent_in_body(CharacterTokens(split, text)) {
-                                Done => (),
+                            match self.foster_parent_in_body(Token::Characters(split, text)) {
+                                ProcessResult::Done => (),
                                 _ => panic!("not prepared to handle this!"),
                             }
                         }
@@ -915,12 +915,12 @@ where
                         }
                     }
 
-                    Reprocess(self.orig_mode.take().unwrap(), token)
+                    ProcessResult::Reprocess(self.orig_mode.take().unwrap(), token)
                 }
             }),
 
             //§ parsing-main-incaption
-            InCaption => match_token!(token {
+            InsertionMode::InCaption => match_token!(token {
                 tag @ <caption> <col> <colgroup> <tbody> <td> <tfoot>
                   <th> <thead> <tr> </table> </caption> => {
                     if self.in_scope_named(table_scope, local_name!("caption")) {
@@ -929,56 +929,56 @@ where
                         self.clear_active_formatting_to_marker();
                         match tag {
                             Tag { kind: EndTag, name: local_name!("caption"), .. } => {
-                                self.mode.set(InTable);
-                                Done
+                                self.mode.set(InsertionMode::InTable);
+                                ProcessResult::Done
                             }
-                            _ => Reprocess(InTable, TagToken(tag))
+                            _ => ProcessResult::Reprocess(InsertionMode::InTable, Token::Tag(tag))
                         }
                     } else {
                         self.unexpected(&tag);
-                        Done
+                        ProcessResult::Done
                     }
                 }
 
                 </body> </col> </colgroup> </html> </tbody>
                   </td> </tfoot> </th> </thead> </tr> => self.unexpected(&token),
 
-                token => self.step(InBody, token),
+                token => self.step(InsertionMode::InBody, token),
             }),
 
             //§ parsing-main-incolgroup
-            InColumnGroup => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, text) => self.append_text(text),
-                CommentToken(text) => self.append_comment(text),
+            InsertionMode::InColumnGroup => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, text) => self.append_text(text),
+                Token::Comment(text) => self.append_comment(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
                 tag @ <col> => {
                     self.insert_and_pop_element_for(tag);
-                    DoneAckSelfClosing
+                    ProcessResult::DoneAckSelfClosing
                 }
 
                 </colgroup> => {
                     if self.current_node_named(local_name!("colgroup")) {
                         self.pop();
-                        self.mode.set(InTable);
+                        self.mode.set(InsertionMode::InTable);
                     } else {
                         self.unexpected(&token);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 </col> => self.unexpected(&token),
 
-                <template> </template> => self.step(InHead, token),
+                <template> </template> => self.step(InsertionMode::InHead, token),
 
-                EOFToken => self.step(InBody, token),
+                Token::Eof => self.step(InsertionMode::InBody, token),
 
                 token => {
                     if self.current_node_named(local_name!("colgroup")) {
                         self.pop();
-                        Reprocess(InTable, token)
+                        ProcessResult::Reprocess(InsertionMode::InTable, token)
                     } else {
                         self.unexpected(&token)
                     }
@@ -986,30 +986,30 @@ where
             }),
 
             //§ parsing-main-intbody
-            InTableBody => match_token!(token {
+            InsertionMode::InTableBody => match_token!(token {
                 tag @ <tr> => {
                     self.pop_until_current(table_body_context);
                     self.insert_element_for(tag);
-                    self.mode.set(InRow);
-                    Done
+                    self.mode.set(InsertionMode::InRow);
+                    ProcessResult::Done
                 }
 
                 <th> <td> => {
                     self.unexpected(&token);
                     self.pop_until_current(table_body_context);
                     self.insert_phantom(local_name!("tr"));
-                    Reprocess(InRow, token)
+                    ProcessResult::Reprocess(InsertionMode::InRow, token)
                 }
 
                 tag @ </tbody> </tfoot> </thead> => {
                     if self.in_scope_named(table_scope, tag.name.clone()) {
                         self.pop_until_current(table_body_context);
                         self.pop();
-                        self.mode.set(InTable);
+                        self.mode.set(InsertionMode::InTable);
                     } else {
                         self.unexpected(&tag);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 <caption> <col> <colgroup> <tbody> <tfoot> <thead> </table> => {
@@ -1017,7 +1017,7 @@ where
                     if self.in_scope(table_scope, |e| self.elem_in(&e, table_outer)) {
                         self.pop_until_current(table_body_context);
                         self.pop();
-                        Reprocess(InTable, token)
+                        ProcessResult::Reprocess(InsertionMode::InTable, token)
                     } else {
                         self.unexpected(&token)
                     }
@@ -1026,17 +1026,17 @@ where
                 </body> </caption> </col> </colgroup> </html> </td> </th> </tr>
                     => self.unexpected(&token),
 
-                token => self.step(InTable, token),
+                token => self.step(InsertionMode::InTable, token),
             }),
 
             //§ parsing-main-intr
-            InRow => match_token!(token {
+            InsertionMode::InRow => match_token!(token {
                 tag @ <th> <td> => {
                     self.pop_until_current(table_row_context);
                     self.insert_element_for(tag);
-                    self.mode.set(InCell);
-                    self.active_formatting.borrow_mut().push(Marker);
-                    Done
+                    self.mode.set(InsertionMode::InCell);
+                    self.active_formatting.borrow_mut().push(FormatEntry::Marker);
+                    ProcessResult::Done
                 }
 
                 </tr> => {
@@ -1044,11 +1044,11 @@ where
                         self.pop_until_current(table_row_context);
                         let node = self.pop();
                         self.assert_named(&node, local_name!("tr"));
-                        self.mode.set(InTableBody);
+                        self.mode.set(InsertionMode::InTableBody);
                     } else {
                         self.unexpected(&token);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 <caption> <col> <colgroup> <tbody> <tfoot> <thead> <tr> </table> => {
@@ -1056,7 +1056,7 @@ where
                         self.pop_until_current(table_row_context);
                         let node = self.pop();
                         self.assert_named(&node, local_name!("tr"));
-                        Reprocess(InTableBody, token)
+                        ProcessResult::Reprocess(InsertionMode::InTableBody, token)
                     } else {
                         self.unexpected(&token)
                     }
@@ -1068,9 +1068,9 @@ where
                             self.pop_until_current(table_row_context);
                             let node = self.pop();
                             self.assert_named(&node, local_name!("tr"));
-                            Reprocess(InTableBody, TagToken(tag))
+                            ProcessResult::Reprocess(InsertionMode::InTableBody, Token::Tag(tag))
                         } else {
-                            Done
+                            ProcessResult::Done
                         }
                     } else {
                         self.unexpected(&tag)
@@ -1080,27 +1080,27 @@ where
                 </body> </caption> </col> </colgroup> </html> </td> </th>
                     => self.unexpected(&token),
 
-                token => self.step(InTable, token),
+                token => self.step(InsertionMode::InTable, token),
             }),
 
             //§ parsing-main-intd
-            InCell => match_token!(token {
+            InsertionMode::InCell => match_token!(token {
                 tag @ </td> </th> => {
                     if self.in_scope_named(table_scope, tag.name.clone()) {
                         self.generate_implied_end(cursory_implied_end);
                         self.expect_to_close(tag.name);
                         self.clear_active_formatting_to_marker();
-                        self.mode.set(InRow);
+                        self.mode.set(InsertionMode::InRow);
                     } else {
                         self.unexpected(&tag);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 <caption> <col> <colgroup> <tbody> <td> <tfoot> <th> <thead> <tr> => {
                     if self.in_scope(table_scope, |n| self.elem_in(&n, td_th)) {
                         self.close_the_cell();
-                        Reprocess(InRow, token)
+                        ProcessResult::Reprocess(InsertionMode::InRow, token)
                     } else {
                         self.unexpected(&token)
                     }
@@ -1112,29 +1112,29 @@ where
                 tag @ </table> </tbody> </tfoot> </thead> </tr> => {
                     if self.in_scope_named(table_scope, tag.name.clone()) {
                         self.close_the_cell();
-                        Reprocess(InRow, TagToken(tag))
+                        ProcessResult::Reprocess(InsertionMode::InRow, Token::Tag(tag))
                     } else {
                         self.unexpected(&tag)
                     }
                 }
 
-                token => self.step(InBody, token),
+                token => self.step(InsertionMode::InBody, token),
             }),
 
             //§ parsing-main-inselect
-            InSelect => match_token!(token {
-                NullCharacterToken => self.unexpected(&token),
-                CharacterTokens(_, text) => self.append_text(text),
-                CommentToken(text) => self.append_comment(text),
+            InsertionMode::InSelect => match_token!(token {
+                Token::NullCharacter => self.unexpected(&token),
+                Token::Characters(_, text) => self.append_text(text),
+                Token::Comment(text) => self.append_comment(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
                 tag @ <option> => {
                     if self.current_node_named(local_name!("option")) {
                         self.pop();
                     }
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <optgroup> => {
@@ -1145,7 +1145,7 @@ where
                         self.pop();
                     }
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <hr> => {
@@ -1157,7 +1157,7 @@ where
                     }
                     self.insert_element_for(tag);
                     self.pop();
-                    DoneAckSelfClosing
+                    ProcessResult::DoneAckSelfClosing
                 }
 
                 </optgroup> => {
@@ -1172,7 +1172,7 @@ where
                     } else {
                         self.unexpected(&token);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 </option> => {
@@ -1181,7 +1181,7 @@ where
                     } else {
                         self.unexpected(&token);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <select> </select> => {
@@ -1195,82 +1195,82 @@ where
                         self.pop_until_named(local_name!("select"));
                         self.mode.set(self.reset_insertion_mode());
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 <input> <keygen> <textarea> => {
                     self.unexpected(&token);
                     if self.in_scope_named(select_scope, local_name!("select")) {
                         self.pop_until_named(local_name!("select"));
-                        Reprocess(self.reset_insertion_mode(), token)
+                        ProcessResult::Reprocess(self.reset_insertion_mode(), token)
                     } else {
-                        Done
+                        ProcessResult::Done
                     }
                 }
 
-                <script> <template> </template> => self.step(InHead, token),
+                <script> <template> </template> => self.step(InsertionMode::InHead, token),
 
-                EOFToken => self.step(InBody, token),
+                Token::Eof => self.step(InsertionMode::InBody, token),
 
                 token => self.unexpected(&token),
             }),
 
             //§ parsing-main-inselectintable
-            InSelectInTable => match_token!(token {
+            InsertionMode::InSelectInTable => match_token!(token {
                 <caption> <table> <tbody> <tfoot> <thead> <tr> <td> <th> => {
                     self.unexpected(&token);
                     self.pop_until_named(local_name!("select"));
-                    Reprocess(self.reset_insertion_mode(), token)
+                    ProcessResult::Reprocess(self.reset_insertion_mode(), token)
                 }
 
                 tag @ </caption> </table> </tbody> </tfoot> </thead> </tr> </td> </th> => {
                     self.unexpected(&tag);
                     if self.in_scope_named(table_scope, tag.name.clone()) {
                         self.pop_until_named(local_name!("select"));
-                        Reprocess(self.reset_insertion_mode(), TagToken(tag))
+                        ProcessResult::Reprocess(self.reset_insertion_mode(), Token::Tag(tag))
                     } else {
-                        Done
+                        ProcessResult::Done
                     }
                 }
 
-                token => self.step(InSelect, token),
+                token => self.step(InsertionMode::InSelect, token),
             }),
 
             //§ parsing-main-intemplate
-            InTemplate => match_token!(token {
-                CharacterTokens(_, _) => self.step(InBody, token),
-                CommentToken(_) => self.step(InBody, token),
+            InsertionMode::InTemplate => match_token!(token {
+                Token::Characters(_, _) => self.step(InsertionMode::InBody, token),
+                Token::Comment(_) => self.step(InsertionMode::InBody, token),
 
                 <base> <basefont> <bgsound> <link> <meta> <noframes> <script>
                 <style> <template> <title> </template> => {
-                    self.step(InHead, token)
+                    self.step(InsertionMode::InHead, token)
                 }
 
                 <caption> <colgroup> <tbody> <tfoot> <thead> => {
                     self.template_modes.borrow_mut().pop();
-                    self.template_modes.borrow_mut().push(InTable);
-                    Reprocess(InTable, token)
+                    self.template_modes.borrow_mut().push(InsertionMode::InTable);
+                    ProcessResult::Reprocess(InsertionMode::InTable, token)
                 }
 
                 <col> => {
                     self.template_modes.borrow_mut().pop();
-                    self.template_modes.borrow_mut().push(InColumnGroup);
-                    Reprocess(InColumnGroup, token)
+                    self.template_modes.borrow_mut().push(InsertionMode::InColumnGroup);
+                    ProcessResult::Reprocess(InsertionMode::InColumnGroup, token)
                 }
 
                 <tr> => {
                     self.template_modes.borrow_mut().pop();
-                    self.template_modes.borrow_mut().push(InTableBody);
-                    Reprocess(InTableBody, token)
+                    self.template_modes.borrow_mut().push(InsertionMode::InTableBody);
+                    ProcessResult::Reprocess(InsertionMode::InTableBody, token)
                 }
 
                 <td> <th> => {
                     self.template_modes.borrow_mut().pop();
-                    self.template_modes.borrow_mut().push(InRow);
-                    Reprocess(InRow, token)
+                    self.template_modes.borrow_mut().push(InsertionMode::InRow);
+                    ProcessResult::Reprocess(InsertionMode::InRow, token)
                 }
 
-                EOFToken => {
+                Token::Eof => {
                     if !self.in_html_elem_named(local_name!("template")) {
                         self.stop_parsing()
                     } else {
@@ -1279,55 +1279,55 @@ where
                         self.clear_active_formatting_to_marker();
                         self.template_modes.borrow_mut().pop();
                         self.mode.set(self.reset_insertion_mode());
-                        Reprocess(self.reset_insertion_mode(), token)
+                        ProcessResult::Reprocess(self.reset_insertion_mode(), token)
                     }
                 }
 
                 tag @ <_> => {
                     self.template_modes.borrow_mut().pop();
-                    self.template_modes.borrow_mut().push(InBody);
-                    Reprocess(InBody, TagToken(tag))
+                    self.template_modes.borrow_mut().push(InsertionMode::InBody);
+                    ProcessResult::Reprocess(InsertionMode::InBody, Token::Tag(tag))
                 }
 
                 token => self.unexpected(&token),
             }),
 
             //§ parsing-main-afterbody
-            AfterBody => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, _) => self.step(InBody, token),
-                CommentToken(text) => self.append_comment_to_html(text),
+            InsertionMode::AfterBody => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, _) => self.step(InsertionMode::InBody, token),
+                Token::Comment(text) => self.append_comment_to_html(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
                 </html> => {
                     if self.is_fragment() {
                         self.unexpected(&token);
                     } else {
-                        self.mode.set(AfterAfterBody);
+                        self.mode.set(InsertionMode::AfterAfterBody);
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
-                EOFToken => self.stop_parsing(),
+                Token::Eof => self.stop_parsing(),
 
                 token => {
                     self.unexpected(&token);
-                    Reprocess(InBody, token)
+                    ProcessResult::Reprocess(InsertionMode::InBody, token)
                 }
             }),
 
             //§ parsing-main-inframeset
-            InFrameset => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, text) => self.append_text(text),
-                CommentToken(text) => self.append_comment(text),
+            InsertionMode::InFrameset => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, text) => self.append_text(text),
+                Token::Comment(text) => self.append_comment(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
                 tag @ <frameset> => {
                     self.insert_element_for(tag);
-                    Done
+                    ProcessResult::Done
                 }
 
                 </frameset> => {
@@ -1336,20 +1336,20 @@ where
                     } else {
                         self.pop();
                         if !self.is_fragment() && !self.current_node_named(local_name!("frameset")) {
-                            self.mode.set(AfterFrameset);
+                            self.mode.set(InsertionMode::AfterFrameset);
                         }
                     }
-                    Done
+                    ProcessResult::Done
                 }
 
                 tag @ <frame> => {
                     self.insert_and_pop_element_for(tag);
-                    DoneAckSelfClosing
+                    ProcessResult::DoneAckSelfClosing
                 }
 
-                <noframes> => self.step(InHead, token),
+                <noframes> => self.step(InsertionMode::InHead, token),
 
-                EOFToken => {
+                Token::Eof => {
                     if self.open_elems.borrow().len() != 1 {
                         self.unexpected(&token);
                     }
@@ -1360,52 +1360,52 @@ where
             }),
 
             //§ parsing-main-afterframeset
-            AfterFrameset => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, text) => self.append_text(text),
-                CommentToken(text) => self.append_comment(text),
+            InsertionMode::AfterFrameset => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, text) => self.append_text(text),
+                Token::Comment(text) => self.append_comment(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
                 </html> => {
-                    self.mode.set(AfterAfterFrameset);
-                    Done
+                    self.mode.set(InsertionMode::AfterAfterFrameset);
+                    ProcessResult::Done
                 }
 
-                <noframes> => self.step(InHead, token),
+                <noframes> => self.step(InsertionMode::InHead, token),
 
-                EOFToken => self.stop_parsing(),
+                Token::Eof => self.stop_parsing(),
 
                 token => self.unexpected(&token),
             }),
 
             //§ the-after-after-body-insertion-mode
-            AfterAfterBody => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, _) => self.step(InBody, token),
-                CommentToken(text) => self.append_comment_to_doc(text),
+            InsertionMode::AfterAfterBody => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, _) => self.step(InsertionMode::InBody, token),
+                Token::Comment(text) => self.append_comment_to_doc(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
-                EOFToken => self.stop_parsing(),
+                Token::Eof => self.stop_parsing(),
 
                 token => {
                     self.unexpected(&token);
-                    Reprocess(InBody, token)
+                    ProcessResult::Reprocess(InsertionMode::InBody, token)
                 }
             }),
 
             //§ the-after-after-frameset-insertion-mode
-            AfterAfterFrameset => match_token!(token {
-                CharacterTokens(NotSplit, text) => SplitWhitespace(text),
-                CharacterTokens(Whitespace, _) => self.step(InBody, token),
-                CommentToken(text) => self.append_comment_to_doc(text),
+            InsertionMode::AfterAfterFrameset => match_token!(token {
+                Token::Characters(SplitStatus::NotSplit, text) => ProcessResult::SplitWhitespace(text),
+                Token::Characters(SplitStatus::Whitespace, _) => self.step(InsertionMode::InBody, token),
+                Token::Comment(text) => self.append_comment_to_doc(text),
 
-                <html> => self.step(InBody, token),
+                <html> => self.step(InsertionMode::InBody, token),
 
-                EOFToken => self.stop_parsing(),
+                Token::Eof => self.stop_parsing(),
 
-                <noframes> => self.step(InHead, token),
+                <noframes> => self.step(InsertionMode::InHead, token),
 
                 token => self.unexpected(&token),
             }),
@@ -1415,19 +1415,19 @@ where
 
     pub(crate) fn step_foreign(&self, token: Token) -> ProcessResult<Handle> {
         match_token!(token {
-            NullCharacterToken => {
+            Token::NullCharacter => {
                 self.unexpected(&token);
                 self.append_text("\u{fffd}".to_tendril())
             }
 
-            CharacterTokens(_, text) => {
+            Token::Characters(_, text) => {
                 if any_not_whitespace(&text) {
                     self.frameset_ok.set(false);
                 }
                 self.append_text(text)
             }
 
-            CommentToken(text) => self.append_comment(text),
+            Token::Comment(text) => self.append_comment(text),
 
             tag @ <b> <big> <blockquote> <body> <br> <center> <code> <dd> <div> <dl>
                 <dt> <em> <embed> <h1> <h2> <h3> <h4> <h5> <h6> <head> <hr> <i>
@@ -1458,7 +1458,7 @@ where
                 let mut stack_idx = self.open_elems.borrow().len() - 1;
                 loop {
                     if stack_idx == 0 {
-                        return Done;
+                        return ProcessResult::Done;
                     }
 
                     let html;
@@ -1471,12 +1471,12 @@ where
                     }
                     if !first && html {
                         let mode = self.mode.get();
-                        return self.step(mode, TagToken(tag));
+                        return self.step(mode, Token::Tag(tag));
                     }
 
                     if eq {
                         self.open_elems.borrow_mut().truncate(stack_idx);
-                        return Done;
+                        return ProcessResult::Done;
                     }
 
                     if first {

--- a/html5ever/src/tree_builder/types.rs
+++ b/html5ever/src/tree_builder/types.rs
@@ -7,19 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Types used within the tree builder code.  Not exported to users.
+//! Types used within the tree builder code. Not exported to users.
 
 use crate::tokenizer::states::RawKind;
 use crate::tokenizer::Tag;
 
 use crate::tendril::StrTendril;
-
-pub(crate) use self::FormatEntry::*;
-pub(crate) use self::InsertionMode::*;
-pub(crate) use self::InsertionPoint::*;
-pub(crate) use self::ProcessResult::*;
-pub(crate) use self::SplitStatus::*;
-pub(crate) use self::Token::*;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub(crate) enum InsertionMode {
@@ -60,11 +53,11 @@ pub(crate) enum SplitStatus {
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Token {
-    TagToken(Tag),
-    CommentToken(StrTendril),
-    CharacterTokens(SplitStatus, StrTendril),
-    NullCharacterToken,
-    EOFToken,
+    Tag(Tag),
+    Comment(StrTendril),
+    Characters(SplitStatus, StrTendril),
+    NullCharacter,
+    Eof,
 }
 
 pub(crate) enum ProcessResult<Handle> {

--- a/match_token/src/lib.rs
+++ b/match_token/src/lib.rs
@@ -364,6 +364,6 @@ fn make_tag_pattern(binding: &proc_macro2::TokenStream, tag: Tag) -> proc_macro2
         quote!()
     };
     quote! {
-        crate::tree_builder::types::TagToken(#binding crate::tokenizer::Tag { kind: #kind, #name_field .. })
+        crate::tree_builder::types::Token::Tag(#binding crate::tokenizer::Tag { kind: #kind, #name_field .. })
     }
 }


### PR DESCRIPTION
Currently the tokenizer and treebuilder in html5ever import all variants of  commonly used enums:

```rust
enum Token {
   FooToken,
   BarToken
}

use Token::*;

fn main() {
    let x = FooToken;
}
```

This is not really idiomatic rust. I've never seen any other codebase do this, and it is not the style we use in servo either.

 This change removes the imports and instead uses the `Token::Foo` notation, renaming the variants where appropriate. 

This is a breaking change, because the `PushFlag` import was public (*even though it really shouldn't have been, I suspect that's another common problem in html5ever*).

