### PR TITLE
xml5ever: compare prefix and local name when looking for duplicate attributes

### DIFF
--- a/xml5ever/src/tokenizer/mod.rs
+++ b/xml5ever/src/tokenizer/mod.rs
@@ -1278,27 +1278,26 @@ impl<Sink: TokenSink> XmlTokenizer<Sink> {
             return;
         }
 
-        // Check for a duplicate attribute.
+        let qname = process_qname(replace(
+            &mut self.current_attr_name.borrow_mut(),
+            StrTendril::new(),
+        ));
+
+        // Check for a duplicate attribute. Two attributes are the same only if
+        // both their prefix and their local name match, so xml:lang and lang
+        // are distinct names and may sit on the same element.
         // FIXME: the spec says we should error as soon as the name is finished.
         // FIXME: linear time search, do we care?
-        let dup = {
-            let current_attr_name = self.current_attr_name.borrow();
-            let name = &current_attr_name[..];
-            self.current_tag_attrs
-                .borrow()
-                .iter()
-                .any(|a| &*a.name.local == name)
-        };
+        let dup = self
+            .current_tag_attrs
+            .borrow()
+            .iter()
+            .any(|a| a.name.prefix == qname.prefix && a.name.local == qname.local);
 
         if dup {
             self.emit_error(Borrowed("Duplicate attribute"));
-            self.current_attr_name.borrow_mut().clear();
             self.current_attr_value.borrow_mut().clear();
         } else {
-            let qname = process_qname(replace(
-                &mut self.current_attr_name.borrow_mut(),
-                StrTendril::new(),
-            ));
             let attr = Attribute {
                 name: qname.clone(),
                 value: replace(&mut self.current_attr_value.borrow_mut(), StrTendril::new()),
@@ -1347,6 +1346,21 @@ mod test {
         }
     }
 
+    struct ErrorCollector {
+        errors: RefCell<Vec<String>>,
+    }
+
+    impl TokenSink for ErrorCollector {
+        type Handle = ();
+
+        fn process_token(&self, token: Token) -> ProcessResult<()> {
+            if let Token::ParseError(error) = token {
+                self.errors.borrow_mut().push(error.to_string());
+            }
+            ProcessResult::Continue
+        }
+    }
+
     fn tokenize_pis(input: &str) -> Vec<(String, String)> {
         let sink = PiCollector {
             pis: RefCell::new(Vec::new()),
@@ -1357,6 +1371,18 @@ mod test {
         let _ = tokenizer.feed(&queue);
         tokenizer.end();
         tokenizer.sink.pis.into_inner()
+    }
+
+    fn tokenize_errors(input: &str) -> Vec<String> {
+        let sink = ErrorCollector {
+            errors: RefCell::new(Vec::new()),
+        };
+        let queue = BufferQueue::default();
+        queue.push_back(StrTendril::from(input));
+        let tokenizer = XmlTokenizer::new(sink, Default::default());
+        let _ = tokenizer.feed(&queue);
+        tokenizer.end();
+        tokenizer.sink.errors.into_inner()
     }
 
     #[test]
@@ -1409,6 +1435,38 @@ mod test {
         assert_eq!(
             tokenize_pis("<?target a?"),
             vec![("target".to_owned(), "a?".to_owned())]
+        );
+    }
+
+    #[test]
+    fn qualified_and_unqualified_names_are_distinct() {
+        // The xml prefix is bound to http://www.w3.org/XML/1998/namespace by
+        // definition, so xml:lang and lang have different expanded names and
+        // both orderings are fine. This is the second of the two legal cases
+        // in https://www.w3.org/TR/REC-xml-names/#uniqAttrs
+        assert!(tokenize_errors(r#"<root xml:lang="en" lang="en"/>"#).is_empty());
+        assert!(tokenize_errors(r#"<root lang="en" xml:lang="en"/>"#).is_empty());
+    }
+
+    #[test]
+    fn different_prefixes_are_left_to_the_tree_builder() {
+        // Whether these two are duplicates depends on what a and b are bound
+        // to, and the tokenizer has no bindings, so it says nothing either way.
+        // XmlTreeBuilder::bind_attr_qname resolves the prefixes and compares
+        // expanded names, which is where a real duplicate gets caught.
+        assert!(tokenize_errors(r#"<root a:name="1" b:name="2"/>"#).is_empty());
+    }
+
+    #[test]
+    fn real_duplicates_are_still_reported() {
+        assert_eq!(
+            tokenize_errors(r#"<root lang="en" lang="fr"/>"#),
+            vec!["Duplicate attribute".to_owned()]
+        );
+
+        assert_eq!(
+            tokenize_errors(r#"<root xml:lang="en" xml:lang="fr"/>"#),
+            vec!["Duplicate attribute".to_owned()]
         );
     }
 


### PR DESCRIPTION
Fixes #775

`<root xml:lang="en" lang="en"/>` was reported as `Duplicate attribute`, but `<root lang="en" xml:lang="en"/>` parsed fine.

### Why

`finish_attribute` compared the raw attribute name it had just read against the local names of the attributes already on the tag:

```rust
let current_attr_name = self.current_attr_name.borrow();
let name = &current_attr_name[..];
self.current_tag_attrs
    .borrow()
    .iter()
    .any(|a| &*a.name.local == name)
```

The stored attributes have been through `process_qname` by then, so `xml:lang` is sitting there as prefix `xml` with local name `lang`. Reading a plain `lang` right after it matches that local name and gets rejected.

That is also where the order dependence comes from. With `lang` first, the raw name `xml:lang` is compared against the local name `lang`, they do not match, and both attributes survive.

Namespaces in XML section 6.3 says two attributes are the same only when their expanded names are the same. The `xml` prefix is bound to `http://www.w3.org/XML/1998/namespace` by definition per section 3, whether or not it is declared, so `xml:lang` and `lang` have different expanded names and both orderings should parse cleanly. Section 6.3 lists that exact shape as legal, in its `<good a="1" n1:a="2" />` example. It also affects the WPT test `html/rendering/non-replaced-elements/tables/table-align-float.xhtml`, whose root element carries both.

### The fix

Run `process_qname` first, then compare the prefix along with the local name. Real duplicates still get reported, including two attributes that share a prefix.

Worth being clear about where this check sits. The tokenizer has no namespace bindings, they are resolved later, so it can only catch names that are identical. The case where two different prefixes are bound to the same namespace URI is a real duplicate under section 6.3, and that one is already handled in the tree builder by `bind_attr_qname` and `check_duplicate_attr`, which resolve the prefix and compare `(Namespace, LocalName)`. So the split is that the tokenizer catches identical names and the tree builder catches everything that needs bindings. This PR only corrects the tokenizer half.

### Testing

Added unit tests in `xml5ever/src/tokenizer/mod.rs` for both orderings from the issue, for real duplicates with and without a prefix, and one recording that the tokenizer deliberately stays quiet about two different prefixes since it cannot resolve them. The first two fail without the change.

`cargo test --all`, `cargo fmt --all -- --check` and `cargo clippy --all-features --all-targets` are clean.
