### PR TITLE
Fix clippy warning.

### DIFF
--- a/tendril/src/util.rs
+++ b/tendril/src/util.rs
@@ -24,7 +24,7 @@ pub unsafe fn unsafe_slice_mut(buf: &mut [u8], start: usize, new_len: usize) -> 
 #[inline(always)]
 pub unsafe fn copy_and_advance(dest: &mut *mut u8, src: &[u8]) {
     ptr::copy_nonoverlapping(src.as_ptr(), *dest, src.len());
-    *dest = dest.offset(src.len() as isize)
+    *dest = dest.add(src.len())
 }
 
 #[inline(always)]


### PR DESCRIPTION
```
 Warning: warning: use of `offset` with a `usize` casted to an `isize`
  --> tendril/src/util.rs:27:13
   |
27 |     *dest = dest.offset(src.len() as isize)
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#ptr_offset_with_cast
   = note: `#[warn(clippy::ptr_offset_with_cast)]` on by default
help: use `add` instead
   |
27 -     *dest = dest.offset(src.len() as isize)
27 +     *dest = dest.add(src.len())
   |
```