### PR TITLE
Batch parsing of inline scripts/stylesheets

### DIFF
--- a/html5ever/src/tokenizer/mod.rs
+++ b/html5ever/src/tokenizer/mod.rs
@@ -769,7 +769,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
             //§ rcdata-state
             states::RawData(Rcdata) => loop {
-                match pop_except_from!(self, input, small_char_set!('\r' '\0' '&' '<' '\n')) {
+                match pop_except_from!(self, input, small_char_set!('\0' '&' '<')) {
                     FromSet('\0') => {
                         self.bad_char_error();
                         self.emit_char('\u{fffd}');
@@ -783,7 +783,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
             //§ rawtext-state
             states::RawData(Rawtext) => loop {
-                match pop_except_from!(self, input, small_char_set!('\r' '\0' '<' '\n')) {
+                match pop_except_from!(self, input, small_char_set!('\0' '<')) {
                     FromSet('\0') => {
                         self.bad_char_error();
                         self.emit_char('\u{fffd}');
@@ -796,7 +796,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
             //§ script-data-state
             states::RawData(ScriptData) => loop {
-                match pop_except_from!(self, input, small_char_set!('\r' '\0' '<' '\n')) {
+                match pop_except_from!(self, input, small_char_set!('\0' '<')) {
                     FromSet('\0') => {
                         self.bad_char_error();
                         self.emit_char('\u{fffd}');
@@ -809,7 +809,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
             //§ script-data-escaped-state
             states::RawData(ScriptDataEscaped(Escaped)) => loop {
-                match pop_except_from!(self, input, small_char_set!('\r' '\0' '-' '<' '\n')) {
+                match pop_except_from!(self, input, small_char_set!('\0' '-' '<')) {
                     FromSet('\0') => {
                         self.bad_char_error();
                         self.emit_char('\u{fffd}');
@@ -826,7 +826,7 @@ impl<Sink: TokenSink> Tokenizer<Sink> {
 
             //§ script-data-double-escaped-state
             states::RawData(ScriptDataEscaped(DoubleEscaped)) => loop {
-                match pop_except_from!(self, input, small_char_set!('\r' '\0' '-' '<' '\n')) {
+                match pop_except_from!(self, input, small_char_set!('\0' '-' '<')) {
                     FromSet('\0') => {
                         self.bad_char_error();
                         self.emit_char('\u{fffd}');


### PR DESCRIPTION
Before: html5ever produces tokens for each line of inline content
After: html5ever batchs inline contents until encounter '<', which represents endtag in most cases
Fixes: https://github.com/servo/servo/issues/34502