### PR TITLE
Continue parsing instead of stopping on script in xml5ever.

### DIFF
--- a/xml5ever/src/driver.rs
+++ b/xml5ever/src/driver.rs
@@ -16,6 +16,7 @@ use crate::tendril;
 use crate::tendril::stream::{TendrilSink, Utf8LossyDecoder};
 use crate::tendril::StrTendril;
 use markup5ever::buffer_queue::BufferQueue;
+use markup5ever::TokenizerResult;
 
 /// All-encompasing parser setting structure.
 #[derive(Clone, Default)]
@@ -64,7 +65,7 @@ impl<Sink: TreeSink> TendrilSink<tendril::fmt::UTF8> for XmlParser<Sink> {
     fn process(&mut self, t: StrTendril) {
         self.input_buffer.push_back(t);
         // FIXME: Properly support </script> somehow.
-        let _ = self.tokenizer.feed(&self.input_buffer);
+        while let TokenizerResult::Script(_) = self.tokenizer.feed(&self.input_buffer) {}
     }
 
     // FIXME: Is it too noisy to report every character decoding error?


### PR DESCRIPTION
Changes `XmlParser::process` to function like the html equivelant.

I think this is what it was meant to be when it was implemented here: https://github.com/servo/html5ever/pull/591#pullrequestreview-2734323784