### PR TITLE
html5ever: avoid unnecessary attribute clone in `TreeBuilder::insert_element`.

### DIFF
--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -1380,6 +1380,7 @@ where
                 ref prev_element,
             } => (element.clone(), Some(prev_element.clone())),
         };
+
         // Step 12.
         let qname = QualName::new(None, ns, name);
         let form_is_associatable = form_associatable(qname.expanded())
@@ -1390,7 +1391,8 @@ where
                     .iter()
                     .any(|a| a.name.expanded() == expanded_name!("", "form")));
 
-        // check the form is associatable, then create element, and we are avoiding of cloning attributes.
+        // By checking whether the form is associatable first, then creating the element
+        // we can avoid cloning the attributes.
         let elem = create_element_with_flags(&self.sink, qname, attrs, had_duplicate_attributes);
 
         if form_is_associatable {

--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -1370,14 +1370,6 @@ where
         declare_tag_set!(listed = [form_associatable] - "img");
 
         // Step 7.
-        let qname = QualName::new(None, ns, name);
-        let elem = create_element_with_flags(
-            &self.sink,
-            qname.clone(),
-            attrs.clone(),
-            had_duplicate_attributes,
-        );
-
         let insertion_point = self.appropriate_place_for_insertion(None);
         let (node1, node2) = match insertion_point {
             InsertionPoint::LastChild(ref p) | InsertionPoint::BeforeSibling(ref p) => {
@@ -1388,16 +1380,20 @@ where
                 ref prev_element,
             } => (element.clone(), Some(prev_element.clone())),
         };
-
         // Step 12.
-        if form_associatable(qname.expanded())
+        let qname = QualName::new(None, ns, name);
+        let form_is_associatable = form_associatable(qname.expanded())
             && self.form_elem.borrow().is_some()
             && !self.in_html_elem_named(local_name!("template"))
             && !(listed(qname.expanded())
                 && attrs
                     .iter()
-                    .any(|a| a.name.expanded() == expanded_name!("", "form")))
-        {
+                    .any(|a| a.name.expanded() == expanded_name!("", "form")));
+
+        // check the form is associatable, then create element, and we are avoiding of cloning attributes.
+        let elem = create_element_with_flags(&self.sink, qname, attrs, had_duplicate_attributes);
+
+        if form_is_associatable {
             let form = self.form_elem.borrow().as_ref().unwrap().clone();
             self.sink
                 .associate_with_form(&elem, &form, (&node1, node2.as_ref()));


### PR DESCRIPTION
Reordered code in `impl TreeBuilder<Handle, Sink>::insert_element` to avoid an unnecessary clone of tag attributes.