### PR TITLE
Add a fast path for the data state using SSE2 instructions

### DIFF
--- a/markup5ever/util/buffer_queue.rs
+++ b/markup5ever/util/buffer_queue.rs
@@ -18,7 +18,11 @@
 //!
 //! [`BufferQueue`]: struct.BufferQueue.html
 
-use std::{cell::RefCell, collections::VecDeque, mem};
+use std::{
+    cell::{RefCell, RefMut},
+    collections::VecDeque,
+    mem,
+};
 
 use tendril::StrTendril;
 
@@ -245,6 +249,19 @@ impl BufferQueue {
             &mut *self.buffers.borrow_mut(),
             &mut *other.buffers.borrow_mut(),
         );
+    }
+
+    /// Return a mutable reference to the first tendril in the queue.
+    pub fn peek_front_chunk_mut(&self) -> Option<RefMut<StrTendril>> {
+        let buffers = self.buffers.borrow_mut();
+        if buffers.is_empty() {
+            return None;
+        }
+
+        let front_buffer = RefMut::map(buffers, |buffers| {
+            buffers.front_mut().expect("there is at least one buffer")
+        });
+        Some(front_buffer)
     }
 }
 


### PR DESCRIPTION
The data state is where the HTML tokenizer spends most of it's time. It is also very simple - all it does is scan the input stream for the next character in a set. This can easily be optimized with SIMD instructions. The algorithm I used is described in https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/.

This change significantly speeds up the tokenizer. Both `lipsum.html` and `lipsum.zh.html` see improvements of 70-80%, which is not suprising since they never leave the data state.

Very small inputs regress slightly. There is also a performance regression of ~5% for malicious input that consists only of tags (the `strong.html` benchmark). In that case the SIMD instructions are overkill because the target character (`<`) is always the first one in the input stream.

Note that the implementation could be made significantly faster by not keeping track of newlines. The only use in servo for the line number is for script elements, where the line number eventually ends up in https://github.com/servo/mozjs/blob/d1525dfaee22cc1ea9ee16c552cdeedaa9f20741/mozjs-sys/src/jsglue.cpp#L608.

<details>
<summary>Benchmark results</summary>

```
html tokenizing lipsum.html
                        time:   [1.8185 µs 1.8217 µs 1.8253 µs]
                        change: [-75.139% -75.046% -74.950%] (p = 0.00 < 0.05)
                        Performance has improved.

html tokenizing lipsum-zh.html
                        time:   [1.0855 µs 1.0918 µs 1.1002 µs]
                        change: [-80.345% -80.260% -80.165%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

html tokenizing medium-fragment.html
                        time:   [30.136 µs 30.179 µs 30.227 µs]
                        change: [-0.8699% -0.5956% -0.3121%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe

html tokenizing small-fragment.html
                        time:   [2.5780 µs 2.5908 µs 2.6047 µs]
                        change: [-11.670% -11.371% -11.033%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe

html tokenizing tiny-fragment.html
                        time:   [316.23 ns 316.68 ns 317.18 ns]
                        change: [+2.2782% +3.0717% +3.7761%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe

html tokenizing strong.html
                        time:   [20.781 µs 20.887 µs 21.012 µs]
                        change: [+5.7845% +6.2623% +6.7381%] (p = 0.00 < 0.05)
                        Performance has regressed.
```
</details>