### PR TITLE
Automatically check semVer compatibility in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,10 +143,10 @@ jobs:
       - name: Run cargo-semver-checks
         id: semver
         run: |
-          (cargo semver-checks --baseline-rev main && echo "label=non-breaking" >> $GITHUB_OUTPUT) || echo "label=breaking" >> $GITHUB_OUTPUT
+          (cargo semver-checks --baseline-rev main && echo "label=V-non-breaking" >> $GITHUB_OUTPUT) || echo "label=V-breaking" >> $GITHUB_OUTPUT
       - name: Assign labels
         run: |
-          gh pr edit "$NUMBER" --remove-label breaking --remove-label non-breaking
+          gh pr edit "$NUMBER" --remove-label V-breaking --remove-label V-non-breaking
           gh pr edit "$NUMBER" --add-label "$LABELS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action will automatically assign the "breaking" or "non-breaking" to PRs based on the output of `cargo-semver-checks`.

Testing: I opened two test PRs in my fork, which were labelled correctly (https://github.com/simonwuelker/html5ever/pulls)