### PR TITLE
Remove redundant clones in `html5ever/src/tree_builder/mod.rs`

### DIFF
--- a/html5ever/src/tree_builder/mod.rs
+++ b/html5ever/src/tree_builder/mod.rs
@@ -1446,12 +1446,8 @@ where
     ) -> Handle {
         let adjusted_insertion_location = self.appropriate_place_for_insertion(None);
         let qname = QualName::new(None, ns, tag.name.clone());
-        let elem = create_element_with_flags(
-            &self.sink,
-            qname.clone(),
-            tag.attrs.clone(),
-            tag.had_duplicate_attributes,
-        );
+        let elem =
+            create_element_with_flags(&self.sink, qname, tag.attrs, tag.had_duplicate_attributes);
 
         if !only_add_to_element_stack {
             self.insert_at(adjusted_insertion_location, AppendNode(elem.clone()));


### PR DESCRIPTION
If I am not overlooking anything, I believe these clones are redundant and can thus be safely removed.

For reference, this change was found by an optimizer developed as a research project.

CC @nunoplopes
