### PR TITLE
Initialize logger for rcdom examples, cleanup html5ever a bit

### DIFF
--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -1616,7 +1616,7 @@ mod test {
         }
 
         fn finish_str(&self) {
-            if self.current_str.borrow().len() > 0 {
+            if !self.current_str.borrow().is_empty() {
                 let s = self.current_str.take();
                 self.tokens.borrow_mut().push(CharacterTokens(s));
             }

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -23,6 +23,7 @@ xml5ever = { version = "0.22", path = "../xml5ever" }
 [dev-dependencies]
 libtest-mimic = "0.8.1"
 serde_json = "1.0"
+env_logger = "0.10"
 
 [[test]]
 name = "html-tokenizer"

--- a/rcdom/examples/hello_xml.rs
+++ b/rcdom/examples/hello_xml.rs
@@ -17,6 +17,8 @@ use xml5ever::tendril::TendrilSink;
 use xml5ever::tree_builder::TreeSink;
 
 fn main() {
+    env_logger::init();
+
     // To parse a string into a tree of nodes, we need to invoke
     // `parse_document` and supply it with a TreeSink implementation (RcDom).
     let dom: RcDom = parse_document(RcDom::default(), Default::default()).one("<hello>XML</hello>");

--- a/rcdom/examples/html2html.rs
+++ b/rcdom/examples/html2html.rs
@@ -27,6 +27,8 @@ use html5ever::{parse_document, serialize};
 use rcdom::{RcDom, SerializableHandle};
 
 fn main() {
+    env_logger::init();
+
     let opts = ParseOpts {
         tree_builder: TreeBuilderOpts {
             drop_doctype: true,

--- a/rcdom/examples/xml_tree_printer.rs
+++ b/rcdom/examples/xml_tree_printer.rs
@@ -51,6 +51,8 @@ fn walk(prefix: &str, handle: &Handle) {
 }
 
 fn main() {
+    env_logger::init();
+
     let stdin = io::stdin();
 
     // To parse XML into a tree form, we need a TreeSink

--- a/rcdom/tests/html-tokenizer.rs
+++ b/rcdom/tests/html-tokenizer.rs
@@ -92,7 +92,7 @@ impl TokenLogger {
     }
 
     fn finish_str(&self) {
-        if self.current_str.borrow().len() > 0 {
+        if !self.current_str.borrow().is_empty() {
             let s = self.current_str.take();
             self.tokens.borrow_mut().push(CharacterTokens(s));
         }

--- a/rcdom/tests/html-tree-builder.rs
+++ b/rcdom/tests/html-tree-builder.rs
@@ -76,7 +76,7 @@ fn parse_tests<It: Iterator<Item = String>>(mut lines: It) -> Vec<HashMap<String
 
 fn serialize(buf: &mut String, indent: usize, handle: Handle) {
     buf.push('|');
-    buf.extend(iter::repeat(" ").take(indent));
+    buf.extend(iter::repeat_n(" ", indent));
 
     let node = handle;
     match node.data {
@@ -127,7 +127,7 @@ fn serialize(buf: &mut String, indent: usize, handle: Handle) {
 
             for attr in attrs.into_iter() {
                 buf.push('|');
-                buf.extend(iter::repeat(" ").take(indent + 2));
+                buf.extend(iter::repeat_n(" ", indent + 2));
                 match attr.name.ns {
                     ns!(xlink) => buf.push_str("xlink "),
                     ns!(xml) => buf.push_str("xml "),
@@ -152,7 +152,7 @@ fn serialize(buf: &mut String, indent: usize, handle: Handle) {
     {
         if let Some(ref content) = &*template_contents.borrow() {
             buf.push('|');
-            buf.extend(iter::repeat(" ").take(indent + 2));
+            buf.extend(iter::repeat_n(" ", indent + 2));
             buf.push_str("content\n");
             for child in content.children.borrow().iter() {
                 serialize(buf, indent + 4, child.clone());

--- a/rcdom/tests/xml-tokenizer.rs
+++ b/rcdom/tests/xml-tokenizer.rs
@@ -79,7 +79,7 @@ impl TokenLogger {
     }
 
     fn finish_str(&self) {
-        if self.current_str.borrow().len() > 0 {
+        if !self.current_str.borrow().is_empty() {
             let s = self.current_str.take();
             self.tokens.borrow_mut().push(CharacterTokens(s));
         }

--- a/rcdom/tests/xml-tree-builder.rs
+++ b/rcdom/tests/xml-tree-builder.rs
@@ -70,7 +70,7 @@ fn parse_tests<It: Iterator<Item = String>>(mut lines: It) -> Vec<HashMap<String
 
 fn serialize(buf: &mut String, indent: usize, handle: Handle) {
     buf.push('|');
-    buf.extend(iter::repeat(" ").take(indent));
+    buf.extend(iter::repeat_n(" ", indent));
 
     let node = handle;
     match &node.data {
@@ -132,7 +132,7 @@ fn serialize(buf: &mut String, indent: usize, handle: Handle) {
 
             for attr in attrs.into_iter() {
                 buf.push('|');
-                buf.extend(iter::repeat(" ").take(indent + 2));
+                buf.extend(iter::repeat_n(" ", indent + 2));
 
                 if !attr.name.ns.is_empty() {
                     buf.push('{');


### PR DESCRIPTION
* Fix some clippy errors
* Add documentation to a few methods
* initialize logger for rcdom examples, so they are more useful for debugging

These are changes that I did while looking a bit into https://github.com/servo/html5ever/issues/588, they're not particularly not important but it feels silly to not commit them.