### PR TITLE
Don't clone input buffer inside html5ever benchmark loop

### DIFF
--- a/html5ever/benches/html5ever.rs
+++ b/html5ever/benches/html5ever.rs
@@ -5,10 +5,10 @@ extern crate html5ever;
 use std::fs;
 use std::path::PathBuf;
 
-use criterion::Criterion;
+use criterion::{BatchSize, Criterion};
 
-use html5ever::tendril::*;
 use html5ever::tokenizer::{BufferQueue, Token, TokenSink, TokenSinkResult, Tokenizer};
+use html5ever::{tendril::*, TokenizerResult};
 
 struct Sink;
 
@@ -51,19 +51,25 @@ fn run_bench(c: &mut Criterion, name: &str) {
 
     let test_name = format!("html tokenizing {name}");
 
+    // Construct a buffer queue to feed to the tokenizer
+    let buffer_queue = BufferQueue::default();
+    for buf in input.into_iter() {
+        buffer_queue.push_back(buf);
+    }
+
     c.bench_function(&test_name, move |b| {
-        b.iter(|| {
-            let tok = Tokenizer::new(Sink, Default::default());
-            let buffer = BufferQueue::default();
-            // We are doing clone inside the bench function, this is not ideal, but possibly
-            // necessary since our iterator consumes the underlying buffer.
-            for buf in input.clone().into_iter() {
-                buffer.push_back(buf);
-                let _ = tok.feed(&buffer);
-            }
-            let _ = tok.feed(&buffer);
-            tok.end();
-        })
+        b.iter_batched(
+            || buffer_queue.clone(),
+            |buffer_queue| {
+                let tok = Tokenizer::new(Sink, Default::default());
+
+                // Tokenize the entire input, ignoring any <script> elements we find along the way
+                while tok.feed(&buffer_queue) != TokenizerResult::Done {}
+
+                tok.end();
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 

--- a/markup5ever/interface/mod.rs
+++ b/markup5ever/interface/mod.rs
@@ -61,7 +61,7 @@ impl fmt::Debug for ExpandedName<'_> {
 }
 
 #[must_use]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum TokenizerResult<Handle> {
     Done,
     Script(Handle),

--- a/markup5ever/util/buffer_queue.rs
+++ b/markup5ever/util/buffer_queue.rs
@@ -47,7 +47,7 @@ pub enum SetResult {
 /// Internally it uses [`VecDeque`] and has the same complexity properties.
 ///
 /// [`VecDeque`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BufferQueue {
     /// Buffers to process.
     buffers: RefCell<VecDeque<StrTendril>>,


### PR DESCRIPTION
This clone operation should not be counted towards the benchmark time. When the benchmark was written criterion did not support per-iteration setup, but now it does using `Bencher::iter_batched`. Using this method reduces the benchmark time by 9% in `lipsum.html`.

Additionally, the way html5ever was used inside the benchmarks was wrong if there were `<script>` elements in the input. 
To fully tokenize input in html5ever, you need to spin on the `Tokenizer::feed` method until it returns `Done`.
None of our benchmarks contain any script elements, but it's better to fix it anyways.