### PR TITLE
Simplify version management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "web_atoms",
     "markup5ever",
@@ -8,11 +9,40 @@ members = [
     "match_token"
 ]
 
-resolver = "2"
-
 [workspace.package]
+version = "0.35.0"
+license = "MIT OR Apache-2.0"
+authors = [ "The html5ever Project Developers" ]
+repository = "https://github.com/servo/html5ever"
+edition = "2021"
 rust-version = "1.70.0"
 
 [workspace.dependencies]
-match_token = { version = "0.2.0", path = "match_token" }
+# Repo dependencies
+web_atoms = { version = "0.1", path = "web_atoms" }
+match_token = { version = "0.35.0", path = "match_token" }
+markup5ever = { version = "0.35.0", path = "markup5ever" }
+xml5ever = { version = "0.35.0", path = "xml5ever" }
+html5ever = { version = "0.35.0", path = "html5ever" }
+
+# External dependencies
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"
+log = "0.4"
+mac = "0.1"
+tendril = "0.4"
+string_cache = "0.8.8"
+string_cache_codegen = "0.5.4"
+phf = "0.11"
+phf_codegen = "0.11"
+
+# Dev dependencies
+criterion = "0.6"
+libtest-mimic = "0.8.1"
+serde_json = "1.0"
+env_logger = "0.10"
+typed-arena = "2.0.2"
+
+
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ html5ever is written in [Rust][], therefore it avoids the notorious security pro
 
 ## Getting started in Rust
 
-Add html5ever as a dependency in your [`Cargo.toml`](https://crates.io/) file:
+Add html5ever as a dependency:
 
-```toml
-[dependencies]
-html5ever = "0.34"
+```bash
+cargo add html5ever
 ```
 
 You should also take a look at [`examples/html2html.rs`], [`examples/print-rcdom.rs`], and the [API documentation][].

--- a/RELEASING.MD
+++ b/RELEASING.MD
@@ -1,0 +1,30 @@
+# Crate Publishing Guide
+
+The following crates are on a synchronised release cycle with version managed through the workspace `Cargo.toml`:
+
+- **match_token**
+- **markup5ever**
+- **xml5ever**
+- **html5ever**
+
+The **markup5ever_rcdom** crate's version is also set to match these crates. But it is set to `publish = false` and isn't
+published to crates.io.
+
+The **web_atoms** crate is on a separate cycle as it needs frequent releases but these rarely contain breaking changes.
+
+## Making a release of **web_atoms**:
+
+- Bump the version in `web_atoms/Cargo.toml`
+   - If just adding an atom, the patch version should be bumped
+   - If upgrading `phf` version the minor version should be bumped as this is breaking
+- Update the version **web_atoms** in the workspace `Cargo.toml`'s `[workspace.dependencies]` section to match
+- Publish the new version of **web_atoms**
+- Optionally: publish a new version of the other crates to match
+
+## Making a release of all other crates
+
+In the workspace `Cargo.toml`:
+
+- Update the `version` key in the `[workspace.package]` section
+- Update the versions for `match_token`, `markup5ever`, `xml5ever`, and `html5ever` in the `[workspace.dependencies]` section to match
+- Publish all of the crates. The order they are listed in at the top of this file will work.

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "html5ever"
-version = "0.34.0"
-authors = [ "The html5ever Project Developers" ]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/servo/html5ever"
 description = "High-performance browser-grade HTML5 parser"
 documentation = "https://docs.rs/html5ever"
 categories = [ "parser-implementations", "web-programming" ]
 keywords = ["html", "html5", "parser", "parsing"]
-edition = "2021"
 readme = "../README.md"
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+edition.workspace = true
 rust-version.workspace = true
 
 [features]
 trace_tokenizer = []
 
 [dependencies]
-log = "0.4"
-markup5ever = { version = "0.17", path = "../markup5ever" }
+markup5ever = { workspace = true }
 match_token = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.6"
-typed-arena = "2.0.2"
+criterion = { workspace = true }
+typed-arena = { workspace = true }
 
 [[bench]]
 name = "html5ever"

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "markup5ever"
-version = "0.17.0"
-authors = [ "The html5ever Project Developers" ]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/servo/html5ever"
 description = "Common code for xml5ever and html5ever"
 documentation = "https://docs.rs/markup5ever"
 categories = [ "parser-implementations", "web-programming" ]
-edition = "2021"
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+edition.workspace = true
 rust-version.workspace = true
 
 [lib]
 path = "lib.rs"
 
 [dependencies]
-web_atoms = { version = "0.1", path = "../web_atoms" }
-tendril = "0.4"
-log = "0.4"
+web_atoms = { workspace = true }
+tendril = { workspace = true }
+log = { workspace = true }

--- a/match_token/Cargo.toml
+++ b/match_token/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
 name = "match_token"
-version = "0.2.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
 description = "Procedural macro for html5ever."
-repository = "https://github.com/servo/html5ever"
+documentation = "https://docs.rs/match_token"
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-syn = { version = "2", features = ["full"] }
-quote = "1"
-proc-macro2 = "1"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "markup5ever_rcdom"
-version = "0.3.0"
-authors = [ "The html5ever Project Developers" ]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/servo/html5ever"
 description = "Basic, unsupported DOM structure for use by tests in html5ever/xml5ever"
 readme = "README.md"
 documentation = "https://docs.rs/markup5ever_rcdom"
 categories = [ "parser-implementations", "web-programming" ]
-edition = "2021"
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+edition.workspace = true
 publish = false
 
 [lib]
 path = "lib.rs"
 
 [dependencies]
-tendril = "0.4"
-html5ever = { version = "0.34", path = "../html5ever" }
-markup5ever = { version = "0.17", path = "../markup5ever" }
-xml5ever = { version = "0.23", path = "../xml5ever" }
+html5ever = { workspace = true }
+markup5ever = { workspace = true }
+xml5ever = { workspace = true }
+tendril = { workspace = true }
 
 [dev-dependencies]
 libtest-mimic = "0.8.1"

--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -15,9 +15,9 @@ rust-version.workspace = true
 path = "lib.rs"
 
 [dependencies]
-string_cache = "0.8.8"
-phf = "0.11"
+string_cache = { workspace = true }
+phf = { workspace = true }
 
 [build-dependencies]
-string_cache_codegen = "0.5.4"
-phf_codegen = "0.11"
+string_cache_codegen = { workspace = true }
+phf_codegen = { workspace = true }

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -1,9 +1,6 @@
 [package]
 name = "xml5ever"
-version = "0.23.0"
 authors = ["The xml5ever project developers"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/servo/html5ever"
 description = "Push based streaming parser for XML."
 documentation = "https://docs.rs/xml5ever"
 homepage = "https://github.com/servo/html5ever/blob/main/xml5ever/README.md"
@@ -11,18 +8,21 @@ readme = "README.md"
 keywords = ["xml", "xml5", "parser", "parsing"]
 exclude = ["xml5lib-tests/*"]
 categories = ["parser-implementations", "web-programming"]
-edition = "2021"
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 rust-version.workspace = true
 
 [features]
 trace_tokenizer = []
 
 [dependencies]
-log = "0.4"
-markup5ever = { version = "0.17", path = "../markup5ever" }
+markup5ever = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.6"
+criterion = { workspace = true }
 
 [[bench]]
 name = "xml5ever"

--- a/xml5ever/README.md
+++ b/xml5ever/README.md
@@ -34,11 +34,10 @@ templates. XML5 tries to handle most common errors, in a manner similar to HTML5
 
 # Installation
 
-Add xml5ever as a dependency in your project manifest:
+Add xml5ever as a dependency:
 
-```toml
-[dependencies]
-xml5ever = "0.23"
+```bash
+cargo add xml5ever
 ```
 
 # Getting started


### PR DESCRIPTION
# Objectives

- Simplify version management of `html5ever`
- Prevent mistakes with publishing
- Implements https://github.com/servo/html5ever/issues/605

## Changes made
- Moved version definition to root (workspace) `Cargo.toml`
- Moved all dependency definitions to root (workspace) `Cargo.toml`
- Synchronised version numbers for all crates except `web_atoms` (and bumped them all to `0.35.0`)
- Removed references to specific version numbers from the READMEs. These now suggest using `cargo add` instead.
- Added publishing guide in `RELEASING.md`

## Notes

The premise of this PR is that even frequent breaking releases typically aren't actually problematic for users so long as they are actually made with a semver-breaking version bump. But we have recently broken people's builds on a few occasions by accidentally publishing breaking changes under a semver-compatible version number. So we should bias towards bumping version numbers more aggressively in such a way that helps us to avoid making such mistakes in future.