### PR TITLE
Fix `mismatched_lifetime_syntaxes` lint

### DIFF
--- a/html5ever/examples/noop-tree-builder.rs
+++ b/html5ever/examples/noop-tree-builder.rs
@@ -63,7 +63,7 @@ impl TreeSink for Sink {
         x == y
     }
 
-    fn elem_name(&self, target: &usize) -> ExpandedName {
+    fn elem_name(&self, target: &usize) -> ExpandedName<'_> {
         self.names
             .borrow()
             .get(target)


### PR DESCRIPTION
This is a new lint in Rust 1.89 that is breaking CI. Fix is to add an explicit lifetime annotation.