### PR TITLE
Svg missing experimental/unplanned local names

### DIFF
--- a/web_atoms/local_names.txt
+++ b/web_atoms/local_names.txt
@@ -400,6 +400,10 @@ h5
 h6
 handler
 hanging
+hatch
+hatchContentUnits
+hatchUnits
+hatchpath
 head
 header
 headers
@@ -779,6 +783,7 @@ picture
 piece
 piecewise
 ping
+pitch
 placeholder
 plaintext
 plus
@@ -902,6 +907,9 @@ sizes
 slope
 slot
 small
+solid-color
+solid-opacity
+solidColor
 solidcolor
 source
 space


### PR DESCRIPTION
https://github.com/servo/html5ever/pull/679

This is a follow up PR, these atoms would be useful to me in terms of writing tooling, but are likely not useful for a general use-case, so whether this is merged is up to the reviewer.

[hatch](https://docs.w3cub.com/svg/element/hatch.html) and [solidColor](https://udn.realityripple.com/docs/Web/SVG/Element/solidColor) as far as I know have been removed from the SVG 2 draft.

Note, https://github.com/servo/html5ever/pull/685/commits/8bfe5e9ac2d9dbc360d116dde9e324190b77c149 is merged, please review only https://github.com/servo/html5ever/pull/685/commits/3d9dec9057400c1d169c0622531de523f07237c5