### PR TITLE
Generate rustdoc documentation for all publicly exported items

### DIFF
--- a/xml5ever/src/tokenizer/states.rs
+++ b/xml5ever/src/tokenizer/states.rs
@@ -12,19 +12,19 @@
 //! This is public for use by the tokenizer tests.  Other library
 //! users should not have to care about this.
 
-pub use self::AttrValueKind::*;
-pub use self::DoctypeKind::*;
-pub use self::XmlState::*;
+#![allow(missing_docs)] // FIXME
+
+pub use AttrValueKind::*;
+pub use DoctypeKind::*;
+pub use XmlState::*;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
-#[doc(hidden)]
 pub enum DoctypeKind {
     Public,
     System,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
-#[doc(hidden)]
 pub enum XmlState {
     Data,
     TagState,
@@ -73,7 +73,6 @@ pub enum XmlState {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug)]
-#[doc(hidden)]
 pub enum AttrValueKind {
     Unquoted,
     SingleQuoted,

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -47,14 +47,12 @@ impl NamespaceMapStack {
         self.0.push(map);
     }
 
-    #[doc(hidden)]
-    pub fn pop(&mut self) {
+    fn pop(&mut self) {
         self.0.pop();
     }
 }
 
-#[doc(hidden)]
-pub struct NamespaceMap {
+pub(crate) struct NamespaceMap {
     // Map that maps prefixes to URI.
     //
     // Key denotes namespace prefix, and value denotes
@@ -77,8 +75,7 @@ impl Debug for NamespaceMap {
 
 impl NamespaceMap {
     // Returns an empty namespace.
-    #[doc(hidden)]
-    pub fn empty() -> NamespaceMap {
+    pub(crate) fn empty() -> NamespaceMap {
         NamespaceMap {
             scope: BTreeMap::new(),
         }
@@ -96,18 +93,15 @@ impl NamespaceMap {
         }
     }
 
-    #[doc(hidden)]
-    pub fn get(&self, prefix: &Option<Prefix>) -> Option<&Option<Namespace>> {
+    pub(crate) fn get(&self, prefix: &Option<Prefix>) -> Option<&Option<Namespace>> {
         self.scope.get(prefix)
     }
 
-    #[doc(hidden)]
-    pub fn get_scope_iter(&self) -> Iter<'_, Option<Prefix>, Option<Namespace>> {
+    pub(crate) fn get_scope_iter(&self) -> Iter<'_, Option<Prefix>, Option<Namespace>> {
         self.scope.iter()
     }
 
-    #[doc(hidden)]
-    pub fn insert(&mut self, name: &QualName) {
+    pub(crate) fn insert(&mut self, name: &QualName) {
         let prefix = name.prefix.as_ref().cloned();
         let namespace = Some(Namespace::from(&*name.ns));
         self.scope.insert(prefix, namespace);
@@ -438,7 +432,6 @@ fn current_node<Handle>(open_elems: &[Handle]) -> &Handle {
     open_elems.last().expect("no current element")
 }
 
-#[doc(hidden)]
 impl<Handle, Sink> XmlTreeBuilder<Handle, Sink>
 where
     Handle: Clone,
@@ -607,7 +600,6 @@ fn any_not_whitespace(x: &StrTendril) -> bool {
         .all(|b| matches!(b, b'\t' | b'\r' | b'\n' | b'\x0C' | b' '))
 }
 
-#[doc(hidden)]
 impl<Handle, Sink> XmlTreeBuilder<Handle, Sink>
 where
     Handle: Clone,


### PR DESCRIPTION
A few of the items in xml5ever are annotated with `#[doc(hidden)]`. This causes the `initial_state` field in https://docs.rs/xml5ever/latest/xml5ever/tokenizer/struct.XmlTokenizerOpts.html to not link to the enum, which is bad.

Presumably this is done because the author wanted to get around the `#[deny(missing_docs)]` lint? I'm not sure. Not all of these need to be public and I have reduced the visibility of a few items (`NamespaceMap` and a few methods) to `pub(crate)`. This makes this PR a breaking change. I believe that these were not intended to be public in the first place, but I can undo that if requested.

