### PR TITLE
Make serde dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ log = "0.4"
 new_debug_unreachable = "1.0.2"
 phf = "0.13"
 phf_codegen = "0.13"
-string_cache = "0.9.0"
+string_cache = { version = "0.9.0", default-features = false }
 string_cache_codegen = "0.6.1"
 utf-8 = "0.7"
 

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 
 [features]
 trace_tokenizer = []
+serde = ["markup5ever/serde"]
 
 [dependencies]
 markup5ever = { workspace = true }

--- a/markup5ever/Cargo.toml
+++ b/markup5ever/Cargo.toml
@@ -13,6 +13,9 @@ rust-version.workspace = true
 [lib]
 path = "lib.rs"
 
+[features]
+serde = ["web_atoms/serde"]
+
 [dependencies]
 web_atoms = { workspace = true }
 tendril = { workspace = true }

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 
 [dependencies]
 html5ever = { workspace = true }
-markup5ever = { workspace = true }
+markup5ever = { workspace = true, features = ["serde"]}
 xml5ever = { workspace = true }
 tendril = { workspace = true }
 

--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -14,6 +14,9 @@ rust-version.workspace = true
 [lib]
 path = "lib.rs"
 
+[features]
+serde = ["string_cache/serde_support"]
+
 [dependencies]
 string_cache = { workspace = true }
 phf = { workspace = true }

--- a/xml5ever/Cargo.toml
+++ b/xml5ever/Cargo.toml
@@ -16,6 +16,7 @@ rust-version.workspace = true
 
 [features]
 trace_tokenizer = []
+serde = ["markup5ever/serde"]
 
 [dependencies]
 markup5ever = { workspace = true }


### PR DESCRIPTION
html5ever was previously depending on `string_cache` with default features. Which enables the `serde` feature. This PR makes that an optional feature and disables it by default as it not required for any of the functionality in *5ever crates.