### PR TITLE
Replace the absolute paths to test files with the relative paths

### DIFF
--- a/html5ever/benches/html5ever.rs
+++ b/html5ever/benches/html5ever.rs
@@ -24,7 +24,7 @@ impl TokenSink for Sink {
 }
 
 fn run_bench(c: &mut Criterion, name: &str) {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut path = PathBuf::from("./");
     path.push("data/bench/");
     path.push(name);
     let mut file = fs::File::open(&path).expect("can't open file");

--- a/rcdom/tests/html-tokenizer.rs
+++ b/rcdom/tests/html-tokenizer.rs
@@ -26,7 +26,7 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use std::{char, env};
+use std::char;
 
 use util::runner::{run_all, Test};
 
@@ -478,5 +478,5 @@ fn tests(src_dir: &Path) -> Vec<Test> {
 }
 
 fn main() {
-    run_all(tests(Path::new(env!("CARGO_MANIFEST_DIR"))));
+    run_all(tests(Path::new("./")));
 }

--- a/rcdom/tests/html-tree-builder.rs
+++ b/rcdom/tests/html-tree-builder.rs
@@ -18,7 +18,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::io::BufRead;
 use std::path::Path;
-use std::{env, fs, io, iter, mem};
+use std::{fs, io, iter, mem};
 
 use html5ever::tendril::{StrTendril, TendrilSink};
 use html5ever::{parse_document, parse_fragment, ParseOpts};
@@ -284,7 +284,7 @@ fn tests(src_dir: &Path, ignores: &HashSet<String>) -> Vec<Test> {
 }
 
 fn main() {
-    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let src_dir = Path::new("./");
     let mut ignores = HashSet::new();
     {
         let f = fs::File::open(src_dir.join("data/test/ignore")).unwrap();

--- a/rcdom/tests/xml-tokenizer.rs
+++ b/rcdom/tests/xml-tokenizer.rs
@@ -10,7 +10,6 @@
 use serde_json::{Map, Value};
 use std::borrow::Cow::Borrowed;
 use std::cell::RefCell;
-use std::env;
 use std::ffi::OsStr;
 use std::io::Read;
 use std::path::Path;
@@ -371,5 +370,5 @@ fn tests(src_dir: &Path) -> Vec<Test> {
 }
 
 fn main() {
-    run_all(tests(Path::new(env!("CARGO_MANIFEST_DIR"))));
+    run_all(tests(Path::new("./")));
 }

--- a/rcdom/tests/xml-tree-builder.rs
+++ b/rcdom/tests/xml-tree-builder.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::io::BufRead;
 use std::path::Path;
-use std::{env, fs, io, iter, mem};
+use std::{fs, io, iter, mem};
 use util::find_tests::foreach_xml5lib_test;
 use util::runner::{run_all, Test};
 use xml5ever::driver::parse_document;
@@ -224,7 +224,7 @@ fn tests(src_dir: &Path, ignores: &HashSet<String>) -> Vec<Test> {
 }
 
 fn main() {
-    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let src_dir = Path::new("./");
     let mut ignores = HashSet::new();
     if let Ok(f) = fs::File::open(src_dir.join("data/test/ignore")) {
         let r = io::BufReader::new(f);

--- a/xml5ever/benches/xml5ever.rs
+++ b/xml5ever/benches/xml5ever.rs
@@ -26,7 +26,7 @@ impl TokenSink for Sink {
 }
 
 fn run_bench(c: &mut Criterion, name: &str) {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut path = PathBuf::from("./");
     path.push("data/bench/");
     path.push(name);
     let mut file = fs::File::open(&path).expect("can't open file");


### PR DESCRIPTION
As long as the absolute path `env!("CARGO_MANIFEST_DIR")` is used to access the test files it is often impossible to test a cross-platform build on the target platform since the corresponding path can't be created.
On the other hand according to [The Cargo Book](https://doc.rust-lang.org/cargo/commands/cargo-test.html)

> The working directory when running each unit and integration test is set to the root directory of the package the test belongs to.
> Setting the working directory of tests to the package's root directory makes it possible for tests to reliably access the package's files using relative paths, regardless from where `cargo test` was executed from.
