### PR TITLE
Release web-atoms 0.1.3

### DIFF
--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web_atoms"
-version = "0.1.2"
+version = "0.1.3"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"


### PR DESCRIPTION
Apologies for the PR spam, I forgot to bump the crate version in https://github.com/servo/html5ever/pull/614.