### PR TITLE
Publish html5ever 0.32.0.

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html5ever"
-version = "0.31.0"
+version = "0.32.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 
 [dependencies]
 tendril = "0.4"
-html5ever = { version = "0.31", path = "../html5ever" }
+html5ever = { version = "0.32", path = "../html5ever" }
 markup5ever = { version = "0.16", path = "../markup5ever" }
 xml5ever = { version = "0.22", path = "../xml5ever" }
 


### PR DESCRIPTION
This version includes https://github.com/servo/html5ever/pull/593, which is a breaking change.