### PR TITLE
Fix allocator capacity bounds checking and tracking in Buf32

### DIFF
--- a/tendril/src/buf32.rs
+++ b/tendril/src/buf32.rs
@@ -30,6 +30,18 @@ fn bytes_to_vec_capacity<H>(x: u32) -> usize {
     1 + ((x - 1) / header)
 }
 
+#[inline(always)]
+fn vec_capacity_to_bytes<H>(vec_cap: usize) -> u32 {
+    // The first H element is consumed by the header metadata,
+    // the remaining elements are available for the string payload.
+    let actual_cap_bytes = (vec_cap - 1) * mem::size_of::<H>();
+
+    if actual_cap_bytes > u32::MAX as usize {
+        panic!("{}", OFLOW);
+    }
+    actual_cap_bytes as u32
+}
+
 impl<H> Buf32<H> {
     #[inline]
     pub unsafe fn with_capacity(mut cap: u32, h: H) -> Buf32<H> {
@@ -38,6 +50,8 @@ impl<H> Buf32<H> {
         }
 
         let mut vec = Vec::<H>::with_capacity(bytes_to_vec_capacity::<H>(cap));
+        cap = vec_capacity_to_bytes::<H>(vec.capacity());
+
         let ptr = vec.as_mut_ptr();
         mem::forget(vec);
         ptr::write(ptr, h);
@@ -82,7 +96,8 @@ impl<H> Buf32<H> {
         let mut vec = Vec::from_raw_parts(self.ptr, 0, bytes_to_vec_capacity::<H>(self.cap));
         vec.reserve_exact(bytes_to_vec_capacity::<H>(new_cap));
         self.ptr = vec.as_mut_ptr();
-        self.cap = new_cap;
+        self.cap = vec_capacity_to_bytes::<H>(vec.capacity());
+
         mem::forget(vec);
     }
 }


### PR DESCRIPTION
This PR fixes a memory safety vulnerability in `Buf32`  that causes Undefined Behavior when interacting with global allocators that over-provision memory (such as  `jemalloc` ).

  When  `Buf32` initially allocates memory via  `Vec::with_capacity()` , the global allocator often returns a buffer slightly larger than requested to align with memory chunk boundaries. Previously,  `Buf32`  mistakenly stored the requested capacity rather than the actual capacity returned by the allocator.

  When the buffer was later deallocated or resized using  `Vec::from_raw_parts` , it passed this smaller, incorrect capacity back to the global allocator. Providing a mismatched layout size back to the allocator violates  Vec 's API invariants and is
  Undefined Behavior, which can result in immediate segmentation faults or silent heap corruption.

  Changes:

  •  `Buf32::with_capacity`  now queries  `vec.capacity()` to determine the true allocated layout size.
  • The capacity calculation translates this back into byte capacity by explicitly subtracting the first  H  header block.
  • Adds a bounds check against  `u32::MAX`  to explicitly panic and prevent 32-bit truncation if an allocation happens to unexpectedly exceed  `u32::MAX`  bytes.

  Resolves #751