### PR TITLE
Add `imagesizes` and `imagesrcset` atoms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.71.0"
 [workspace.dependencies]
 # Repo dependencies
 tendril = { version = "0.5", path = "tendril" }
-web_atoms = { version = "0.2.5", path = "web_atoms" }
+web_atoms = { version = "0.2.6", path = "web_atoms" }
 markup5ever = { version = "0.39", path = "markup5ever" }
 xml5ever = { version = "0.39", path = "xml5ever" }
 html5ever = { version = "0.39", path = "html5ever" }

--- a/web_atoms/Cargo.toml
+++ b/web_atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web_atoms"
-version = "0.2.5"
+version = "0.2.6"
 authors = [ "The html5ever Project Developers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/html5ever"

--- a/web_atoms/local_names.txt
+++ b/web_atoms/local_names.txt
@@ -437,6 +437,8 @@ ideographic
 iframe
 image
 image-rendering
+imagesizes
+imagesrcset
 imaginary
 imaginaryi
 img


### PR DESCRIPTION
This is part of implementing source set operations on the `<link>` element (see https://github.com/servo/servo/issues/47024).