### PR TITLE
Bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.0"
+version = "0.36.0"
 license = "MIT OR Apache-2.0"
 authors = [ "The html5ever Project Developers" ]
 repository = "https://github.com/servo/html5ever"
@@ -21,9 +21,9 @@ rust-version = "1.71.0"
 # Repo dependencies
 tendril = { version = "0.4.3", path = "tendril" }
 web_atoms = { version = "0.1", path = "web_atoms" }
-markup5ever = { version = "0.35.0", path = "markup5ever" }
-xml5ever = { version = "0.35.0", path = "xml5ever" }
-html5ever = { version = "0.35.0", path = "html5ever" }
+markup5ever = { version = "0.36.0", path = "markup5ever" }
+xml5ever = { version = "0.36.0", path = "xml5ever" }
+html5ever = { version = "0.36.0", path = "html5ever" }
 
 # External dependencies
 encoding = "0.2"

--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web_atoms"
-version = "0.1.3"
+version = "0.1.4"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"


### PR DESCRIPTION
Bumps html5ever, markup5ever and xml5everf to 0.36.0.
Bumps web_atoms to 0.1.4.