### PR TITLE
Remove unsupported category.

### DIFF
--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/servo/html5ever"
 description = "Atoms for xml5ever and html5ever"
 documentation = "https://docs.rs/web_atoms"
 build = "build.rs"
-categories = [ "string-interning", "web-programming" ]
+categories = [ "web-programming" ]
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
Only the category slugs listed at https://crates.io/category_slugs are allowed. I had to remove this one and publish with `--allow-dirty` to perform the initial publish of web_atoms.