### PR TITLE
Fix UTF-8 corruption in HTML serialization

### DIFF
--- a/html5ever/src/serialize/mod.rs
+++ b/html5ever/src/serialize/mod.rs
@@ -139,6 +139,7 @@ impl<Wr: Write> HtmlSerializer<Wr> {
                 },
                 _ => {
                     //  0xC2 not followed by 0xA0 (not NBSP), so keep looking.
+                    self.writer.write_all(&bytes[next_special..search_start])?;
                     continue;
                 },
             };

--- a/rcdom/tests/html-serializer.rs
+++ b/rcdom/tests/html-serializer.rs
@@ -147,6 +147,10 @@ test!(
 );
 test!(attr_escape_amp, r#"<base foo="&amp;">"#);
 test!(
+    attr_literal_non_nbsp_c2,
+    r#"<p title="©®&nbsp;«&amp;»"></p>"#
+);
+test!(
     attr_escape_amp_2,
     r#"<base foo=&amp>"#,
     r#"<base foo="&amp;">"#
@@ -168,6 +172,7 @@ test!(
 );
 
 test!(text_literal, r#"<p>"'"</p>"#);
+test!(text_literal_non_nbsp_c2, "<p>©®&nbsp;«&amp;»</p>");
 test!(text_escape_amp, r#"<p>&amp;</p>"#);
 test!(text_escape_amp_2, r#"<p>&amp</p>"#, r#"<p>&amp;</p>"#);
 test!(text_escape_nbsp, "<p>x\u{a0}y</p>", r#"<p>x&nbsp;y</p>"#);


### PR DESCRIPTION
Serializing ordinary HTML such as `<p>©</p>` produces invalid UTF-8 in 0.40.0: `©` (`C2 A9`) becomes a lone `A9` byte. Attribute values and other characters in U+0080–U+00BF, except NBSP, are also affected. Consumers that validate UTF-8 can therefore reject otherwise valid HTML.

The [HTML specification's escaping algorithm](https://html.spec.whatwg.org/multipage/parsing.html#escapingString) replaces `&`, NBSP, `<`, `>`, and double quotes in attribute mode. Other characters must be preserved.

The byte scanner introduced in #740 looks for `0xC2` to recognize NBSP (`C2 A0`). When the following byte is not `A0`, it advances past `C2` without writing it. This patch writes that byte before continuing; the next iteration writes the continuation byte. NBSP escaping and the separate raw-text path remain unchanged.

Adds text and attribute regressions mixing ©, ®, « and » with NBSP and ampersand escaping. Both tests fail before the fix.

Verification:

- 18 library tests and all 45 HTML serializer tests pass.
- The existing `html2html` example matches independently calculated escaping rules for 198 cases covering all 64 code points U+0080–U+00BF, adjacent escapes, repeated characters, long spans, and wider Unicode; script/style raw text is preserved.
- Formatting and html5ever Clippy checks pass.

Local checks used an untracked lockfile with `jiff 0.2.35`: the published `0.2.36` package fails to compile because included documentation files are missing. No dependency changes are included.
