### PR TITLE
Add missing local names (`mask-type`, `playbackorder`, and `timelinebegin`) for SVG

### DIFF
--- a/web_atoms/local_names.txt
+++ b/web_atoms/local_names.txt
@@ -530,6 +530,7 @@ markerUnits
 markerWidth
 marquee
 mask
+mask-type
 maskContentUnits
 maskUnits
 math
@@ -791,6 +792,7 @@ ping
 pitch
 placeholder
 plaintext
+playbackorder
 plus
 pointer-events
 points
@@ -1001,6 +1003,7 @@ thead
 thickmathspace
 thinmathspace
 time
+timelinebegin
 times
 title
 to


### PR DESCRIPTION
This PR adds 3 more missing atoms from prior merges on this branch.

- `mask-type`
- `playbackorder`
- `timelinebegin`