### PR TITLE
Bump tendril to 0.5.1

### DIFF
--- a/tendril/Cargo.toml
+++ b/tendril/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 description = "Compact buffer/string type for zero-copy parsing"
 authors = [
   "Keegan McAllister <mcallister.keegan@gmail.com>",


### PR DESCRIPTION
Releases #731 to reduce ecosystem dependency on the archived `utf-8` crate.