### PR TITLE
Add shadowrootslotassignment atom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.71.0"
 [workspace.dependencies]
 # Repo dependencies
 tendril = { version = "0.5", path = "tendril" }
-web_atoms = { version = "0.2.3", path = "web_atoms" }
+web_atoms = { version = "0.2.4", path = "web_atoms" }
 markup5ever = { version = "0.39", path = "markup5ever" }
 xml5ever = { version = "0.39", path = "xml5ever" }
 html5ever = { version = "0.39", path = "html5ever" }

--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web_atoms"
-version = "0.2.3"
+version = "0.2.4"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/web_atoms/local_names.txt
+++ b/web_atoms/local_names.txt
@@ -911,6 +911,7 @@ shadowrootclonable
 shadowrootdelegatesfocus
 shadowrootmode
 shadowrootserializable
+shadowrootslotassignment
 shape
 shape-rendering
 show


### PR DESCRIPTION
Necessary to bring servo up to date with the specification for declarative shadow roots: https://github.com/whatwg/html/pull/12267.

Companion PR for https://github.com/servo/servo/pull/44246


