### PR TITLE
Preserve xmlns attributes and rewrite the XML serialization algorithm

### DIFF
--- a/rcdom/lib.rs
+++ b/rcdom/lib.rs
@@ -44,7 +44,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::{HashSet, VecDeque};
 use std::default::Default;
 use std::fmt;
-use std::io;
+use std::io::{self, Write};
 use std::mem;
 use std::rc::{Rc, Weak};
 
@@ -52,14 +52,14 @@ use tendril::StrTendril;
 
 use markup5ever::interface::tree_builder;
 use markup5ever::interface::tree_builder::{ElementFlags, NodeOrText, QuirksMode, TreeSink};
-use markup5ever::serialize::TraversalScope;
-use markup5ever::serialize::TraversalScope::{ChildrenOnly, IncludeNode};
-use markup5ever::serialize::{Serialize, Serializer};
+use markup5ever::interface::ElemName;
+use markup5ever::serialize::TraversalScope::{self, ChildrenOnly, IncludeNode};
+use markup5ever::serialize::{AttrRef, Serialize, Serializer};
 use markup5ever::Attribute;
 use markup5ever::ExpandedName;
 use markup5ever::QualName;
-use xml5ever::interface::ElemName;
-use xml5ever::local_name;
+use markup5ever::{local_name, ns, Namespace};
+use xml5ever::serialize::{NamespacePrefixMap, XmlSerializer};
 
 /// The different kinds of nodes in the DOM.
 #[derive(Debug, Clone)]
@@ -672,4 +672,95 @@ impl Serialize for SerializableHandle {
 
         Ok(())
     }
+}
+
+pub fn serialize_xml<Wr: Write>(writer: &mut Wr, node: &Node) -> io::Result<()> {
+    let mut ser = XmlSerializer::new(writer);
+    serialize_xml_fragment(&mut ser, node)
+}
+
+fn serialize_xml_fragment<Wr: Write>(
+    serializer: &mut XmlSerializer<Wr>,
+    node: &Node,
+) -> io::Result<()> {
+    let namespace = ns!();
+    let prefix_map = NamespacePrefixMap::new();
+    do_serialize_xml_fragment(serializer, node, &namespace, prefix_map)
+}
+
+fn do_serialize_xml_fragment<Wr: Write>(
+    serializer: &mut XmlSerializer<Wr>,
+    node: &Node,
+    namespace: &Namespace,
+    prefix_map: NamespacePrefixMap,
+) -> io::Result<()> {
+    match node.data {
+        NodeData::Element {
+            ref name,
+            ref attrs,
+            ref template_contents,
+            ..
+        } => {
+            let has_children =
+                !node.children.borrow().is_empty() || template_contents.borrow().is_some();
+            let attributes: Vec<_> = attrs
+                .borrow()
+                .iter()
+                .map(|attr| {
+                    let qname = attr.name.clone();
+                    let value = attr.value.clone();
+                    (qname, value)
+                })
+                .collect();
+            let attr_refs = attributes.iter().map(|(qname, value)| {
+                let ar: AttrRef = (qname, &**value);
+                ar
+            });
+            if has_children {
+                let (qualified_name, inherit_ns, inherit_prefix_map) =
+                    serializer.start_elem(name, attr_refs, namespace.clone(), &prefix_map)?;
+                match &*template_contents.borrow() {
+                    Some(template_contents) => {
+                        do_serialize_xml_fragment(
+                            serializer,
+                            &template_contents,
+                            &inherit_ns,
+                            inherit_prefix_map,
+                        )?;
+                    },
+                    None => {
+                        for child in node.children.borrow().iter() {
+                            do_serialize_xml_fragment(
+                                serializer,
+                                child,
+                                &inherit_ns,
+                                inherit_prefix_map.clone(),
+                            )?;
+                        }
+                    },
+                }
+                serializer.end_elem(qualified_name)?;
+            } else {
+                serializer.write_empty_elem(name, attr_refs, namespace.clone(), &prefix_map)?;
+            }
+        },
+
+        NodeData::Doctype { ref name, .. } => serializer.write_doctype(name)?,
+
+        NodeData::Text { ref contents } => serializer.write_text(&contents.borrow())?,
+
+        NodeData::Comment { ref contents } => serializer.write_comment(contents)?,
+
+        NodeData::ProcessingInstruction {
+            ref target,
+            ref contents,
+        } => serializer.write_processing_instruction(target, contents)?,
+
+        NodeData::Document => {
+            for child in node.children.borrow().iter() {
+                do_serialize_xml_fragment(serializer, child, &namespace, prefix_map.clone())?;
+            }
+        },
+    }
+    Ok(())
 }

--- a/rcdom/lib.rs
+++ b/rcdom/lib.rs
@@ -684,7 +684,7 @@ fn serialize_xml_fragment<Wr: Write>(
     node: &Node,
 ) -> io::Result<()> {
     let namespace = ns!();
-    let prefix_map = NamespacePrefixMap::new();
+    let prefix_map = NamespacePrefixMap::default();
     do_serialize_xml_fragment(serializer, node, &namespace, prefix_map)
 }
 
@@ -723,7 +723,7 @@ fn do_serialize_xml_fragment<Wr: Write>(
                     Some(template_contents) => {
                         do_serialize_xml_fragment(
                             serializer,
-                            &template_contents,
+                            template_contents,
                             &inherit_ns,
                             inherit_prefix_map,
                         )?;
@@ -758,7 +758,7 @@ fn do_serialize_xml_fragment<Wr: Write>(
 
         NodeData::Document => {
             for child in node.children.borrow().iter() {
-                do_serialize_xml_fragment(serializer, child, &namespace, prefix_map.clone())?;
+                do_serialize_xml_fragment(serializer, child, namespace, prefix_map.clone())?;
             }
         },
     }

--- a/rcdom/tests/xml-driver.rs
+++ b/rcdom/tests/xml-driver.rs
@@ -159,7 +159,7 @@ fn template() {
                 .borrow_mut()
                 .push(contents.document.children.borrow()[0].clone());
         },
-        _ => {},
+        _ => panic!("Unexpected child of document")
     }
     assert_serialization(
         r##"<template xmlns="http://www.w3.org/1999/xhtml"><div>Pass</div></template>"##,

--- a/rcdom/tests/xml-driver.rs
+++ b/rcdom/tests/xml-driver.rs
@@ -159,7 +159,7 @@ fn template() {
                 .borrow_mut()
                 .push(contents.document.children.borrow()[0].clone());
         },
-        _ => panic!("Unexpected child of document")
+        _ => panic!("Unexpected child of document"),
     }
     assert_serialization(
         r##"<template xmlns="http://www.w3.org/1999/xhtml"><div>Pass</div></template>"##,

--- a/rcdom/tests/xml-driver.rs
+++ b/rcdom/tests/xml-driver.rs
@@ -1,6 +1,6 @@
-use markup5ever_rcdom::{RcDom, SerializableHandle};
+use markup5ever::{expanded_name, local_name, ns};
+use markup5ever_rcdom::{serialize_xml, NodeData, RcDom};
 use xml5ever::driver;
-use xml5ever::serialize;
 use xml5ever::tendril::TendrilSink;
 
 #[test]
@@ -76,16 +76,14 @@ fn from_utf8() {
 
 fn assert_eq_serialization(text: &'static str, dom: RcDom) {
     let mut serialized = Vec::new();
-    let document: SerializableHandle = dom.document.clone().into();
-    serialize::serialize(&mut serialized, &document, Default::default()).unwrap();
+    serialize_xml(&mut serialized, &dom.document).unwrap();
 
     let dom_from_text = driver::parse_document(RcDom::default(), Default::default())
         .from_utf8()
         .one(text.as_bytes());
 
     let mut reserialized = Vec::new();
-    let document: SerializableHandle = dom_from_text.document.clone().into();
-    serialize::serialize(&mut reserialized, &document, Default::default()).unwrap();
+    serialize_xml(&mut reserialized, &dom_from_text.document).unwrap();
 
     assert_eq!(
         String::from_utf8(serialized).unwrap(),
@@ -95,7 +93,76 @@ fn assert_eq_serialization(text: &'static str, dom: RcDom) {
 
 fn assert_serialization(text: &'static str, dom: RcDom) {
     let mut serialized = Vec::new();
-    let document: SerializableHandle = dom.document.clone().into();
-    serialize::serialize(&mut serialized, &document, Default::default()).unwrap();
+    serialize_xml(&mut serialized, &dom.document).unwrap();
     assert_eq!(String::from_utf8(serialized).unwrap(), text);
+}
+
+#[test]
+fn xmlns_on_root() {
+    assert_serialization(
+       r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
+    <sodipodi:namedview>
+        ...
+    </sodipodi:namedview>
+
+    <path d="..." sodipodi:nodetypes="cccc"/>
+</svg>"##,
+        driver::parse_document(RcDom::default(), Default::default())
+            .from_utf8()
+            .one(r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
+    <sodipodi:namedview>
+        ...
+    </sodipodi:namedview>
+
+    <path d="..." sodipodi:nodetypes="cccc"/>
+</svg>"##.as_bytes()),
+    );
+}
+
+#[test]
+fn xmlns_applies_to_attr() {
+    assert_serialization(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
+    <path d="..." sodipodi:nodetypes="cccc"/>
+</svg>"##,
+        driver::parse_document(RcDom::default(), Default::default())
+            .from_utf8()
+            .one(r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
+    <path d="..." sodipodi:nodetypes="cccc"/>
+</svg>"##.as_bytes()),
+    );
+}
+
+#[test]
+fn template() {
+    let dom = driver::parse_document(RcDom::default(), Default::default())
+        .from_utf8()
+        .one(r##"<template xmlns="http://www.w3.org/1999/xhtml"/>"##.as_bytes());
+    let contents = driver::parse_document(RcDom::default(), Default::default())
+        .from_utf8()
+        .one(r##"<div xmlns="http://www.w3.org/1999/xhtml">Pass</div>"##.as_bytes());
+    match &dom.document.children.borrow()[0].data {
+        NodeData::Element {
+            name,
+            template_contents,
+            ..
+        } => {
+            match name.expanded() {
+                expanded_name!(html "template") => {},
+                name => panic!("Root element should be template, was {:?}", name),
+            }
+            template_contents
+                .borrow()
+                .as_ref()
+                .expect("Should have template contents")
+                .children
+                .borrow_mut()
+                .push(contents.document.children.borrow()[0].clone());
+        },
+        _ => {},
+    }
+    assert_serialization(
+        r##"<template xmlns="http://www.w3.org/1999/xhtml"><div>Pass</div></template>"##,
+        dom,
+    );
 }

--- a/rcdom/tests/xml-tree-builder.rs
+++ b/rcdom/tests/xml-tree-builder.rs
@@ -126,11 +126,7 @@ fn serialize(buf: &mut String, indent: usize, handle: Handle) {
             buf.push_str(&name.local);
             buf.push_str(">\n");
 
-            let mut attrs = attrs.borrow().clone();
-            attrs.sort_by(|x, y| x.name.local.cmp(&y.name.local));
-            // FIXME: sort by UTF-16 code unit
-
-            for attr in attrs.into_iter() {
+            for attr in &*attrs.borrow() {
                 buf.push('|');
                 buf.extend(iter::repeat_n(" ", indent + 2));
 
@@ -140,7 +136,7 @@ fn serialize(buf: &mut String, indent: usize, handle: Handle) {
                     buf.push('}');
                 }
 
-                if let Some(attr_prefix) = attr.name.prefix {
+                if let Some(ref attr_prefix) = attr.name.prefix {
                     buf.push_str(&attr_prefix);
                     buf.push(':');
                 }

--- a/rcdom/tests/xml-tree-builder.rs
+++ b/rcdom/tests/xml-tree-builder.rs
@@ -137,7 +137,7 @@ fn serialize(buf: &mut String, indent: usize, handle: Handle) {
                 }
 
                 if let Some(ref attr_prefix) = attr.name.prefix {
-                    buf.push_str(&attr_prefix);
+                    buf.push_str(attr_prefix);
                     buf.push(':');
                 }
 

--- a/xml5ever/src/lib.rs
+++ b/xml5ever/src/lib.rs
@@ -33,6 +33,9 @@
 #![allow(unexpected_cfgs)]
 #![deny(missing_docs)]
 
+#[macro_use]
+extern crate markup5ever;
+
 pub use markup5ever::*;
 
 pub(crate) mod macros;

--- a/xml5ever/src/lib.rs
+++ b/xml5ever/src/lib.rs
@@ -33,9 +33,6 @@
 #![allow(unexpected_cfgs)]
 #![deny(missing_docs)]
 
-#[macro_use]
-extern crate markup5ever;
-
 pub use markup5ever::*;
 
 pub(crate) mod macros;

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -47,13 +47,16 @@ pub struct NamespacePrefixMap {
     scope: BTreeMap<Namespace, Vec<Prefix>>,
 }
 
-impl NamespacePrefixMap {
+impl Default for NamespacePrefixMap {
     /// Create a new `NamespacePrefixMap`, containing only the "xml" prefix for the XML namespace.
-    pub fn new() -> NamespacePrefixMap {
+    fn default() -> Self {
         let mut scope = BTreeMap::new();
         scope.insert(ns!(xml), vec![namespace_prefix!(xml)]);
         NamespacePrefixMap { scope }
     }
+}
+
+impl NamespacePrefixMap {
     fn find(&self, ns: &Namespace, prefix: &Prefix) -> bool {
         let Some(list) = self.scope.get(ns) else {
             return false;
@@ -62,13 +65,11 @@ impl NamespacePrefixMap {
     }
 
     fn add(&mut self, ns: Namespace, prefix: Prefix) {
-        self.scope.entry(ns).or_insert_with(Vec::new).push(prefix);
+        self.scope.entry(ns).or_default().push(prefix);
     }
 
     fn retrieve(&self, ns: &Namespace, preferred: &Option<Prefix>) -> Option<Prefix> {
-        let Some(candidates) = self.scope.get(&ns) else {
-            return None;
-        };
+        let candidates = self.scope.get(ns)?;
         if let Some(preferred) = preferred {
             if candidates.contains(preferred) {
                 return Some(preferred.clone());
@@ -206,10 +207,8 @@ impl<Wr: Write> XmlSerializer<Wr> {
                         continue;
                     }
                     // `xmlns="ns"`
-                    if prefix.is_none() {
-                        if ignore_namespace_definition_attribute {
-                            continue;
-                        }
+                    if prefix.is_none() && ignore_namespace_definition_attribute {
+                        continue;
                     }
                     // `xmlns:foo="ns"`
                     if prefix.is_some() {
@@ -241,7 +240,7 @@ impl<Wr: Write> XmlSerializer<Wr> {
                     self.serialize_attribute(
                         &Some(namespace_prefix!(xmlns)),
                         &LocalName::from(&*new_prefix),
-                        &*attribute_namespace,
+                        attribute_namespace,
                     )?;
                 }
             }
@@ -298,7 +297,7 @@ impl<Wr: Write> XmlSerializer<Wr> {
                 qualified_name = format!("xml:{}", name.local);
             // Step 11.3.
             } else {
-                qualified_name = (&*name.local).to_owned();
+                qualified_name = (*name.local).to_owned();
             }
             // Step 11.4. (see below)
         } else {
@@ -341,7 +340,7 @@ impl<Wr: Write> XmlSerializer<Wr> {
                                     ns!(xmlns),
                                     LocalName::from(&*prefix),
                                 ),
-                                (&**ns).to_owned(),
+                                (**ns).to_owned(),
                             ));
 
                             match local_default_namespace {
@@ -355,18 +354,18 @@ impl<Wr: Write> XmlSerializer<Wr> {
                             match local_default_namespace {
                                 // Step 12.7
                                 Some(ldn) if ldn == *ns => {
-                                    qualified_name = (&*name.local).to_owned();
+                                    qualified_name = (*name.local).to_owned();
                                     inherited_ns = ns.clone();
                                 },
                                 // Step 12.6
                                 _ => {
                                     ignore_namespace_definition_attribute = true;
-                                    qualified_name = (&*name.local).to_owned();
+                                    qualified_name = (*name.local).to_owned();
                                     inherited_ns = ns.clone();
                                     debug_assert!(extra_attr.is_none());
                                     extra_attr = Some((
                                         QualName::new(None, ns!(xmlns), local_name!(xmlns)),
-                                        (&**ns).to_owned(),
+                                        (**ns).to_owned(),
                                     ));
                                 },
                             }

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -7,10 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::tree_builder::NamespaceMap;
 use crate::QualName;
 pub use markup5ever::serialize::{AttrRef, Serialize, Serializer, TraversalScope};
-use std::io::{self, Write};
+use markup5ever::{LocalName, Namespace, Prefix};
+use std::{
+    collections::BTreeMap,
+    io::{self, Write},
+};
 
 #[derive(Clone)]
 /// Struct for setting serializer options.
@@ -27,73 +30,82 @@ impl Default for SerializeOpts {
     }
 }
 
-/// Method for serializing generic node to a given writer.
-pub fn serialize<Wr, T>(writer: Wr, node: &T, opts: SerializeOpts) -> io::Result<()>
-where
-    Wr: Write,
-    T: Serialize,
-{
-    let mut ser = XmlSerializer::new(writer);
-    node.serialize(&mut ser, opts.traversal_scope)
-}
-
 /// Struct used for serializing nodes into a text that other XML
-/// parses can read.
+/// parsers can read.
 ///
 /// Serializer contains a set of functions (start_elem, end_elem...)
-/// that make parsing nodes easier.
+/// that make serializing nodes easier.
 pub struct XmlSerializer<Wr> {
     writer: Wr,
-    namespace_stack: NamespaceMapStack,
+    prefix_index: u32,
 }
 
-#[derive(Debug)]
-struct NamespaceMapStack(Vec<NamespaceMap>);
+/// For each `Namespace` that has been encountered so far, this contains the list of prefixes that
+/// are defined to map to that namespace.
+#[derive(Clone, Debug)]
+pub struct NamespacePrefixMap {
+    scope: BTreeMap<Namespace, Vec<Prefix>>,
+}
 
-impl NamespaceMapStack {
-    fn new() -> NamespaceMapStack {
-        NamespaceMapStack(vec![])
+impl NamespacePrefixMap {
+    /// Create a new `NamespacePrefixMap`, containing only the "xml" prefix for the XML namespace.
+    pub fn new() -> NamespacePrefixMap {
+        let mut scope = BTreeMap::new();
+        scope.insert(ns!(xml), vec![namespace_prefix!(xml)]);
+        NamespacePrefixMap { scope }
+    }
+    fn find(&self, ns: &Namespace, prefix: &Prefix) -> bool {
+        let Some(list) = self.scope.get(ns) else {
+            return false;
+        };
+        list.contains(prefix)
     }
 
-    fn push(&mut self, namespace: NamespaceMap) {
-        self.0.push(namespace);
+    fn add(&mut self, ns: Namespace, prefix: Prefix) {
+        self.scope.entry(ns).or_insert_with(Vec::new).push(prefix);
     }
 
-    fn pop(&mut self) {
-        self.0.pop();
+    fn retrieve(&self, ns: &Namespace, preferred: &Option<Prefix>) -> Option<Prefix> {
+        let Some(candidates) = self.scope.get(&ns) else {
+            return None;
+        };
+        if let Some(preferred) = preferred {
+            if candidates.contains(preferred) {
+                return Some(preferred.clone());
+            }
+        }
+        Some(
+            candidates
+                .last()
+                .expect("candidates should be non-empty")
+                .clone(),
+        )
+    }
+
+    fn generate_a_prefix(&mut self, ns: &Namespace, prefix_index: &mut u32) -> Prefix {
+        // Note: https://github.com/w3c/DOM-Parsing/issues/44 is reproduced faithfully here.
+        let generated_prefix = Prefix::from(format!("ns{}", *prefix_index));
+        *prefix_index += 1;
+        self.add(ns.clone(), generated_prefix.clone());
+        generated_prefix
     }
 }
 
 /// Writes given text into the Serializer, escaping it,
 /// depending on where the text is written inside the tag or attribute value.
-///
-/// For example
-///```text
-///    <tag>'&-quotes'</tag>   becomes      <tag>'&amp;-quotes'</tag>
-///    <tag = "'&-quotes'">    becomes      <tag = "&apos;&amp;-quotes&apos;"
-///```
 fn write_to_buf_escaped<W: Write>(writer: &mut W, text: &str, attr_mode: bool) -> io::Result<()> {
     for c in text.chars() {
         match c {
             '&' => writer.write_all(b"&amp;"),
-            '\'' if attr_mode => writer.write_all(b"&apos;"),
             '"' if attr_mode => writer.write_all(b"&quot;"),
-            '<' if !attr_mode => writer.write_all(b"&lt;"),
-            '>' if !attr_mode => writer.write_all(b"&gt;"),
+            '<' => writer.write_all(b"&lt;"),
+            '>' => writer.write_all(b"&gt;"),
+            '\t' if attr_mode => writer.write_all(b"&#9;"),
+            '\n' if attr_mode => writer.write_all(b"&#xA;"),
+            '\r' if attr_mode => writer.write_all(b"&#xD;"),
             c => writer.write_fmt(format_args!("{c}")),
         }?;
     }
-    Ok(())
-}
-
-#[inline]
-fn write_qual_name<W: Write>(writer: &mut W, name: &QualName) -> io::Result<()> {
-    if let Some(ref prefix) = name.prefix {
-        writer.write_all(prefix.as_bytes())?;
-        writer.write_all(b":")?;
-    }
-
-    writer.write_all(name.local.as_bytes())?;
     Ok(())
 }
 
@@ -102,111 +114,376 @@ impl<Wr: Write> XmlSerializer<Wr> {
     pub fn new(writer: Wr) -> Self {
         XmlSerializer {
             writer,
-            namespace_stack: NamespaceMapStack::new(),
+            prefix_index: 1,
         }
     }
 
-    #[inline(always)]
-    fn qual_name(&mut self, name: &QualName) -> io::Result<()> {
-        self.find_or_insert_ns(name);
-        write_qual_name(&mut self.writer, name)
-    }
-
-    #[inline(always)]
-    fn qual_attr_name(&mut self, name: &QualName) -> io::Result<()> {
-        self.find_or_insert_ns(name);
-        write_qual_name(&mut self.writer, name)
-    }
-
-    fn find_uri(&self, name: &QualName) -> bool {
-        let mut found = false;
-        for stack in self.namespace_stack.0.iter().rev() {
-            if let Some(Some(el)) = stack.get(&name.prefix) {
-                found = *el == name.ns;
-                break;
-            }
-        }
-        found
-    }
-
-    fn find_or_insert_ns(&mut self, name: &QualName) {
-        if (name.prefix.is_some() || !name.ns.is_empty()) && !self.find_uri(name) {
-            if let Some(last_ns) = self.namespace_stack.0.last_mut() {
-                last_ns.insert(name);
-            }
-        }
-    }
-}
-
-impl<Wr: Write> Serializer for XmlSerializer<Wr> {
-    /// Serializes given start element into text. Start element contains
-    /// qualified name and an attributes iterator.
-    fn start_elem<'a, AttrIter>(&mut self, name: QualName, attrs: AttrIter) -> io::Result<()>
+    fn record_the_namespace_information<'a, AttrIter>(
+        &self,
+        attributes: AttrIter,
+        map: &mut NamespacePrefixMap,
+    ) -> (BTreeMap<Prefix, Namespace>, Option<Namespace>)
     where
         AttrIter: Iterator<Item = AttrRef<'a>>,
     {
-        self.namespace_stack.push(NamespaceMap::empty());
-
-        self.writer.write_all(b"<")?;
-        self.qual_name(&name)?;
-        if let Some(current_namespace) = self.namespace_stack.0.last() {
-            for (prefix, url_opt) in current_namespace.get_scope_iter() {
-                self.writer.write_all(b" xmlns")?;
-                if let Some(ref prefix) = *prefix {
-                    self.writer.write_all(b":")?;
-                    self.writer.write_all(prefix.as_bytes())?;
+        // Note: the specification creates `local_prefixes_map` outside this algorithm; our approach
+        // equivalent.
+        let mut local_prefixes_map: BTreeMap<Prefix, Namespace> = BTreeMap::new();
+        // Step 1.
+        let mut local_default_namespace: Option<Namespace> = None;
+        // Step 2.
+        for (name, value) in attributes {
+            // Step 2.1.
+            let attribute_namespace = &name.ns;
+            // Step 2.2.
+            let attribute_prefix = &name.prefix;
+            // Step 2.3.
+            if *attribute_namespace == ns!(xmlns) {
+                if attribute_prefix.is_none() {
+                    local_default_namespace = Some(Namespace::from(value));
+                    continue;
                 }
-
-                self.writer.write_all(b"=\"")?;
-                let url = if let Some(ref a) = *url_opt {
-                    a.as_bytes()
-                } else {
-                    b""
-                };
-                self.writer.write_all(url)?;
-                self.writer.write_all(b"\"")?;
+                let prefix_definition = Prefix::from(&*name.local);
+                let namespace_definition = Namespace::from(value);
+                if namespace_definition == ns!(xmlns) {
+                    continue;
+                }
+                if map.find(&namespace_definition, &prefix_definition) {
+                    continue;
+                }
+                map.add(namespace_definition.clone(), prefix_definition.clone());
+                local_prefixes_map.insert(prefix_definition.clone(), namespace_definition.clone());
             }
         }
-        for (name, value) in attrs {
-            self.writer.write_all(b" ")?;
-            self.qual_attr_name(name)?;
-            self.writer.write_all(b"=\"")?;
-            write_to_buf_escaped(&mut self.writer, value, true)?;
-            self.writer.write_all(b"\"")?;
+        (local_prefixes_map, local_default_namespace)
+    }
+
+    fn serialize_attribute(
+        &mut self,
+        prefix: &Option<Prefix>,
+        local: &LocalName,
+        value: &str,
+    ) -> io::Result<()> {
+        self.writer.write_all(b" ")?;
+        if let Some(ref prefix) = prefix {
+            self.writer.write_all(prefix.as_bytes())?;
+            self.writer.write_all(b":")?;
         }
-        self.writer.write_all(b">")?;
+        self.writer.write_all(local.as_bytes())?;
+        self.writer.write_all(b"=\"")?;
+        write_to_buf_escaped(&mut self.writer, value, true)?;
+        self.writer.write_all(b"\"")?;
         Ok(())
     }
 
-    /// Serializes given end element into text.
-    fn end_elem(&mut self, name: QualName) -> io::Result<()> {
-        self.namespace_stack.pop();
+    fn serialize_attributes<'a, AttrIter>(
+        &mut self,
+        attributes: AttrIter,
+        map: &mut NamespacePrefixMap,
+        local_prefixes_map: &mut BTreeMap<Prefix, Namespace>,
+        ignore_namespace_definition_attribute: bool,
+    ) -> io::Result<()>
+    where
+        AttrIter: Iterator<Item = AttrRef<'a>>,
+    {
+        // Step 3.
+        for (name, value) in attributes {
+            // Step 3.1.
+            let attribute_namespace = &name.ns;
+            // Step 3.5
+            let mut candidate_prefix = None;
+            // Step 3.6.
+            if *attribute_namespace != ns!() {
+                // Step 3.6.1.
+                let prefix = &name.prefix;
+                // Step 3.6.2.
+                candidate_prefix = map.retrieve(attribute_namespace, prefix);
+                // Step 3.6.3.
+                if *attribute_namespace == ns!(xmlns) {
+                    let value = Namespace::from(value);
+                    // Step 3.6.3.1.
+                    if value == ns!(xml) {
+                        continue;
+                    }
+                    // `xmlns="ns"`
+                    if prefix.is_none() {
+                        if ignore_namespace_definition_attribute {
+                            continue;
+                        }
+                    }
+                    // `xmlns:foo="ns"`
+                    if prefix.is_some() {
+                        let local = Prefix::from(&*name.local);
+                        let x = local_prefixes_map.get(&local);
+                        match x {
+                            Some(x) if *x == value => {},
+                            _ => {
+                                let found = map.find(&value, &local);
+                                if found {
+                                    continue;
+                                }
+                            },
+                        }
+                    }
+                    // Step 3.6.3.4.
+                    if *prefix == Some(namespace_prefix!(xmlns)) {
+                        candidate_prefix = Some(namespace_prefix!(xmlns));
+                    }
+                // Step 3.6.4.
+                } else if candidate_prefix.is_none() {
+                    let new_prefix = match prefix {
+                        Some(prefix) if !local_prefixes_map.contains_key(prefix) => prefix.clone(),
+                        _ => map.generate_a_prefix(attribute_namespace, &mut self.prefix_index),
+                    };
+                    map.add(attribute_namespace.clone(), new_prefix.clone());
+                    local_prefixes_map.insert(new_prefix.clone(), attribute_namespace.clone());
+                    candidate_prefix = Some(new_prefix.clone());
+                    self.serialize_attribute(
+                        &Some(namespace_prefix!(xmlns)),
+                        &LocalName::from(&*new_prefix),
+                        &*attribute_namespace,
+                    )?;
+                }
+            }
+            self.serialize_attribute(&candidate_prefix, &name.local, value)?;
+        }
+        Ok(())
+    }
+
+    /// This serializes the entire start tag, except for the final `>`. The caller decides whether
+    /// to serialize `>` and a separate end tag, or a self-closing `/>`.
+    fn start_elem_aux<'a, AttrIter>(
+        &mut self,
+        name: &QualName,
+        attrs: AttrIter,
+        namespace: Namespace,
+        prefix_map: &NamespacePrefixMap,
+    ) -> io::Result<(String, Namespace, NamespacePrefixMap)>
+    where
+        AttrIter: Iterator<Item = AttrRef<'a>> + Clone,
+    {
+        let mut extra_attr: Option<(QualName, String)> = None;
+        // Step 2.
+        self.writer.write_all(b"<")?;
+
+        // Step 3.
+        let qualified_name: String;
+
+        // Step 4. (See `write_empty_elem`)
+
+        // Step 5.
+        let mut ignore_namespace_definition_attribute = false;
+
+        // Step 6.
+        let mut map = prefix_map.clone();
+
+        // Step 7-8.
+        let (mut local_prefixes_map, local_default_namespace) =
+            self.record_the_namespace_information(attrs.clone(), &mut map);
+
+        // Step 9.
+        let mut inherited_ns = namespace;
+
+        // Step 10.
+        let ns = &name.ns;
+
+        // Step 11.
+        if *inherited_ns == *ns {
+            // Step 11.1.
+            if local_default_namespace.is_some() {
+                ignore_namespace_definition_attribute = true;
+            }
+            // Step 11.2.
+            if *ns == ns!(xml) {
+                qualified_name = format!("xml:{}", name.local);
+            // Step 11.3.
+            } else {
+                qualified_name = (&*name.local).to_owned();
+            }
+            // Step 11.4. (see below)
+        } else {
+            // Step 12.
+            // Step 12.1.
+            let prefix = &name.prefix;
+            // Step 12.3.
+            let candidate_prefix = if *prefix == Some(namespace_prefix!(xmlns)) {
+                prefix.clone()
+            } else {
+                // Step 12.2.
+                map.retrieve(ns, prefix)
+            };
+            match candidate_prefix {
+                // Step 12.4.
+                Some(candidate_prefix) => {
+                    qualified_name = format!("{}:{}", candidate_prefix, name.local);
+                    match local_default_namespace {
+                        Some(ldn) if ldn != ns!(xml) => {
+                            inherited_ns = ldn;
+                        },
+                        _ => {},
+                    }
+                },
+                None => {
+                    match prefix {
+                        // Step 12.5.
+                        Some(prefix) => {
+                            let prefix = if local_prefixes_map.contains_key(prefix) {
+                                map.generate_a_prefix(ns, &mut self.prefix_index)
+                            } else {
+                                map.add(ns.clone(), prefix.clone());
+                                prefix.clone()
+                            };
+                            qualified_name = format!("{}:{}", prefix, name.local);
+                            debug_assert!(extra_attr.is_none());
+                            extra_attr = Some((
+                                QualName::new(
+                                    Some(namespace_prefix!(xmlns)),
+                                    ns!(xmlns),
+                                    LocalName::from(&*prefix),
+                                ),
+                                (&**ns).to_owned(),
+                            ));
+
+                            match local_default_namespace {
+                                Some(ldn) if ldn != ns!(xml) => {
+                                    inherited_ns = ldn;
+                                },
+                                _ => {},
+                            }
+                        },
+                        None => {
+                            match local_default_namespace {
+                                // Step 12.7
+                                Some(ldn) if ldn == *ns => {
+                                    qualified_name = (&*name.local).to_owned();
+                                    inherited_ns = ns.clone();
+                                },
+                                // Step 12.6
+                                _ => {
+                                    ignore_namespace_definition_attribute = true;
+                                    qualified_name = (&*name.local).to_owned();
+                                    inherited_ns = ns.clone();
+                                    debug_assert!(extra_attr.is_none());
+                                    extra_attr = Some((
+                                        QualName::new(None, ns!(xmlns), local_name!(xmlns)),
+                                        (&**ns).to_owned(),
+                                    ));
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        }
+        self.writer.write_all(qualified_name.as_bytes())?;
+        if let Some((name, value)) = extra_attr {
+            self.serialize_attribute(&name.prefix, &name.local, &value)?;
+        }
+        self.serialize_attributes(
+            attrs,
+            &mut map,
+            &mut local_prefixes_map,
+            ignore_namespace_definition_attribute,
+        )?;
+        Ok((qualified_name, inherited_ns, map))
+    }
+}
+
+impl<Wr: Write> XmlSerializer<Wr> {
+    /// Serializes given start element into text. Start element contains
+    /// qualified name and a list of attributes.
+    pub fn start_elem<'a, AttrIter>(
+        &mut self,
+        name: &QualName,
+        attrs: AttrIter,
+        namespace: Namespace,
+        prefix_map: &NamespacePrefixMap,
+    ) -> io::Result<(String, Namespace, NamespacePrefixMap)>
+    where
+        AttrIter: Iterator<Item = AttrRef<'a>> + Clone,
+    {
+        let result = self.start_elem_aux(name, attrs, namespace, prefix_map)?;
+        self.writer.write_all(b">")?;
+        Ok(result)
+    }
+
+    /// Serializes an element without children into text. This may use self-closing syntax,
+    /// depending on the situation.
+    /// Note: HTML template elements do not necessarily come through this function.
+    pub fn write_empty_elem<'a, AttrIter>(
+        &mut self,
+        name: &QualName,
+        attrs: AttrIter,
+        namespace: Namespace,
+        prefix_map: &NamespacePrefixMap,
+    ) -> io::Result<()>
+    where
+        AttrIter: Iterator<Item = AttrRef<'a>> + Clone,
+    {
+        let (qualified_name, _, _) = self.start_elem_aux(name, attrs, namespace, prefix_map)?;
+        if name.ns == ns!(html) {
+            match name.local {
+                local_name!("area")
+                | local_name!("base")
+                | local_name!("basefont")
+                | local_name!("bgsound")
+                | local_name!("br")
+                | local_name!("col")
+                | local_name!("embed")
+                | local_name!("frame")
+                | local_name!("hr")
+                | local_name!("img")
+                | local_name!("input")
+                | local_name!("keygen")
+                | local_name!("link")
+                | local_name!("menuitem")
+                | local_name!("meta")
+                | local_name!("param")
+                | local_name!("source")
+                | local_name!("track")
+                | local_name!("wbr") => {
+                    self.writer.write_all(b" />")?;
+                    return Ok(());
+                },
+                _ => {},
+            }
+        } else {
+            self.writer.write_all(b"/>")?;
+            return Ok(());
+        }
+        self.writer.write_all(b">")?;
+        self.end_elem(qualified_name)?;
+        Ok(())
+    }
+
+    /// Serialize the end of an element, for example `</div>`.
+    pub fn end_elem(&mut self, name: String) -> io::Result<()> {
         self.writer.write_all(b"</")?;
-        self.qual_name(&name)?;
+        self.writer.write_all(name.as_bytes())?;
         self.writer.write_all(b">")
     }
 
     /// Serializes comment into text.
-    fn write_comment(&mut self, text: &str) -> io::Result<()> {
+    pub fn write_comment(&mut self, text: &str) -> io::Result<()> {
         self.writer.write_all(b"<!--")?;
         self.writer.write_all(text.as_bytes())?;
         self.writer.write_all(b"-->")
     }
 
     /// Serializes given doctype
-    fn write_doctype(&mut self, name: &str) -> io::Result<()> {
+    pub fn write_doctype(&mut self, name: &str) -> io::Result<()> {
         self.writer.write_all(b"<!DOCTYPE ")?;
         self.writer.write_all(name.as_bytes())?;
         self.writer.write_all(b">")
     }
 
     /// Serializes text for a node or an attributes.
-    fn write_text(&mut self, text: &str) -> io::Result<()> {
+    pub fn write_text(&mut self, text: &str) -> io::Result<()> {
         write_to_buf_escaped(&mut self.writer, text, false)
     }
 
     /// Serializes given processing instruction.
-    fn write_processing_instruction(&mut self, target: &str, data: &str) -> io::Result<()> {
+    pub fn write_processing_instruction(&mut self, target: &str, data: &str) -> io::Result<()> {
         self.writer.write_all(b"<?")?;
         self.writer.write_all(target.as_bytes())?;
         self.writer.write_all(b" ")?;

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -9,7 +9,7 @@
 
 use crate::QualName;
 pub use markup5ever::serialize::{AttrRef, Serialize, Serializer, TraversalScope};
-use markup5ever::{LocalName, Namespace, Prefix};
+use markup5ever::{LocalName, Namespace, Prefix, local_name, namespace_prefix, ns};
 use std::{
     collections::BTreeMap,
     io::{self, Write},

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -9,7 +9,7 @@
 
 use crate::QualName;
 pub use markup5ever::serialize::{AttrRef, TraversalScope};
-use markup5ever::{LocalName, Namespace, Prefix, local_name, namespace_prefix, ns};
+use markup5ever::{local_name, namespace_prefix, ns, LocalName, Namespace, Prefix};
 use std::{
     collections::BTreeMap,
     io::{self, Write},

--- a/xml5ever/src/serialize/mod.rs
+++ b/xml5ever/src/serialize/mod.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use crate::QualName;
-pub use markup5ever::serialize::{AttrRef, Serialize, Serializer, TraversalScope};
+pub use markup5ever::serialize::{AttrRef, TraversalScope};
 use markup5ever::{LocalName, Namespace, Prefix, local_name, namespace_prefix, ns};
 use std::{
     collections::BTreeMap,

--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -21,7 +21,7 @@ use crate::macros::time;
 use crate::tendril::StrTendril;
 use crate::{buffer_queue, Attribute, QualName, SmallCharSet};
 use log::debug;
-use markup5ever::{local_name, namespace_prefix, ns, small_char_set, TokenizerResult};
+use markup5ever::{ns, small_char_set, TokenizerResult};
 use std::borrow::Cow::{self, Borrowed};
 use std::cell::{Cell, RefCell, RefMut};
 use std::cmp::Reverse;
@@ -1299,13 +1299,7 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
                 value: replace(&mut self.current_attr_value.borrow_mut(), StrTendril::new()),
             };
 
-            if qname.local == local_name!("xmlns")
-                || qname.prefix == Some(namespace_prefix!("xmlns"))
-            {
-                self.current_tag_attrs.borrow_mut().insert(0, attr);
-            } else {
-                self.current_tag_attrs.borrow_mut().push(attr);
-            }
+            self.current_tag_attrs.borrow_mut().push(attr);
         }
     }
 

--- a/xml5ever/src/tree_builder/mod.rs
+++ b/xml5ever/src/tree_builder/mod.rs
@@ -14,7 +14,6 @@ use markup5ever::{local_name, namespace_prefix, ns};
 use std::borrow::Cow;
 use std::borrow::Cow::Borrowed;
 use std::cell::{Cell, Ref, RefCell};
-use std::collections::btree_map::Iter;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::fmt::{Debug, Error, Formatter};
 use std::mem;
@@ -94,16 +93,6 @@ impl NamespaceMap {
 
     pub(crate) fn get(&self, prefix: &Option<Prefix>) -> Option<&Option<Namespace>> {
         self.scope.get(prefix)
-    }
-
-    pub(crate) fn get_scope_iter(&self) -> Iter<'_, Option<Prefix>, Option<Namespace>> {
-        self.scope.iter()
-    }
-
-    pub(crate) fn insert(&mut self, name: &QualName) {
-        let prefix = name.prefix.as_ref().cloned();
-        let namespace = Some(Namespace::from(&*name.ns));
-        self.scope.insert(prefix, namespace);
     }
 
     fn insert_ns(&mut self, attr: &Attribute) -> InsResult {
@@ -326,8 +315,6 @@ where
         // List of already present namespace local name attribute pairs.
         let mut present_attrs: HashSet<(Namespace, LocalName)> = Default::default();
 
-        let mut new_attr = vec![];
-        // First we extract all namespace declarations
         for attr in tag.attrs.iter_mut().filter(|attr| {
             attr.name.prefix == Some(namespace_prefix!("xmlns"))
                 || attr.name.local == local_name!("xmlns")
@@ -335,18 +322,18 @@ where
             self.declare_ns(attr);
         }
 
-        // Then we bind those namespace declarations to attributes
-        for attr in tag.attrs.iter_mut().filter(|attr| {
-            attr.name.prefix != Some(namespace_prefix!("xmlns"))
-                && attr.name.local != local_name!("xmlns")
-        }) {
-            if self.bind_attr_qname(&mut present_attrs, &mut attr.name) {
-                new_attr.push(attr.clone());
-            }
-        }
-        tag.attrs = new_attr;
+        // Deduplicate any attributes with the same namespace and local name, keeping the first one.
+        // Note that attributes with different prefixes that map to the same namespace are also
+        // removed. All attributes without a prefix are kept.
+        tag.attrs.retain_mut(|attr| {
+            // Update `attr.name.ns` based on the current stack of namespaces. If the
+            // combination of local name and namespace already exists in `present_attrs`,
+            // drop the current attribute.
+            self.bind_attr_qname(&mut present_attrs, &mut attr.name)
+        });
 
-        // Then we bind the tags namespace.
+        // Then we bind the tags namespace. Note that the prefix of the tag can be declared in the
+        // attributes of the tag itself, so attributes need to be processed first.
         self.bind_qname(&mut tag.name);
 
         // Finally, we dump current namespace if its unneeded.
@@ -355,9 +342,8 @@ where
             NamespaceMap::empty(),
         );
 
-        // Only start tag doesn't dump current namespace. However, <script /> is treated
-        // differently than every other empty tag, so it needs to retain the current
-        // namespace as well.
+        // If this was a start tag (or an empty script tag), push the namespace map for this tag
+        // onto the stack.
         if tag.kind == StartTag || (tag.kind == EmptyTag && tag.name.local == local_name!("script"))
         {
             self.namespace_stack.borrow_mut().push(x);


### PR DESCRIPTION
In #586, it turned out that a targeted change to preserve xmlns attributes exposed issues in the XML serializer that caused test failures in Servo.
This change brings the XML serializer in line with the specification and mostly with other browsers.

The XML serializer needs to keep track of state related to namespaces and their prefixes.
Implementing this correctly is not workable using a unified trait between HTML and XML.
This is a breaking change: to serialize to XML, users now need to use the new xml5ever::serialize::XmlSerializer.

This implements the latest [DOM Parsing and Serialization specification](https://w3c.github.io/DOM-Parsing/).

Fixes #569.

Co-authored-by: Josh Matthews <josh@joshmatthews.net>
Co-authored-by: Devon Govett <devongovett@gmail.com>
