### PR TITLE
publish versions of html,xml and markup5ever with new tendril release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.37.0"
+version = "0.37.1"
 license = "MIT OR Apache-2.0"
 authors = [ "The html5ever Project Developers" ]
 repository = "https://github.com/servo/html5ever"
@@ -21,9 +21,9 @@ rust-version = "1.71.0"
 # Repo dependencies
 tendril = { version = "0.5", path = "tendril" }
 web_atoms = { version = "0.2.1", path = "web_atoms" }
-markup5ever = { version = "0.37", path = "markup5ever" }
-xml5ever = { version = "0.37", path = "xml5ever" }
-html5ever = { version = "0.37", path = "html5ever" }
+markup5ever = { version = "0.37.1", path = "markup5ever" }
+xml5ever = { version = "0.37.1", path = "xml5ever" }
+html5ever = { version = "0.37.1", path = "html5ever" }
 
 # External dependencies
 encoding_rs = "0.8.12"


### PR DESCRIPTION
https://github.com/servo/html5ever/pull/704 bumped tendril to 0.5 but there are no versions of markup5ever/html5ever/xml5ever using this release yet, preventing me from using it in servo. I missed this detail in the original PR.

As far as I know it is more or less an unresolved question whether bumping a dependency to a non-backwards-compatible new version should be considered a breaking change, I went with a patch release here.  