### PR TITLE
Update to string-cache 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ memchr = "2.8.0"
 new_debug_unreachable = "1.0.2"
 phf = "0.14"
 phf_codegen = "0.14"
-string_cache = { version = "0.10.0", default-features = false }
-string_cache_codegen = "0.7.0"
+string_cache = { version = "0.11.0", default-features = false }
+string_cache_codegen = "0.11.0"
 
 # Dev dependencies
 criterion = "0.8"

--- a/rcdom/tests/html-serializer.rs
+++ b/rcdom/tests/html-serializer.rs
@@ -41,7 +41,7 @@ impl Serialize for Tokens {
                     let name = QualName::new(
                         None,
                         "http://www.w3.org/1999/xhtml".into(),
-                        tag.name.as_ref().into(),
+                        tag.name.as_str().into(),
                     );
                     match tag.kind {
                         TagKind::StartTag => serializer.start_elem(


### PR DESCRIPTION
This is a breaking change to public APIs, but https://github.com/servo/html5ever/pull/750 already merged a semver-incompatible version bump that is not released yet.