### PR TITLE
ci: Integrate github inline annotation for clippy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,9 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy --all-features --all-targets -- -D warnings
+        uses: servo/actions/cargo-annotation@main
+        with:
+          cargo-command: clippy --all-features --all-targets -- -D warnings
 
   build_result:
     name: Result


### PR DESCRIPTION
Recently, we decided to centralize reusable actions in github/actions to make maintenance and updates easier across repositories. As part of this change, we are now adding Clippy annotations to some repos to make it easier to view errors directly in PRs.

https://github.com/servo/ipc-channel/pull/405#discussion_r2247738361