### PR TITLE
Determine the initial state for fragment parsing using the scripting flag of the context element

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html5ever"
-version = "0.32.1"
+version = "0.33.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -223,7 +223,10 @@ where
 
     // https://html.spec.whatwg.org/multipage/#concept-frag-parse-context
     // Step 4. Set the state of the HTML parser's tokenization stage as follows:
-    pub fn tokenizer_state_for_context_elem(&self) -> tok_state::State {
+    pub fn tokenizer_state_for_context_elem(
+        &self,
+        context_element_allows_scripting: bool,
+    ) -> tok_state::State {
         let context_elem = self.context_elem.borrow();
         let elem = context_elem.as_ref().expect("no context element");
         let elem_name = self.sink.elem_name(elem);
@@ -246,7 +249,7 @@ where
             local_name!("script") => tok_state::RawData(tok_state::ScriptData),
 
             local_name!("noscript") => {
-                if self.opts.scripting_enabled {
+                if context_element_allows_scripting {
                     tok_state::RawData(tok_state::Rawtext)
                 } else {
                     tok_state::Data

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 
 [dependencies]
 tendril = "0.4"
-html5ever = { version = "0.32", path = "../html5ever" }
+html5ever = { version = "0.33", path = "../html5ever" }
 markup5ever = { version = "0.16", path = "../markup5ever" }
 xml5ever = { version = "0.23", path = "../xml5ever" }
 

--- a/rcdom/tests/html-serializer.rs
+++ b/rcdom/tests/html-serializer.rs
@@ -94,6 +94,7 @@ fn parse_and_serialize(input: StrTendril) -> StrTendril {
         ParseOpts::default(),
         QualName::new(None, ns!(html), local_name!("body")),
         vec![],
+        true,
     )
     .one(input);
     let inner: SerializableHandle = dom.document.children.borrow()[0].clone().into();
@@ -252,6 +253,7 @@ fn deep_tree() {
         ParseOpts::default(),
         QualName::new(None, ns!(html), local_name!("div")),
         vec![],
+        true,
     );
     let src = "<b>".repeat(60_000);
     let dom = parser.one(src);

--- a/rcdom/tests/html-tree-builder.rs
+++ b/rcdom/tests/html-tree-builder.rs
@@ -225,7 +225,7 @@ fn make_test_desc_with_scripting_flag(
                     }
                 },
                 Some(ref context) => {
-                    let dom = parse_fragment(RcDom::default(), opts, context.clone(), vec![])
+                    let dom = parse_fragment(RcDom::default(), opts, context.clone(), vec![], true)
                         .one(data.clone());
                     // fragment case: serialize children of the html element
                     // rather than children of the document


### PR DESCRIPTION
Companion PR for https://github.com/servo/servo/pull/37704. Refer to that PR for a description of the change.

Fixes https://github.com/servo/html5ever/issues/579

This is a breaking change.