### PR TITLE
Don't return a string from `TreeSink::attach_declarative_shadow_root`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add html5ever as a dependency in your [`Cargo.toml`](https://crates.io/) file:
 
 ```toml
 [dependencies]
-html5ever = "0.32"
+html5ever = "0.34"
 ```
 
 You should also take a look at [`examples/html2html.rs`], [`examples/print-rcdom.rs`], and the [API documentation][].

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html5ever"
-version = "0.33.0"
+version = "0.34.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -1492,9 +1492,9 @@ where
         tag: &Tag,
         shadow_host: &Handle,
         template: &Handle,
-    ) -> Result<(), String> {
+    ) -> bool {
         self.sink
-            .attach_declarative_shadow(shadow_host, template, tag.attrs.clone())
+            .attach_declarative_shadow(shadow_host, template, &tag.attrs)
     }
 
     fn create_formatting_element_for(&self, tag: Tag) -> Handle {

--- a/html5ever/src/tree_builder/rules.rs
+++ b/html5ever/src/tree_builder/rules.rs
@@ -173,7 +173,8 @@ where
 
                         // Step 3 - 8.
                         // Attach a shadow root with declarative shadow host element, mode, clonable, serializable, delegatesFocus, and "named".
-                        if self.attach_declarative_shadow(&tag, &shadow_host, &template).is_err() {
+                        let succeeded = self.attach_declarative_shadow(&tag, &shadow_host, &template);
+                        if !succeeded {
                             // Step 8.1.1. Insert an element at the adjusted insertion location with template.
                             // Pop the current template element created in step 2 first.
                             self.pop();

--- a/markup5ever/interface/tree_builder.rs
+++ b/markup5ever/interface/tree_builder.rs
@@ -249,16 +249,16 @@ pub trait TreeSink {
         true
     }
 
-    /// Attach declarative shadow
+    /// Attempt to attach a declarative shadow root at the given location.
+    ///
+    /// Returns a boolean indicating whether the operation succeeded or not.
     fn attach_declarative_shadow(
         &self,
         _location: &Self::Handle,
         _template: &Self::Handle,
-        _attrs: Vec<Attribute>,
-    ) -> Result<(), String> {
-        Err(String::from(
-            "No implementation for attach_declarative_shadow",
-        ))
+        _attrs: &[Attribute],
+    ) -> bool {
+        false
     }
 }
 

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 
 [dependencies]
 tendril = "0.4"
-html5ever = { version = "0.33", path = "../html5ever" }
+html5ever = { version = "0.34", path = "../html5ever" }
 markup5ever = { version = "0.16", path = "../markup5ever" }
 xml5ever = { version = "0.23", path = "../xml5ever" }
 


### PR DESCRIPTION
The string is unused, so this is just a pointless allocation. This change returns a `bool` indicating the operations success instead.

Additionally, pass a reference to the elements attributes. The callee can decide whether they need ownership of the vector or not (servo doesn't).