### PR TITLE
Revert "Store xml namespace attributes for later serialization"

### DIFF
--- a/rcdom/tests/xml-driver.rs
+++ b/rcdom/tests/xml-driver.rs
@@ -99,39 +99,3 @@ fn assert_serialization(text: &'static str, dom: RcDom) {
     serialize::serialize(&mut serialized, &document, Default::default()).unwrap();
     assert_eq!(String::from_utf8(serialized).unwrap(), text);
 }
-
-#[test]
-fn xmlns_on_root() {
-    assert_serialization(
-       r##"<svg xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg">
-    <sodipodi:namedview>
-        ...
-    </sodipodi:namedview>
-
-    <path d="..." sodipodi:nodetypes="cccc"></path>
-</svg>"##,
-        driver::parse_document(RcDom::default(), Default::default())
-            .from_utf8()
-            .one(r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
-    <sodipodi:namedview>
-        ...
-    </sodipodi:namedview>
-
-    <path d="..." sodipodi:nodetypes="cccc"/>
-</svg>"##.as_bytes()),
-    );
-}
-
-#[test]
-fn xmlns_applies_to_attr() {
-    assert_serialization(
-        r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
-    <path d="..." sodipodi:nodetypes="cccc"></path>
-</svg>"##,
-        driver::parse_document(RcDom::default(), Default::default())
-            .from_utf8()
-            .one(r##"<svg xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg">
-    <path d="..." sodipodi:nodetypes="cccc"/>
-</svg>"##.as_bytes()),
-    );
-}

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml5ever"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The xml5ever project developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -149,6 +149,24 @@ impl<Wr: Write> Serializer for XmlSerializer<Wr> {
 
         self.writer.write_all(b"<")?;
         self.qual_name(&name)?;
+        if let Some(current_namespace) = self.namespace_stack.0.last() {
+            for (prefix, url_opt) in current_namespace.get_scope_iter() {
+                self.writer.write_all(b" xmlns")?;
+                if let Some(ref p) = *prefix {
+                    self.writer.write_all(b":")?;
+                    self.writer.write_all(p.as_bytes())?;
+                }
+
+                self.writer.write_all(b"=\"")?;
+                let url = if let Some(ref a) = *url_opt {
+                    a.as_bytes()
+                } else {
+                    b""
+                };
+                self.writer.write_all(url)?;
+                self.writer.write_all(b"\"")?;
+            }
+        }
         for (name, value) in attrs {
             self.writer.write_all(b" ")?;
             self.qual_attr_name(name)?;

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -333,17 +333,25 @@ where
         // List of already present namespace local name attribute pairs.
         let mut present_attrs: HashSet<(Namespace, LocalName)> = Default::default();
 
-        // We need to filter out any duplicate attributes.
-        tag.attrs.retain_mut(|attr| {
-            if attr.name.prefix == Some(namespace_prefix!("xmlns"))
+        let mut new_attr = vec![];
+        // First we extract all namespace declarations
+        for attr in tag.attrs.iter_mut().filter(|attr| {
+            attr.name.prefix == Some(namespace_prefix!("xmlns"))
                 || attr.name.local == local_name!("xmlns")
-            {
-                self.declare_ns(attr);
-                true
-            } else {
-                self.bind_attr_qname(&mut present_attrs, &mut attr.name)
+        }) {
+            self.declare_ns(attr);
+        }
+
+        // Then we bind those namespace declarations to attributes
+        for attr in tag.attrs.iter_mut().filter(|attr| {
+            attr.name.prefix != Some(namespace_prefix!("xmlns"))
+                && attr.name.local != local_name!("xmlns")
+        }) {
+            if self.bind_attr_qname(&mut present_attrs, &mut attr.name) {
+                new_attr.push(attr.clone());
             }
-        });
+        }
+        tag.attrs = new_attr;
 
         // Then we bind the tags namespace.
         self.bind_qname(&mut tag.name);


### PR DESCRIPTION
#586 introduced new test failures in Servo around XML serialization. I shouldn't have merged it without verifying the changes there first, so I'm backing it out until further investigation is possible.