### PR TITLE
Reconstruct active formatting elements when <math> or <svg> start

### DIFF
--- a/html5ever/src/tree_builder/rules.rs
+++ b/html5ever/src/tree_builder/rules.rs
@@ -967,9 +967,15 @@ where
                     ProcessResult::Done
                 },
 
-                Token::Tag(tag @ tag!(<math>)) => self.enter_foreign(tag, ns!(mathml)),
+                Token::Tag(tag @ tag!(<math>)) => {
+                    self.reconstruct_active_formatting_elements();
+                    self.enter_foreign(tag, ns!(mathml))
+                },
 
-                Token::Tag(tag @ tag!(<svg>)) => self.enter_foreign(tag, ns!(svg)),
+                Token::Tag(tag @ tag!(<svg>)) => {
+                    self.reconstruct_active_formatting_elements();
+                    self.enter_foreign(tag, ns!(svg))
+                },
 
                 Token::Tag(
                     tag!(<caption> | <col> | <colgroup> | <frame> | <head> |


### PR DESCRIPTION
As per [13.2.6.4.7 The "in body" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody).

Found via fuzzing in https://github.com/bearcove/hotmeal (one of the fuzz targets compare DOM trees as parsed by Blink and html5ever).

There might be more coming, let me know if you're interested in them or not!