### PR TITLE
Add `innerText` and `textContent` as localname

### DIFF
--- a/web_atoms/local_names.txt
+++ b/web_atoms/local_names.txt
@@ -431,6 +431,7 @@ in
 in2
 index
 infinity
+innerText
 input
 inputmode
 ins
@@ -936,6 +937,7 @@ text
 text-anchor
 text-decoration
 text-rendering
+textContent
 textLength
 textPath
 textarea


### PR DESCRIPTION
Required for https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent
and https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext

Part of servo/servo#36258