### PR TITLE
Update phf to 0.14. Bump versions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install stable toolchain
         run: |
           rustup set profile minimal
-          rustup override set 1.71.0
+          rustup override set 1.85.0
 
       - run: cargo check --lib --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,30 +10,30 @@ members = [
 ]
 
 [workspace.package]
-version = "0.39.0"
+version = "0.40.0"
 license = "MIT OR Apache-2.0"
 authors = [ "The html5ever Project Developers" ]
 repository = "https://github.com/servo/html5ever"
 edition = "2021"
-rust-version = "1.71.0"
+rust-version = "1.85"
 
 [workspace.dependencies]
 # Repo dependencies
 tendril = { version = "0.5", path = "tendril" }
-web_atoms = { version = "0.2.5", path = "web_atoms" }
-markup5ever = { version = "0.39", path = "markup5ever" }
-xml5ever = { version = "0.39", path = "xml5ever" }
-html5ever = { version = "0.39", path = "html5ever" }
+web_atoms = { version = "0.3.0", path = "web_atoms" }
+markup5ever = { version = "0.40", path = "markup5ever" }
+xml5ever = { version = "0.40", path = "xml5ever" }
+html5ever = { version = "0.40", path = "html5ever" }
 
 # External dependencies
 encoding_rs = "0.8.12"
 log = "0.4"
 memchr = "2.8.0"
 new_debug_unreachable = "1.0.2"
-phf = "0.13"
-phf_codegen = "0.13"
-string_cache = { version = "0.9.0", default-features = false }
-string_cache_codegen = "0.6.1"
+phf = "0.14"
+phf_codegen = "0.14"
+string_cache = { version = "0.10.0", default-features = false }
+string_cache_codegen = "0.7.0"
 
 # Dev dependencies
 criterion = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,30 +10,30 @@ members = [
 ]
 
 [workspace.package]
-version = "0.39.0"
+version = "0.40.0"
 license = "MIT OR Apache-2.0"
 authors = [ "The html5ever Project Developers" ]
 repository = "https://github.com/servo/html5ever"
 edition = "2021"
-rust-version = "1.71.0"
+rust-version = "1.85"
 
 [workspace.dependencies]
 # Repo dependencies
 tendril = { version = "0.5", path = "tendril" }
-web_atoms = { version = "0.2.6", path = "web_atoms" }
-markup5ever = { version = "0.39", path = "markup5ever" }
-xml5ever = { version = "0.39", path = "xml5ever" }
-html5ever = { version = "0.39", path = "html5ever" }
+web_atoms = { version = "0.3.0", path = "web_atoms" }
+markup5ever = { version = "0.40", path = "markup5ever" }
+xml5ever = { version = "0.40", path = "xml5ever" }
+html5ever = { version = "0.40", path = "html5ever" }
 
 # External dependencies
 encoding_rs = "0.8.12"
 log = "0.4"
 memchr = "2.8.0"
 new_debug_unreachable = "1.0.2"
-phf = "0.13"
-phf_codegen = "0.13"
-string_cache = { version = "0.9.0", default-features = false }
-string_cache_codegen = "0.6.1"
+phf = "0.14"
+phf_codegen = "0.14"
+string_cache = { version = "0.10.0", default-features = false }
+string_cache_codegen = "0.7.0"
 
 # Dev dependencies
 criterion = "0.8"

--- a/rcdom/Cargo.toml
+++ b/rcdom/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lib]

--- a/tendril/src/tendril.rs
+++ b/tendril/src/tendril.rs
@@ -2268,7 +2268,7 @@ mod test {
         check(b"");
         check(b"abcd");
 
-        let long: Vec<u8> = iter::repeat(b'x').take(1_000_000).collect();
+        let long: Vec<u8> = iter::repeat_n(b'x', 1_000_000).collect();
         check(&long);
     }
 

--- a/tendril/src/tendril.rs
+++ b/tendril/src/tendril.rs
@@ -2279,7 +2279,7 @@ mod test {
         check(b"");
         check(b"abcd");
 
-        let long: Vec<u8> = iter::repeat(b'x').take(1_000_000).collect();
+        let long: Vec<u8> = iter::repeat_n(b'x', 1_000_000).collect();
         check(&long);
     }
 

--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web_atoms"
-version = "0.2.5"
+version = "0.3.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web_atoms"
-version = "0.2.6"
+version = "0.3.0"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"


### PR DESCRIPTION
Also bump MSRV to 1.85 as required by phf.

Per RELEASE.md, phf updates are breaking changes. Thus, bump versions for both web_atom and html5ever.

Depends on https://github.com/servo/string-cache/pull/298