### PR TITLE
Bump markup5ever to `0.16.1`

### DIFF
--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.16.0"
+version = "0.16.1"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"


### PR DESCRIPTION
I believe this should allow us to release the split-out `web_atoms` crate in a non-breaking release.

Steps:
- Merge this PR
- Publish `web_atoms` 0.1
- Publish `markup5ever` 0.16.1
- Update and merge Servo version bump (with lint fix) https://github.com/servo/servo/pull/36542/files