### PR TITLE
fix: Escape '<' and '>' when serializing attribute values

### DIFF
--- a/html5ever/src/serialize/mod.rs
+++ b/html5ever/src/serialize/mod.rs
@@ -107,8 +107,8 @@ impl<Wr: Write> HtmlSerializer<Wr> {
                 '&' => self.writer.write_all(b"&amp;"),
                 '\u{00A0}' => self.writer.write_all(b"&nbsp;"),
                 '"' if attr_mode => self.writer.write_all(b"&quot;"),
-                '<' if !attr_mode => self.writer.write_all(b"&lt;"),
-                '>' if !attr_mode => self.writer.write_all(b"&gt;"),
+                '<' => self.writer.write_all(b"&lt;"),
+                '>' => self.writer.write_all(b"&gt;"),
                 c => self.writer.write_fmt(format_args!("{c}")),
             }?;
         }

--- a/rcdom/tests/html-serializer.rs
+++ b/rcdom/tests/html-serializer.rs
@@ -140,7 +140,11 @@ test!(
     r#"<p><i>Hello!</i></p><i>, World!</i>"#
 );
 
-test!(attr_literal, r#"<base foo="<'>">"#);
+test!(
+    attr_literal,
+    r#"<base foo="<'>">"#,
+    r#"<base foo="&lt;'&gt;">"#
+);
 test!(attr_escape_amp, r#"<base foo="&amp;">"#);
 test!(
     attr_escape_amp_2,


### PR DESCRIPTION
Fixes https://github.com/servo/html5ever/issues/696.

Applies [the recent change to the HTML Standard](https://github.com/whatwg/html/commit/e21bd3b4a94bfdbc23d863128e0b207be9821a0f) on the attribute serialization logic.
