### PR TITLE
Improve serialization performance with memchr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ html5ever = { version = "0.39", path = "html5ever" }
 # External dependencies
 encoding_rs = "0.8.12"
 log = "0.4"
+memchr = "2.8.0"
 new_debug_unreachable = "1.0.2"
 phf = "0.13"
 phf_codegen = "0.13"

--- a/html5ever/Cargo.toml
+++ b/html5ever/Cargo.toml
@@ -18,6 +18,7 @@ serde = ["markup5ever/serde"]
 
 [dependencies]
 markup5ever = { workspace = true }
+memchr = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]

--- a/html5ever/src/serialize/mod.rs
+++ b/html5ever/src/serialize/mod.rs
@@ -10,6 +10,7 @@
 use log::warn;
 pub use markup5ever::serialize::{AttrRef, Serialize, Serializer, TraversalScope};
 use markup5ever::{local_name, ns};
+use memchr::{memchr2, memchr3};
 use std::io::{self, Write};
 
 use crate::{LocalName, QualName};
@@ -102,16 +103,48 @@ impl<Wr: Write> HtmlSerializer<Wr> {
     }
 
     fn write_escaped(&mut self, text: &str, attr_mode: bool) -> io::Result<()> {
-        for c in text.chars() {
-            match c {
-                '&' => self.writer.write_all(b"&amp;"),
-                '\u{00A0}' => self.writer.write_all(b"&nbsp;"),
-                '"' if attr_mode => self.writer.write_all(b"&quot;"),
-                '<' => self.writer.write_all(b"&lt;"),
-                '>' => self.writer.write_all(b"&gt;"),
-                c => self.writer.write_fmt(format_args!("{c}")),
-            }?;
+        // When in attribute mode quotes are escaped, but otherwise not. In order to reduce
+        // branching below, when not in attribute mode, just look for the another of the
+        // escaped characters.
+        let maybe_quote = if attr_mode { b'"' } else { b'<' };
+        let find_next_escaped_character = |slice: &[u8]| {
+            // Use highly-optimized memchr to find the next character that needs to be escaped.
+            // Doing this twice is *much* faster than walking the string by characters.
+            let result = memchr3(maybe_quote, b'<', b'>', slice).unwrap_or(slice.len());
+            memchr2(b'&', 0xC2, &slice[..result]).unwrap_or(result)
+        };
+
+        let bytes = text.as_bytes();
+        let mut search_start = 0;
+        while search_start < text.len() {
+            let next_special = find_next_escaped_character(&bytes[search_start..]) + search_start;
+
+            // Write all text before the search result unconditionally.
+            self.writer.write_all(&bytes[search_start..next_special])?;
+
+            // If we reached the end of the text we can stop processing.
+            if next_special == bytes.len() {
+                break;
+            }
+
+            search_start = next_special + 1;
+            let replacement = match bytes[next_special] {
+                b'&' => "&amp;",
+                b'"' => "&quot;",
+                b'<' => "&lt;",
+                b'>' => "&gt;",
+                0xC2 if bytes.get(next_special + 1) == Some(&0xA0) => {
+                    search_start += 1;
+                    "&nbsp;"
+                },
+                _ => {
+                    //  0xC2 not followed by 0xA0 (not NBSP), so keep looking.
+                    continue;
+                },
+            };
+            self.writer.write_all(replacement.as_bytes())?;
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION
This change greatly improves the performance of serialization (up to
95% on some benchmarks) by changing the way that escaping of HTML
entities works. It uses memchar to avoid creating a `chars()` iterator
on the output stream. When run with the benchmark from #739, I see these
results:

```
serialize "lipsum.html" time:   [6.4817 µs 6.5021 µs 6.5212 µs]
                        change: [−95.179% −95.013% −94.846%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) low severe
  1 (1.00%) low mild

serialize "lipsum-zh.html"
                        time:   [2.0815 µs 2.0888 µs 2.0947 µs]
                        change: [−91.533% −90.940% −90.407%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  15 (15.00%) low severe

serialize "medium-fragment.html"
                        time:   [7.7625 µs 7.7927 µs 7.8147 µs]
                        change: [−84.424% −83.952% −83.486%] (p = 0.00 < 0.05)
                        Performance has improved.

serialize "small-fragment.html"
                        time:   [879.01 ns 886.43 ns 892.78 ns]
                        change: [−89.813% −89.711% −89.610%] (p = 0.00 < 0.05)
                        Performance has improved.

serialize "tiny-fragment.html"
                        time:   [332.13 ns 332.78 ns 333.60 ns]
                        change: [−27.768% −27.617% −27.457%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

serialize "strong.html" time:   [5.4946 µs 5.4988 µs 5.5030 µs]
                        change: [−0.3133% −0.0322% +0.2349%] (p = 0.83 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
```

In this case `lipsum.html` deserialization time dropped from 122.81 µs
to 6.5021 µs.
