### PR TITLE
Prepare web_atoms 0.2.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.71.0"
 [workspace.dependencies]
 # Repo dependencies
 tendril = { version = "0.4.3", path = "tendril" }
-web_atoms = { version = "0.2", path = "web_atoms" }
+web_atoms = { version = "0.2.1", path = "web_atoms" }
 markup5ever = { version = "0.37", path = "markup5ever" }
 xml5ever = { version = "0.37", path = "xml5ever" }
 html5ever = { version = "0.37", path = "html5ever" }

--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web_atoms"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"


### PR DESCRIPTION
#692 introduced a new feature in web_atoms that is used by the crates that depend on it, but that change hasn't been published yet. This blocks publish the new versions of markup5ever, html5ever, and xml5ever.