### PR TITLE
html5ever: Don't crash on truncated content attributes for `<meta http-equiv="Content-Type">` tags

### DIFF
--- a/html5ever/src/encoding.rs
+++ b/html5ever/src/encoding.rs
@@ -36,7 +36,7 @@ pub(crate) fn extract_a_character_encoding_from_a_meta_element(
 
         // Step 4. If the next character is not a U+003D EQUALS SIGN (=), then move position to point just before
         // that next character, and jump back to the step labeled loop.
-        if input.as_bytes()[position] == b'=' {
+        if *input.as_bytes().get(position)? == b'=' {
             break;
         }
     }
@@ -166,6 +166,56 @@ mod tests {
         assert_eq!(
             extract_a_character_encoding_from_a_meta_element(StrTendril::from_slice(
                 "text/html; charset=utf8"
+            )),
+            Some(StrTendril::from_slice("utf8"))
+        );
+    }
+
+    #[test]
+    fn meta_element_with_truncated_charset() {
+        assert_eq!(
+            extract_a_character_encoding_from_a_meta_element(StrTendril::from_slice(
+                "text/html; charset"
+            )),
+            None
+        );
+        assert_eq!(
+            extract_a_character_encoding_from_a_meta_element(StrTendril::from_slice(
+                "text/html; charset"
+            )),
+            None
+        );
+        assert_eq!(
+            extract_a_character_encoding_from_a_meta_element(StrTendril::from_slice(
+                "text/html; charset \t"
+            )),
+            None
+        );
+        assert_eq!(
+            extract_a_character_encoding_from_a_meta_element(StrTendril::from_slice(
+                "text/html; charset="
+            )),
+            None
+        );
+        assert_eq!(
+            extract_a_character_encoding_from_a_meta_element(StrTendril::from_slice(
+                "text/html; charset='"
+            )),
+            None
+        );
+        assert_eq!(
+            extract_a_character_encoding_from_a_meta_element(StrTendril::from_slice(
+                "text/html; charset=\""
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn meta_element_with_invalid_charset_followed_by_valid_charset() {
+        assert_eq!(
+            extract_a_character_encoding_from_a_meta_element(StrTendril::from_slice(
+                "text/html; charset charset=utf8"
             )),
             Some(StrTendril::from_slice("utf8"))
         );

--- a/rcdom/tests/html-tokenizer.rs
+++ b/rcdom/tests/html-tokenizer.rs
@@ -311,14 +311,16 @@ fn unescape(s: &str) -> Option<String> {
                 }
                 let _ = it.next();
                 let hex: String = it.by_ref().take(4).collect();
-                match u32::from_str_radix(&hex, 16).ok().and_then(char::from_u32) {
-                    // Some of the tests use lone surrogates, but we have no
-                    // way to represent them in the UTF-8 input to our parser.
-                    // Since these can only come from script, we will catch
-                    // them there.
-                    None => return None,
-                    Some(c) => out.push(c),
-                }
+
+                // Some of the tests use lone surrogates, but we have no
+                // way to represent them in the UTF-8 input to our parser.
+                // Since these can only come from script, we will catch
+                // them there.
+                out.push(
+                    u32::from_str_radix(&hex, 16)
+                        .ok()
+                        .and_then(char::from_u32)?,
+                );
             },
             Some(c) => out.push(c),
         }

--- a/tendril/examples/fuzz.rs
+++ b/tendril/examples/fuzz.rs
@@ -25,7 +25,7 @@ fn fuzz() {
 
     for _ in 1..100_000 {
         if buf_string.len() > (1 << 30) {
-            buf_string.truncate(0);
+            buf_string.clear();
             buf_tendril.clear();
         }
 
@@ -84,7 +84,7 @@ fn fuzz() {
             },
 
             97 => {
-                buf_string.truncate(0);
+                buf_string.clear();
                 buf_tendril.clear();
                 assert_eq!(&*buf_string, &*buf_tendril);
             },

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -558,7 +558,7 @@ where
         debug!(
             "Close tag: current_node.name {:?} \n Current tag {:?}",
             self.sink.elem_name(&self.current_node()),
-            &tag.name
+            tag.name
         );
 
         if *self.sink.elem_name(&self.current_node()).local_name() != tag.name.local {


### PR DESCRIPTION

Obsoletes https://github.com/servo/html5ever/pull/762
Fixes https://github.com/servo/html5ever/issues/763