### PR TITLE
Fix data race in SendTendril by removing Clone

### DIFF
--- a/tendril/src/tendril.rs
+++ b/tendril/src/tendril.rs
@@ -1228,7 +1228,6 @@ where
 ///
 /// A `SendTendril` may be produced by `Tendril.into_send()` or `SendTendril::from(tendril)`,
 /// and may be returned to a `Tendril` by `Tendril::from(self)`.
-#[derive(Clone)]
 pub struct SendTendril<F>
 where
     F: fmt::Format,


### PR DESCRIPTION
Removed  `#[derive(Clone)]`  from  `SendTendril` . This leverages the compiler to strictly enforce its intended invariant of unique ownership, making it impossible to alias the non-atomic buffer across threads.

  Resolves #753