### PR TITLE
fix(rcdom): inspect descendant node data in get_a_selects_enabled_selectedcontent (closes #776)

### DIFF
--- a/rcdom/lib.rs
+++ b/rcdom/lib.rs
@@ -202,7 +202,7 @@ impl Node {
         while let Some(node) = remaining.pop_front() {
             remaining.extend(node.children.borrow().iter().cloned());
 
-            let NodeData::Element { name, .. } = &self.data else {
+            let NodeData::Element { name, .. } = &node.data else {
                 continue;
             };
             if name.local_name() == &local_name!("selectedcontent") {


### PR DESCRIPTION
### Summary of Fix

Resolves **#776**: `Node::get_a_selects_enabled_selectedcontent` in `rcdom/lib.rs` walked descendant nodes but erroneously matched `&self.data` instead of `&node.data`.

#### Details
- `self` refers to the parent `<select>` element, so `name.local_name() == &local_name!("selectedcontent")` evaluated to false on every iteration, always returning `None`.
- Consequently, the `clone_an_option_into_selectedcontent` routine never ran when parsing customizable selects.
- Changing the pattern match from `&self.data` to `&node.data` allows `<selectedcontent>` descendants to be discovered and properly populated with cloned `<option>` children per WHATWG HTML spec.

Closes #776.
