### PR TITLE
Bump MSRV to 1.71

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install stable toolchain
         run: |
           rustup set profile minimal
-          rustup override set 1.70.0
+          rustup override set 1.71.0
 
       - run: cargo check --lib --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 authors = [ "The html5ever Project Developers" ]
 repository = "https://github.com/servo/html5ever"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.71.0"
 
 [workspace.dependencies]
 # Repo dependencies


### PR DESCRIPTION
Our MSRV is 1.70, parking_lot 0.12.5 needs 1.71. I was not able to tell cargo to pick compatible versions for both `parking_lot`, `parking_lot_core` and `lock_api`. (We can pin `parking_lot` in `Cargo.toml` but that seems to make cargo ignore the specified versions for the other two)

1.71 was released in summer of 2023 so upgrading should not be a problem.
