### PR TITLE
Remove `XmlState::Quiescent`

### DIFF
--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -667,10 +667,6 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
 
         debug!("processing in state {:?}", self.state);
         match self.state.get() {
-            XmlState::Quiescent => {
-                self.state.set(XmlState::Data);
-                ProcessResult::Done
-            },
             //§ data-state
             XmlState::Data => loop {
                 match pop_except_from!(self, input, small_char_set!('\r' '&' '<')) {
@@ -1163,7 +1159,7 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
     fn eof_step(&self) -> ProcessResult<Sink::Handle> {
         debug!("processing EOF in state {:?}", self.state.get());
         match self.state.get() {
-            XmlState::Data | XmlState::Quiescent => go!(self: eof),
+            XmlState::Data => go!(self: eof),
             XmlState::CommentStart | XmlState::CommentLessThan | XmlState::CommentLessThanBang => {
                 go!(self: reconsume Comment)
             },

--- a/xml5ever/src/tokenizer/states.rs
+++ b/xml5ever/src/tokenizer/states.rs
@@ -153,10 +153,6 @@ pub enum XmlState {
     /// Indicates that the parser is currently parsing an ill-formed comment, such as
     /// `<? this is not what a comment should look like! >`.
     BogusComment,
-    /// Interrupts the tokenizer for one single call to `step`.
-    ///
-    /// It is unclear whether this is still necessary ([#649](https://github.com/servo/html5ever/issues/649)).
-    Quiescent,
 }
 
 /// Specifies how an attribute value is quoted, if at all.


### PR DESCRIPTION
Servo previously needed this state, but doesn't anymore.

This is a breaking change, but all repositories on GitHub using `Quiescent` (that I could find) were html5ever forks.

Fixes https://github.com/servo/html5ever/issues/649