### PR TITLE
Remove unecessary tendril dev-dependency.

### DIFF
--- a/tendril/Cargo.toml
+++ b/tendril/Cargo.toml
@@ -24,7 +24,6 @@ utf-8 = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true }
 criterion = { workspace = true }
-tendril = { workspace = true }
 
 [[bench]]
 name = "futf"


### PR DESCRIPTION
This prevents publishing a new version of tendril in this workspace because Cargo attempts to resolve the dev-dependency with the published versions of tendril. I have verified that `cargo build --examples -p tendril`, `cargo build --benches -p tendril`, and `cargo test -p tendril` all work with this dev-dependency removed.