### PR TITLE
Bump web_atoms to 0.2, 5evers to 0.36.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.36.0"
+version = "0.36.1"
 license = "MIT OR Apache-2.0"
 authors = [ "The html5ever Project Developers" ]
 repository = "https://github.com/servo/html5ever"
@@ -20,10 +20,10 @@ rust-version = "1.71.0"
 [workspace.dependencies]
 # Repo dependencies
 tendril = { version = "0.4.3", path = "tendril" }
-web_atoms = { version = "0.1", path = "web_atoms" }
-markup5ever = { version = "0.36.0", path = "markup5ever" }
-xml5ever = { version = "0.36.0", path = "xml5ever" }
-html5ever = { version = "0.36.0", path = "html5ever" }
+web_atoms = { version = "0.2", path = "web_atoms" }
+markup5ever = { version = "0.36.1", path = "markup5ever" }
+xml5ever = { version = "0.36.1", path = "xml5ever" }
+html5ever = { version = "0.36.1", path = "html5ever" }
 
 # External dependencies
 encoding = "0.2"

--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web_atoms"
-version = "0.1.4"
+version = "0.2.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"


### PR DESCRIPTION
Bump `web_atoms` to 0.2 because upgrading `phf` is semver-breaking.

Once this is merged we need to:

- Publish `web_atoms` 0.2
- Publish `0.36.1` versions of `markup5ever`, `xml5ever`, `html5ever`.
- Yank the `0.1.4` version of `web_atoms`
- Yank the `0.36.0` versions of  `markup5ever`, `xml5ever`, `html5ever`.