### PR TITLE
Publish match_token 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ resolver = "2"
 rust-version = "1.70.0"
 
 [workspace.dependencies]
-match_token = { version = "0.1", path = "match_token" }
+match_token = { version = "0.1.1", path = "match_token" }
 

--- a/match_token/Cargo.toml
+++ b/match_token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "match_token"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Procedural macro for html5ever."


### PR DESCRIPTION
This version includes a change that's required to build the newest version of html5ever.