### PR TITLE
Bump markup5ever to 0.17

### DIFF
--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -18,7 +18,7 @@ trace_tokenizer = []
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.16.2", path = "../markup5ever" }
+markup5ever = { version = "0.17", path = "../markup5ever" }
 match_token = { workspace = true }
 
 [dev-dependencies]

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markup5ever"
-version = "0.16.2"
+version = "0.17.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 [dependencies]
 tendril = "0.4"
 html5ever = { version = "0.34", path = "../html5ever" }
-markup5ever = { version = "0.16", path = "../markup5ever" }
+markup5ever = { version = "0.17", path = "../markup5ever" }
 xml5ever = { version = "0.23", path = "../xml5ever" }
 
 [dev-dependencies]

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -20,7 +20,7 @@ trace_tokenizer = []
 [dependencies]
 log = "0.4"
 mac = "0.1"
-markup5ever = { version = "0.16", path = "../markup5ever" }
+markup5ever = { version = "0.17", path = "../markup5ever" }
 
 [dev-dependencies]
 criterion = "0.6"


### PR DESCRIPTION
As per https://github.com/servo/html5ever/pull/633#issuecomment-3013813938 I should have done this as part of #633. 