### PR TITLE
Don't import xml5ever enums into the global namespace

### DIFF
--- a/xml5ever/src/tree_builder/types.rs
+++ b/xml5ever/src/tree_builder/types.rs
@@ -7,10 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use self::Token::*;
-pub use self::XmlPhase::*;
-pub use self::XmlProcessResult::*;
-
 use crate::tendril::StrTendril;
 use crate::tokenizer::{Doctype, Pi, Tag};
 


### PR DESCRIPTION
This is mostly the same as https://github.com/servo/html5ever/pull/593 but for xml5ever.
