### PR TITLE
Fetch PR branch in semver-check workflow

### DIFF
--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 0
       - name: Fetch main branch for reference
         run: |


### PR DESCRIPTION
The semver CI job is still failing after https://github.com/servo/html5ever/pull/715. In https://github.com/servo/html5ever/actions/runs/21148626657/job/60819760648 we can see that the job checks out the remote `main` instead of the PR branch, and then fails to fetch `main` again at a later point. This change explicitly specifies `ref: refs/pull/${{ github.event.pull_request.number }}/head` on the checkout action which should fix the issue.

I've tested this on my fork and it seems to work (successful run is [here](https://github.com/simonwuelker/html5ever/actions/runs/21148840045/job/60823667260)), though evidently that doesn't mean much.

Note that the job will fail on this PR too, as it uses the workflow definition from `main`.